### PR TITLE
feat: add icon support and brush up Button component

### DIFF
--- a/.claude/rules/storybook-guideline.md
+++ b/.claude/rules/storybook-guideline.md
@@ -1,0 +1,51 @@
+# Storybook Guideline
+
+## Story Structure
+
+- **Always define a `Playground` story as the first export.** This is an `args`-based story so that users can interactively test a single component instance via the Controls panel in the Docs tab.
+- **Do NOT create individual stories for each prop value** (e.g. `Default`, `Secondary`, `Outline` as separate stories).
+  - Instead, group related states into a single render story (e.g. `AllVariants`, `Sizes`).
+- **Group stories by prop or concern**, such as:
+  - `AllVariants` — all visual variants side by side
+  - `Sizes` — all size options
+  - `Icons` / `IconPositions` — icon-related combinations
+  - `Disabled` — disabled states across variants
+- Keep the number of stories minimal and scannable. Each story should demonstrate a meaningful dimension of the component.
+
+## argTypes & Descriptions
+
+- Always define `argTypes` for all public props.
+- Write `description` values in **English**.
+- Include `table.type.summary` and `table.defaultValue.summary` for documentation clarity.
+
+Example:
+
+```ts
+argTypes: {
+  variant: {
+    description: 'Visual style of the button.',
+    control: 'select',
+    options: ['primary', 'secondary'],
+    table: {
+      type: { summary: '"primary" | "secondary"' },
+      defaultValue: { summary: 'primary' },
+    },
+  },
+}
+```
+
+## Language
+
+- All `description` text and Storybook labels should be written in **English**.
+- Button labels and content inside stories should also use **English** (e.g. "Search", "Delete", not "検索", "削除").
+
+## Render Stories
+
+- Use `render: () => (...)` for grouped display stories.
+- Use `name` property for human-readable story titles (e.g. `name: 'All Variants'`).
+- Use Tailwind utility classes (`flex`, `gap-4`, `items-center`, etc.) for layout inside render stories.
+
+## Meta Configuration
+
+- Always include `tags: ['autodocs']` to enable auto-generated documentation.
+- Set `parameters: { layout: 'centered' }` unless the component requires full-width layout.

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -73,6 +73,9 @@ const preview: Preview = {
           body.classList.add('light')
         }
 
+        // Sync body background for Storybook iframe
+        body.style.backgroundColor = isDark ? '#1a1a1a' : '#fff'
+
         // Apply season theme
         if (season && season !== 'none') {
           root.setAttribute('data-season', season)
@@ -82,7 +85,7 @@ const preview: Preview = {
       }, [isDark, season])
 
       return (
-        <div className={`${isDark ? 'dark' : ''} bg-paper-warm p-8`}>
+        <div className={`${isDark ? 'dark' : ''} p-8`} style={{ backgroundColor: isDark ? '#1a1a1a' : '#fff' }}>
           <Story />
         </div>
       )

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,9 +1,11 @@
 # CLAUDE.md — yasmro-ui
 
-Design system component library built with React, CVA, Radix UI, and Tailwind CSS.
+Design system component library based on [shadcn/ui](https://ui.shadcn.com/), customized for the yasmro brand.
+When adding or modifying components, follow shadcn/ui conventions (Radix UI + CVA + cn utility) as the baseline.
 
 ## Tech Stack
 
+- **Base**: shadcn/ui
 - **Framework**: React + TypeScript
 - **Styling**: Tailwind CSS + class-variance-authority (CVA)
 - **Primitives**: Radix UI

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,23 @@
+# CLAUDE.md — yasmro-ui
+
+Design system component library built with React, CVA, Radix UI, and Tailwind CSS.
+
+## Tech Stack
+
+- **Framework**: React + TypeScript
+- **Styling**: Tailwind CSS + class-variance-authority (CVA)
+- **Primitives**: Radix UI
+- **Storybook**: Component documentation & visual testing
+- **Build**: tsup
+- **Test**: Vitest
+- **Package Manager**: pnpm
+
+## Project Structure
+
+- `src/components/lv1/` — Primitive components (Button, etc.)
+- `src/variants/` — CVA variant definitions
+- `src/lib/` — Shared utilities
+
+## Guidelines
+
+- See [.claude/rules/storybook-guideline.md](.claude/rules/storybook-guideline.md) for Storybook conventions

--- a/package.json
+++ b/package.json
@@ -96,6 +96,7 @@
     "@radix-ui/react-slot": "^1.1.1",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "lucide-react": "^1.7.0",
     "tailwind-merge": "^2.6.0"
   },
   "license": "MIT",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
+      lucide-react:
+        specifier: ^1.7.0
+        version: 1.7.0(react@19.2.4)
       tailwind-merge:
         specifier: ^2.6.0
         version: 2.6.1
@@ -1902,6 +1905,11 @@ packages:
 
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
+
+  lucide-react@1.7.0:
+    resolution: {integrity: sha512-yI7BeItCLZJTXikmK4KNUGCKoGzSvbKlfCvw44bU4fXAL6v3gYS4uHD1jzsLkfwODYwI6Drw5Tu9Z5ulDe0TSg==}
+    peerDependencies:
+      react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   lz-string@1.5.0:
     resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
@@ -4140,6 +4148,10 @@ snapshots:
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
+
+  lucide-react@1.7.0(react@19.2.4):
+    dependencies:
+      react: 19.2.4
 
   lz-string@1.5.0: {}
 

--- a/src/components/lv1/Button/Button.stories.tsx
+++ b/src/components/lv1/Button/Button.stories.tsx
@@ -12,9 +12,9 @@ const meta: Meta<typeof Button> = {
     variant: {
       description: 'Visual style of the button.',
       control: 'select',
-      options: ['primary', 'secondary', 'outline', 'ghost', 'destructive', 'link', 'inverse'],
+      options: ['primary', 'secondary', 'tertiary', 'destructive', 'link'],
       table: {
-        type: { summary: '"primary" | "secondary" | "outline" | "ghost" | "destructive" | "link" | "inverse"' },
+        type: { summary: '"primary" | "secondary" | "tertiary" | "destructive" | "link"' },
         defaultValue: { summary: 'primary' },
       },
     },
@@ -88,11 +88,9 @@ export const AllVariants: Story = {
     <div className="flex flex-wrap gap-4">
       <Button variant="primary">Primary</Button>
       <Button variant="secondary">Secondary</Button>
-      <Button variant="outline">Outline</Button>
-      <Button variant="ghost">Ghost</Button>
+      <Button variant="tertiary">Tertiary</Button>
       <Button variant="destructive">Destructive</Button>
       <Button variant="link">Link</Button>
-      <Button variant="inverse">Inverse</Button>
     </div>
   ),
 }
@@ -139,7 +137,7 @@ export const Disabled: Story = {
     <div className="flex flex-wrap gap-4">
       <Button disabled>Primary</Button>
       <Button variant="secondary" disabled>Secondary</Button>
-      <Button variant="outline" disabled>Outline</Button>
+      <Button variant="tertiary" disabled>Tertiary</Button>
       <Button variant="destructive" disabled icon="Trash2">Delete</Button>
     </div>
   ),

--- a/src/components/lv1/Button/Button.stories.tsx
+++ b/src/components/lv1/Button/Button.stories.tsx
@@ -10,7 +10,7 @@ const meta: Meta<typeof Button> = {
   tags: ['autodocs'],
   argTypes: {
     variant: {
-      description: 'ボタンの視覚スタイル',
+      description: 'Visual style of the button.',
       control: 'select',
       options: ['primary', 'secondary', 'outline', 'ghost', 'destructive', 'link', 'inverse'],
       table: {
@@ -19,7 +19,7 @@ const meta: Meta<typeof Button> = {
       },
     },
     size: {
-      description: 'ボタンのサイズ',
+      description: 'Size of the button.',
       control: 'select',
       options: ['sm', 'md', 'lg', 'icon'],
       table: {
@@ -28,7 +28,7 @@ const meta: Meta<typeof Button> = {
       },
     },
     icon: {
-      description: 'Lucide アイコン名（PascalCase）',
+      description: 'Lucide icon name in PascalCase (e.g. "Search", "ArrowRight").',
       control: 'text',
       table: {
         type: { summary: 'IconName' },
@@ -36,7 +36,7 @@ const meta: Meta<typeof Button> = {
       },
     },
     iconPosition: {
-      description: 'アイコンの配置位置',
+      description: 'Position of the icon relative to the label text.',
       control: 'select',
       options: ['start', 'end'],
       table: {
@@ -45,7 +45,7 @@ const meta: Meta<typeof Button> = {
       },
     },
     asChild: {
-      description: '子要素にpropsを委譲する（Radix Slot）',
+      description: 'Delegates props to the child element via Radix Slot.',
       control: 'boolean',
       table: {
         type: { summary: 'boolean' },
@@ -53,7 +53,7 @@ const meta: Meta<typeof Button> = {
       },
     },
     disabled: {
-      description: 'ボタンを無効化する',
+      description: 'Disables the button and applies disabled styling.',
       control: 'boolean',
       table: {
         type: { summary: 'boolean' },
@@ -61,7 +61,7 @@ const meta: Meta<typeof Button> = {
       },
     },
     children: {
-      description: 'ボタンのラベルテキスト',
+      description: 'Label text or content inside the button.',
       control: 'text',
       table: {
         type: { summary: 'ReactNode' },
@@ -73,7 +73,8 @@ const meta: Meta<typeof Button> = {
 export default meta
 type Story = StoryObj<typeof Button>
 
-export const Default: Story = {
+export const Playground: Story = {
+  name: 'Playground',
   args: {
     variant: 'primary',
     size: 'md',
@@ -81,104 +82,8 @@ export const Default: Story = {
   },
 }
 
-export const Secondary: Story = {
-  args: {
-    variant: 'secondary',
-    children: 'Secondary',
-  },
-}
-
-export const Outline: Story = {
-  args: {
-    variant: 'outline',
-    children: 'Outline',
-  },
-}
-
-export const Ghost: Story = {
-  args: {
-    variant: 'ghost',
-    children: 'Ghost',
-  },
-}
-
-export const Destructive: Story = {
-  args: {
-    variant: 'destructive',
-    children: 'Delete',
-  },
-}
-
-export const Link: Story = {
-  args: {
-    variant: 'link',
-    children: 'Link Button',
-  },
-}
-
-export const Inverse: Story = {
-  args: {
-    variant: 'inverse',
-    children: 'Inverse',
-  },
-  parameters: {
-    backgrounds: { default: 'dark' },
-  },
-}
-
-export const Small: Story = {
-  args: {
-    size: 'sm',
-    children: 'Small',
-  },
-}
-
-export const Large: Story = {
-  args: {
-    size: 'lg',
-    children: 'Large',
-  },
-}
-
-export const Disabled: Story = {
-  args: {
-    disabled: true,
-    children: 'Disabled',
-  },
-}
-
-export const WithIconStart: Story = {
-  args: {
-    icon: 'Search',
-    children: '検索',
-  },
-}
-
-export const WithIconEnd: Story = {
-  args: {
-    icon: 'ArrowRight',
-    iconPosition: 'end',
-    children: '次へ',
-  },
-}
-
-export const IconOnly: Story = {
-  args: {
-    icon: 'Plus',
-    size: 'icon',
-    'aria-label': '追加',
-  },
-}
-
-export const DestructiveWithIcon: Story = {
-  args: {
-    variant: 'destructive',
-    icon: 'Trash2',
-    children: '削除',
-  },
-}
-
 export const AllVariants: Story = {
+  name: 'All Variants',
   render: () => (
     <div className="flex flex-wrap gap-4">
       <Button variant="primary">Primary</Button>
@@ -187,28 +92,55 @@ export const AllVariants: Story = {
       <Button variant="ghost">Ghost</Button>
       <Button variant="destructive">Destructive</Button>
       <Button variant="link">Link</Button>
+      <Button variant="inverse">Inverse</Button>
     </div>
   ),
 }
 
-export const AllSizes: Story = {
+export const Sizes: Story = {
+  name: 'Sizes',
   render: () => (
     <div className="flex items-center gap-4">
       <Button size="sm">Small</Button>
       <Button size="md">Medium</Button>
       <Button size="lg">Large</Button>
+      <Button icon="Plus" size="icon" aria-label="Add" />
+    </div>
+  ),
+}
+
+export const Icons: Story = {
+  name: 'Icons',
+  render: () => (
+    <div className="flex items-center gap-4">
+      <Button icon="Search">Search</Button>
+      <Button icon="ArrowRight" iconPosition="end">Next</Button>
+      <Button icon="Plus" size="icon" aria-label="Add" />
+      <Button variant="destructive" icon="Trash2">Delete</Button>
     </div>
   ),
 }
 
 export const IconPositions: Story = {
+  name: 'Icon Positions',
   render: () => (
     <div className="flex items-center gap-4">
-      <Button icon="ChevronLeft">戻る</Button>
-      <Button icon="ChevronRight" iconPosition="end">次へ</Button>
-      <Button icon="Plus" size="icon" aria-label="追加" />
-      <Button icon="Download" size="sm">ダウンロード</Button>
-      <Button icon="Send" size="lg" iconPosition="end">送信</Button>
+      <Button icon="ChevronLeft">Back</Button>
+      <Button icon="ChevronRight" iconPosition="end">Next</Button>
+      <Button icon="Download" size="sm">Download</Button>
+      <Button icon="Send" size="lg" iconPosition="end">Send</Button>
+    </div>
+  ),
+}
+
+export const Disabled: Story = {
+  name: 'Disabled',
+  render: () => (
+    <div className="flex flex-wrap gap-4">
+      <Button disabled>Primary</Button>
+      <Button variant="secondary" disabled>Secondary</Button>
+      <Button variant="outline" disabled>Outline</Button>
+      <Button variant="destructive" disabled icon="Trash2">Delete</Button>
     </div>
   ),
 }

--- a/src/components/lv1/Button/Button.stories.tsx
+++ b/src/components/lv1/Button/Button.stories.tsx
@@ -10,12 +10,62 @@ const meta: Meta<typeof Button> = {
   tags: ['autodocs'],
   argTypes: {
     variant: {
+      description: 'ボタンの視覚スタイル',
       control: 'select',
-      options: ['default', 'secondary', 'outline', 'ghost', 'destructive', 'link', 'inverse'],
+      options: ['primary', 'secondary', 'outline', 'ghost', 'destructive', 'link', 'inverse'],
+      table: {
+        type: { summary: '"primary" | "secondary" | "outline" | "ghost" | "destructive" | "link" | "inverse"' },
+        defaultValue: { summary: 'primary' },
+      },
     },
     size: {
+      description: 'ボタンのサイズ',
       control: 'select',
-      options: ['default', 'sm', 'lg', 'icon'],
+      options: ['sm', 'md', 'lg', 'icon'],
+      table: {
+        type: { summary: '"sm" | "md" | "lg" | "icon"' },
+        defaultValue: { summary: 'md' },
+      },
+    },
+    icon: {
+      description: 'Lucide アイコン名（PascalCase）',
+      control: 'text',
+      table: {
+        type: { summary: 'IconName' },
+        defaultValue: { summary: '-' },
+      },
+    },
+    iconPosition: {
+      description: 'アイコンの配置位置',
+      control: 'select',
+      options: ['start', 'end'],
+      table: {
+        type: { summary: '"start" | "end"' },
+        defaultValue: { summary: 'start' },
+      },
+    },
+    asChild: {
+      description: '子要素にpropsを委譲する（Radix Slot）',
+      control: 'boolean',
+      table: {
+        type: { summary: 'boolean' },
+        defaultValue: { summary: 'false' },
+      },
+    },
+    disabled: {
+      description: 'ボタンを無効化する',
+      control: 'boolean',
+      table: {
+        type: { summary: 'boolean' },
+        defaultValue: { summary: 'false' },
+      },
+    },
+    children: {
+      description: 'ボタンのラベルテキスト',
+      control: 'text',
+      table: {
+        type: { summary: 'ReactNode' },
+      },
     },
   },
 }
@@ -25,6 +75,8 @@ type Story = StoryObj<typeof Button>
 
 export const Default: Story = {
   args: {
+    variant: 'primary',
+    size: 'md',
     children: 'Button',
   },
 }
@@ -95,10 +147,41 @@ export const Disabled: Story = {
   },
 }
 
+export const WithIconStart: Story = {
+  args: {
+    icon: 'Search',
+    children: '検索',
+  },
+}
+
+export const WithIconEnd: Story = {
+  args: {
+    icon: 'ArrowRight',
+    iconPosition: 'end',
+    children: '次へ',
+  },
+}
+
+export const IconOnly: Story = {
+  args: {
+    icon: 'Plus',
+    size: 'icon',
+    'aria-label': '追加',
+  },
+}
+
+export const DestructiveWithIcon: Story = {
+  args: {
+    variant: 'destructive',
+    icon: 'Trash2',
+    children: '削除',
+  },
+}
+
 export const AllVariants: Story = {
   render: () => (
     <div className="flex flex-wrap gap-4">
-      <Button variant="default">Default</Button>
+      <Button variant="primary">Primary</Button>
       <Button variant="secondary">Secondary</Button>
       <Button variant="outline">Outline</Button>
       <Button variant="ghost">Ghost</Button>
@@ -112,8 +195,20 @@ export const AllSizes: Story = {
   render: () => (
     <div className="flex items-center gap-4">
       <Button size="sm">Small</Button>
-      <Button size="default">Default</Button>
+      <Button size="md">Medium</Button>
       <Button size="lg">Large</Button>
+    </div>
+  ),
+}
+
+export const IconPositions: Story = {
+  render: () => (
+    <div className="flex items-center gap-4">
+      <Button icon="ChevronLeft">戻る</Button>
+      <Button icon="ChevronRight" iconPosition="end">次へ</Button>
+      <Button icon="Plus" size="icon" aria-label="追加" />
+      <Button icon="Download" size="sm">ダウンロード</Button>
+      <Button icon="Send" size="lg" iconPosition="end">送信</Button>
     </div>
   ),
 }

--- a/src/components/lv1/Button/Button.stories.tsx
+++ b/src/components/lv1/Button/Button.stories.tsx
@@ -21,9 +21,9 @@ const meta: Meta<typeof Button> = {
     size: {
       description: 'Size of the button.',
       control: 'select',
-      options: ['sm', 'md', 'lg', 'icon'],
+      options: ['sm', 'md', 'lg'],
       table: {
-        type: { summary: '"sm" | "md" | "lg" | "icon"' },
+        type: { summary: '"sm" | "md" | "lg"' },
         defaultValue: { summary: 'md' },
       },
     },
@@ -104,7 +104,7 @@ export const Sizes: Story = {
       <Button size="sm">Small</Button>
       <Button size="md">Medium</Button>
       <Button size="lg">Large</Button>
-      <Button icon="Plus" size="icon" aria-label="Add" />
+      <Button icon="Plus" aria-label="Add" />
     </div>
   ),
 }
@@ -115,7 +115,7 @@ export const Icons: Story = {
     <div className="flex items-center gap-4">
       <Button icon="Search">Search</Button>
       <Button icon="ArrowRight" iconPosition="end">Next</Button>
-      <Button icon="Plus" size="icon" aria-label="Add" />
+      <Button icon="Plus" aria-label="Add" />
       <Button variant="destructive" icon="Trash2">Delete</Button>
     </div>
   ),

--- a/src/components/lv1/Button/Button.test.tsx
+++ b/src/components/lv1/Button/Button.test.tsx
@@ -37,4 +37,35 @@ describe('Button', () => {
     )
     expect(screen.getByRole('link', { name: 'Link Button' })).toBeInTheDocument()
   })
+
+  it('renders icon at start position by default', () => {
+    render(<Button icon="Search">検索</Button>)
+    const button = screen.getByRole('button')
+    const svg = button.querySelector('svg')
+    expect(svg).toBeInTheDocument()
+    expect(svg?.getAttribute('aria-hidden')).toBe('true')
+    expect(button.firstChild).toBe(svg)
+  })
+
+  it('renders icon at end position', () => {
+    render(<Button icon="ArrowRight" iconPosition="end">次へ</Button>)
+    const button = screen.getByRole('button')
+    const svg = button.querySelector('svg')
+    expect(svg).toBeInTheDocument()
+    expect(button.lastChild).toBe(svg)
+  })
+
+  it('renders icon-only button', () => {
+    render(<Button icon="Plus" size="icon" aria-label="追加" />)
+    const button = screen.getByRole('button', { name: '追加' })
+    const svg = button.querySelector('svg')
+    expect(svg).toBeInTheDocument()
+    expect(button).toHaveClass('w-10')
+  })
+
+  it('renders without icon when icon prop is not provided', () => {
+    render(<Button>No Icon</Button>)
+    const button = screen.getByRole('button')
+    expect(button.querySelector('svg')).not.toBeInTheDocument()
+  })
 })

--- a/src/components/lv1/Button/Button.test.tsx
+++ b/src/components/lv1/Button/Button.test.tsx
@@ -9,10 +9,10 @@ describe('Button', () => {
   })
 
   it('renders with different variants', () => {
-    const { rerender } = render(<Button variant="outline">Outline</Button>)
+    const { rerender } = render(<Button variant="secondary">Secondary</Button>)
     expect(screen.getByRole('button')).toHaveClass('border')
 
-    rerender(<Button variant="ghost">Ghost</Button>)
+    rerender(<Button variant="tertiary">Tertiary</Button>)
     expect(screen.getByRole('button')).not.toHaveClass('border')
   })
 

--- a/src/components/lv1/Button/Button.test.tsx
+++ b/src/components/lv1/Button/Button.test.tsx
@@ -55,12 +55,13 @@ describe('Button', () => {
     expect(button.lastChild).toBe(svg)
   })
 
-  it('renders icon-only button', () => {
-    render(<Button icon="Plus" size="icon" aria-label="追加" />)
-    const button = screen.getByRole('button', { name: '追加' })
+  it('renders icon-only button with square aspect ratio', () => {
+    render(<Button icon="Plus" aria-label="Add" />)
+    const button = screen.getByRole('button', { name: 'Add' })
     const svg = button.querySelector('svg')
     expect(svg).toBeInTheDocument()
-    expect(button).toHaveClass('w-10')
+    expect(button).toHaveClass('aspect-square')
+    expect(button).toHaveClass('px-0')
   })
 
   it('renders without icon when icon prop is not provided', () => {

--- a/src/components/lv1/Button/Button.tsx
+++ b/src/components/lv1/Button/Button.tsx
@@ -21,6 +21,7 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
   ) => {
     const Comp = asChild ? Slot : 'button'
     const IconComponent = icon ? icons[icon] : null
+    const isIconOnly = !children && !!icon
 
     if (asChild) {
       return (
@@ -36,7 +37,7 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
 
     return (
       <Comp
-        className={cn(buttonVariants({ variant, size, className }))}
+        className={cn(buttonVariants({ variant, size, className }), isIconOnly && 'aspect-square px-0')}
         ref={ref}
         {...props}
       >

--- a/src/components/lv1/Button/Button.tsx
+++ b/src/components/lv1/Button/Button.tsx
@@ -1,23 +1,49 @@
 import { Slot } from '@radix-ui/react-slot'
+import { icons } from 'lucide-react'
 import { forwardRef, type ButtonHTMLAttributes } from 'react'
 import { cn } from '../../../lib/utils'
 import { buttonVariants, type ButtonVariants } from '../../../variants/button'
+
+export type IconName = keyof typeof icons
 
 export interface ButtonProps
   extends ButtonHTMLAttributes<HTMLButtonElement>,
     ButtonVariants {
   asChild?: boolean
+  icon?: IconName
+  iconPosition?: 'start' | 'end'
 }
 
 export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
-  ({ className, variant, size, asChild = false, ...props }, ref) => {
+  (
+    { className, variant, size, asChild = false, icon, iconPosition = 'start', children, ...props },
+    ref
+  ) => {
     const Comp = asChild ? Slot : 'button'
+    const IconComponent = icon ? icons[icon] : null
+
+    if (asChild) {
+      return (
+        <Comp
+          className={cn(buttonVariants({ variant, size, className }))}
+          ref={ref}
+          {...props}
+        >
+          {children}
+        </Comp>
+      )
+    }
+
     return (
       <Comp
         className={cn(buttonVariants({ variant, size, className }))}
         ref={ref}
         {...props}
-      />
+      >
+        {IconComponent && iconPosition === 'start' && <IconComponent aria-hidden="true" />}
+        {children}
+        {IconComponent && iconPosition === 'end' && <IconComponent aria-hidden="true" />}
+      </Comp>
     )
   }
 )

--- a/src/components/lv1/Button/index.ts
+++ b/src/components/lv1/Button/index.ts
@@ -1,1 +1,1 @@
-export { Button, type ButtonProps } from './Button'
+export { Button, type ButtonProps, type IconName } from './Button'

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -7,13 +7,12 @@
 
 /* Base styles */
 body {
-  background-color: var(--paper-warm);
+  background-color: #fff;
   color: var(--ink-black);
   transition: background-color 0.2s ease, color 0.2s ease;
 }
 
-/* Storybook preview container */
-.docs-story,
-.sb-show-main {
-  background-color: var(--paper-warm) !important;
+body.dark {
+  background-color: var(--ink-black);
+  color: var(--paper-white);
 }

--- a/src/variants/button.ts
+++ b/src/variants/button.ts
@@ -6,17 +6,13 @@ export const buttonVariants = cva(
     variants: {
       variant: {
         primary:
-          'bg-ink-black text-paper-white hover:bg-ink-dark hover:text-paper-white',
-        destructive: 'bg-vermillion text-paper-white hover:opacity-90',
-        outline:
-          'border border-ink-black bg-transparent text-ink-black hover:bg-ink-black hover:text-paper-white',
+          'bg-ink-black text-paper-white not-disabled:hover:bg-ink-dark not-disabled:hover:text-paper-white',
         secondary:
-          'bg-paper-cream text-ink-black hover:bg-paper-warm',
-        ghost:
-          'text-ink-black hover:bg-paper-cream',
-        link: 'text-ink-black underline-offset-4 hover:underline !h-auto !px-0 !py-0 focus-visible:ring-offset-0',
-        inverse:
-          'bg-paper-white text-ink-black hover:bg-paper-cream',
+          'border border-ink-black bg-transparent text-ink-black not-disabled:hover:bg-paper-cream',
+        tertiary:
+          'text-ink-black not-disabled:hover:bg-paper-cream',
+        destructive: 'bg-vermillion text-paper-white not-disabled:hover:opacity-90',
+        link: 'text-ink-black underline-offset-4 not-disabled:hover:underline !h-auto !px-0 !py-0 focus-visible:ring-offset-0',
       },
       size: {
         md: 'h-10 px-5 py-2 text-sm [&_svg]:size-4',

--- a/src/variants/button.ts
+++ b/src/variants/button.ts
@@ -1,30 +1,33 @@
 import { cva, type VariantProps } from 'class-variance-authority'
 
 export const buttonVariants = cva(
-  'btn inline-flex items-center justify-center gap-2 whitespace-nowrap leading-none font-medium cursor-pointer no-underline transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ink-black focus-visible:ring-offset-2 focus-visible:ring-offset-paper-warm disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0',
+  'btn inline-flex items-center justify-center gap-2 whitespace-nowrap leading-none font-medium hover:cursor-pointer no-underline transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ink-black focus-visible:ring-offset-2 focus-visible:ring-offset-paper-warm disabled:cursor-not-allowed disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0',
   {
     variants: {
       variant: {
-        default:
+        primary:
           'bg-ink-black text-paper-white hover:bg-ink-dark hover:text-paper-white',
         destructive: 'bg-vermillion text-paper-white hover:opacity-90',
         outline:
           'border border-ink-black bg-transparent text-ink-black hover:bg-ink-black hover:text-paper-white',
-        secondary: 'bg-gray-200 text-ink-black hover:bg-gray-300',
-        ghost: 'hover:bg-gray-100 text-ink-black',
-        link: 'text-ink-black underline-offset-4 hover:underline',
-        inverse: 'bg-paper-white text-ink-black hover:bg-gray-200',
+        secondary:
+          'bg-paper-cream text-ink-black hover:bg-paper-warm',
+        ghost:
+          'text-ink-black hover:bg-paper-cream',
+        link: 'text-ink-black underline-offset-4 hover:underline !h-auto !px-0 !py-0 focus-visible:ring-offset-0',
+        inverse:
+          'bg-paper-white text-ink-black hover:bg-paper-cream',
       },
       size: {
-        default: 'h-10 px-5 py-2 text-sm [&_svg]:size-4',
+        md: 'h-10 px-5 py-2 text-sm [&_svg]:size-4',
         sm: 'h-8 px-3 text-xs [&_svg]:size-3.5',
         lg: 'h-12 px-8 text-base [&_svg]:size-5',
         icon: 'h-10 w-10 [&_svg]:size-4',
       },
     },
     defaultVariants: {
-      variant: 'default',
-      size: 'default',
+      variant: 'primary',
+      size: 'md',
     },
   },
 )

--- a/src/variants/button.ts
+++ b/src/variants/button.ts
@@ -22,7 +22,6 @@ export const buttonVariants = cva(
         md: 'h-10 px-5 py-2 text-sm [&_svg]:size-4',
         sm: 'h-8 px-3 text-xs [&_svg]:size-3.5',
         lg: 'h-12 px-8 text-base [&_svg]:size-5',
-        icon: 'h-10 w-10 [&_svg]:size-4',
       },
     },
     defaultVariants: {


### PR DESCRIPTION
## Summary
- lucide-react を導入し、`icon` / `iconPosition` props でアイコン名を指定するだけで位置・サイズが自動制御されるように
- variant/size のデフォルト値を `default` → `primary` / `md` にリネーム
- gray-* トークンをセマンティックトークン（paper-*, ink-*）に置き換え、ダークモードでの色同化を修正
- Storybook の argTypes に description / defaultValue を追加
- link バリアントのフォーカスリング・パディングを修正
- hover 時は `cursor-pointer`、disabled 時は `cursor-not-allowed` に変更

## Test plan
- [x] 全9テスト通過（アイコン start/end 配置、icon-only、アイコンなし等）
- [x] typecheck 通過
- [ ] Storybook で全バリアント × Light/Dark の表示確認
- [ ] アイコン付きボタンの各サイズでの表示確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)