### PR TITLE
feat: add Foundation docs (Color & Typography)

### DIFF
--- a/src/core/tokens/semantic.css
+++ b/src/core/tokens/semantic.css
@@ -50,7 +50,7 @@
   --color-surface: var(--gray-900);
   --color-surface-elevated: var(--gray-800);
 
-  --color-text: var(--paper-white);
+  --color-text: var(--ink-black);
   --color-text-muted: var(--gray-400);
   --color-text-subtle: var(--gray-500);
 

--- a/src/docs/Color.stories.tsx
+++ b/src/docs/Color.stories.tsx
@@ -1,0 +1,270 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+
+const meta: Meta = {
+  title: 'Foundation/Color',
+  parameters: {
+    layout: 'fullscreen',
+  },
+}
+
+export default meta
+type Story = StoryObj
+
+const ColorRow = ({
+  name,
+  description,
+  className,
+}: {
+  name: string
+  description: string
+  className: string
+}) => (
+  <div className="flex items-center gap-4 py-3 border-b border-border last:border-b-0">
+    <div className={`w-10 h-10 rounded-lg shrink-0 ${className}`} />
+    <div>
+      <p className="text-sm font-medium text-text font-mono">{name}</p>
+      <p className="text-xs text-text-muted">{description}</p>
+    </div>
+  </div>
+)
+
+const ScaleRow = ({ shades }: { shades: { level: string; className: string }[] }) => (
+  <div className="flex gap-1">
+    {shades.map((s) => (
+      <div key={s.level} className="flex flex-col items-center gap-1">
+        <div className={`w-12 h-12 rounded-lg ${s.className}`} />
+        <span className="text-[10px] text-text-muted font-mono">{s.level}</span>
+      </div>
+    ))}
+  </div>
+)
+
+const SectionTitle = ({ children }: { children: React.ReactNode }) => (
+  <h2 className="text-2xl font-bold text-text mt-8 mb-2">{children}</h2>
+)
+
+const SubsectionTitle = ({ children }: { children: React.ReactNode }) => (
+  <h3 className="text-base font-semibold text-text mt-6 mb-3">{children}</h3>
+)
+
+export const Colors: Story = {
+  name: 'Colors',
+  render: () => (
+    <div className="max-w-3xl mx-auto px-8 py-12">
+      <h1 className="text-4xl font-bold text-text mb-4">Colors</h1>
+      <p className="text-base text-text-muted leading-relaxed mb-8">
+        yasmro's color system is inspired by Japanese calligraphy — ink on paper. The consistent use
+        of color in our design system keeps cognitive loads low and makes for a unified and
+        accessible user experience. Colors adapt automatically between light and dark mode.
+      </p>
+
+      <SectionTitle>Color keys</SectionTitle>
+
+      <SubsectionTitle>Semantic colors</SubsectionTitle>
+      <div className="border border-border rounded-xl px-5">
+        <ColorRow name="background" description="Page background color" className="bg-background" />
+        <ColorRow
+          name="surface"
+          description="Card and container surfaces"
+          className="bg-surface border border-border"
+        />
+        <ColorRow
+          name="text"
+          description="Primary text color for body content"
+          className="bg-text"
+        />
+        <ColorRow
+          name="text-muted"
+          description="Secondary text for descriptions and helper text"
+          className="bg-text-muted"
+        />
+        <ColorRow
+          name="border"
+          description="Default border for dividers and containers"
+          className="bg-border"
+        />
+        <ColorRow
+          name="accent"
+          description="Vermillion accent for emphasis and highlights"
+          className="bg-accent"
+        />
+      </div>
+
+      <SubsectionTitle>Status colors</SubsectionTitle>
+      <div className="border border-border rounded-xl px-5">
+        <ColorRow
+          name="success"
+          description="Positive actions and states (completion, approval)"
+          className="bg-success"
+        />
+        <ColorRow
+          name="warning"
+          description="Caution states that need attention"
+          className="bg-warning"
+        />
+        <ColorRow
+          name="error"
+          description="Destructive actions and error states"
+          className="bg-error"
+        />
+      </div>
+
+      <SubsectionTitle>Ink &amp; Paper</SubsectionTitle>
+      <p className="text-sm text-text-muted mb-3">
+        Core brand palette inspired by Japanese calligraphy. These are the foundational colors.
+      </p>
+      <div className="border border-border rounded-xl px-5">
+        <ColorRow
+          name="ink-black"
+          description="Darkest ink tone — primary text and emphasis"
+          className="bg-ink-black"
+        />
+        <ColorRow
+          name="ink-dark"
+          description="Secondary ink tone for headings"
+          className="bg-ink-dark"
+        />
+        <ColorRow
+          name="ink-medium"
+          description="Medium ink tone for body text"
+          className="bg-ink-medium"
+        />
+        <ColorRow
+          name="ink-light"
+          description="Light ink for muted or disabled text"
+          className="bg-ink-light"
+        />
+        <ColorRow
+          name="paper-white"
+          description="Lightest paper — main background"
+          className="bg-paper-white border border-border"
+        />
+        <ColorRow
+          name="paper-warm"
+          description="Warm paper tone for subtle backgrounds"
+          className="bg-paper-warm border border-border"
+        />
+        <ColorRow
+          name="paper-cream"
+          description="Cream paper for cards and elevated surfaces"
+          className="bg-paper-cream border border-border"
+        />
+        <ColorRow
+          name="sumi"
+          description="Sumi (墨) — traditional ink accent"
+          className="bg-sumi"
+        />
+        <ColorRow
+          name="sumi-faded"
+          description="Faded sumi for secondary accents"
+          className="bg-sumi-faded"
+        />
+        <ColorRow
+          name="vermillion"
+          description="Vermillion (朱) — traditional Japanese red"
+          className="bg-vermillion"
+        />
+      </div>
+
+      <SectionTitle>Color scales</SectionTitle>
+
+      <SubsectionTitle>Primary</SubsectionTitle>
+      <p className="text-sm text-text-muted mb-3">
+        Primary color scale mapped from theme tokens. The default theme uses blue; seasonal themes
+        override this entire scale.
+      </p>
+      <ScaleRow
+        shades={[
+          { level: '100', className: 'bg-primary-100' },
+          { level: '200', className: 'bg-primary-200' },
+          { level: '300', className: 'bg-primary-300' },
+          { level: '400', className: 'bg-primary-400' },
+          { level: '500', className: 'bg-primary-500' },
+          { level: '600', className: 'bg-primary-600' },
+          { level: '700', className: 'bg-primary-700' },
+          { level: '800', className: 'bg-primary-800' },
+          { level: '900', className: 'bg-primary-900' },
+        ]}
+      />
+
+      <SubsectionTitle>Gray</SubsectionTitle>
+      <p className="text-sm text-text-muted mb-3">
+        Neutral gray scale defined in OKLCH for perceptually uniform steps.
+      </p>
+      <ScaleRow
+        shades={[
+          { level: '50', className: 'bg-gray-50' },
+          { level: '100', className: 'bg-gray-100' },
+          { level: '200', className: 'bg-gray-200' },
+          { level: '300', className: 'bg-gray-300' },
+          { level: '400', className: 'bg-gray-400' },
+          { level: '500', className: 'bg-gray-500' },
+          { level: '600', className: 'bg-gray-600' },
+          { level: '700', className: 'bg-gray-700' },
+          { level: '800', className: 'bg-gray-800' },
+          { level: '900', className: 'bg-gray-900' },
+          { level: '950', className: 'bg-gray-950' },
+        ]}
+      />
+
+      <SectionTitle>Seasonal themes</SectionTitle>
+      <p className="text-sm text-text-muted mb-4">
+        Eight seasonal color themes based on the Japanese 二十四節気 (24 solar terms). Each theme
+        overrides the primary color scale via the{' '}
+        <code className="text-xs bg-gray-100 px-1.5 py-0.5 rounded">data-season</code> attribute on
+        the root element.
+      </p>
+      <div className="flex flex-col gap-5">
+        {(
+          [
+            { label: 'Spring Early', jp: '立春', hue: 12 },
+            { label: 'Spring Late', jp: '春分', hue: 138 },
+            { label: 'Summer Early', jp: '立夏', hue: 162 },
+            { label: 'Summer Peak', jp: '夏至', hue: 45 },
+            { label: 'Autumn Early', jp: '立秋', hue: 230 },
+            { label: 'Autumn Late', jp: '秋分', hue: 70 },
+            { label: 'Winter Early', jp: '立冬', hue: 250 },
+            { label: 'Winter Deep', jp: '冬至', hue: 255 },
+          ] as const
+        ).map((season) => (
+          <div key={season.label} className="flex flex-col gap-1">
+            <p className="text-sm font-medium text-text">
+              {season.label} <span className="text-text-muted">({season.jp})</span>
+            </p>
+            <div className="flex gap-0.5">
+              {([100, 200, 300, 400, 500, 600, 700, 800, 900] as const).map((shade) => {
+                const lightness =
+                  shade === 100
+                    ? 0.96
+                    : shade === 200
+                      ? 0.91
+                      : shade === 300
+                        ? 0.83
+                        : shade === 400
+                          ? 0.74
+                          : shade === 500
+                            ? 0.64
+                            : shade === 600
+                              ? 0.56
+                              : shade === 700
+                                ? 0.46
+                                : shade === 800
+                                  ? 0.36
+                                  : 0.27
+                const chroma =
+                  shade <= 200 ? 0.04 : shade <= 500 ? 0.09 : shade <= 700 ? 0.08 : 0.05
+                return (
+                  <div
+                    key={shade}
+                    className="w-8 h-8 rounded-sm first:rounded-l-lg last:rounded-r-lg"
+                    style={{ backgroundColor: `oklch(${lightness} ${chroma} ${season.hue})` }}
+                  />
+                )
+              })}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  ),
+}

--- a/src/docs/Typography.stories.tsx
+++ b/src/docs/Typography.stories.tsx
@@ -1,0 +1,383 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+
+const meta: Meta = {
+  title: 'Foundation/Typography',
+  parameters: {
+    layout: 'fullscreen',
+  },
+}
+
+export default meta
+type Story = StoryObj
+
+const SectionTitle = ({ children }: { children: React.ReactNode }) => (
+  <h2 className="text-2xl font-bold text-text mt-8 mb-2">{children}</h2>
+)
+
+const SubsectionTitle = ({ children }: { children: React.ReactNode }) => (
+  <h3 className="text-base font-semibold text-text mt-6 mb-3">{children}</h3>
+)
+
+const TokenRow = ({
+  label,
+  token,
+  value,
+  style,
+}: {
+  label: string
+  token: string
+  value: string
+  style?: React.CSSProperties
+}) => (
+  <div className="flex items-baseline gap-4 py-2 border-b border-border last:border-b-0">
+    <span className="shrink-0 w-32 text-sm text-text" style={style}>
+      {label}
+    </span>
+    <span className="shrink-0 text-xs text-text-muted font-mono">{token}</span>
+    <span className="text-xs text-text-muted ml-auto">{value}</span>
+  </div>
+)
+
+const TypographyRow = ({
+  name,
+  description,
+  tokens,
+  sampleText,
+  sampleTextJa,
+}: {
+  name: string
+  description: string
+  tokens: { size: string; leading: string; weight: string }
+  sampleText: string
+  sampleTextJa: string
+}) => (
+  <div className="py-4 border-b border-border last:border-b-0">
+    <p
+      className="text-text mb-1"
+      style={{
+        fontSize: `var(${tokens.size})`,
+        lineHeight: `var(${tokens.leading})`,
+        fontWeight: `var(${tokens.weight})`,
+      }}
+    >
+      {sampleText}
+    </p>
+    <p
+      className="text-text-muted mb-2"
+      style={{
+        fontSize: `var(${tokens.size})`,
+        lineHeight: `var(${tokens.leading})`,
+        fontWeight: `var(${tokens.weight})`,
+      }}
+    >
+      {sampleTextJa}
+    </p>
+    <div className="flex items-center gap-3">
+      <span className="text-xs font-medium text-text font-mono">{name}</span>
+      <span className="text-xs text-text-muted">{description}</span>
+    </div>
+  </div>
+)
+
+export const Typography: Story = {
+  name: 'Typography',
+  render: () => (
+    <div className="max-w-3xl mx-auto px-8 py-12">
+      <h1 className="text-4xl font-bold text-text mb-4">Typography</h1>
+      <p className="text-base text-text-muted leading-relaxed mb-8">
+        yasmro's typography system provides consistent text styling across the design system.
+        Semantic tokens bundle font size, line height, and weight into named roles — Heading, Body,
+        and Label — so text styles are applied consistently without manual configuration.
+      </p>
+
+      <SectionTitle>Font families</SectionTitle>
+      <div className="border border-border rounded-xl px-5">
+        <div className="py-4 border-b border-border">
+          <p className="font-sans text-xl text-text mb-1">
+            Hanken Grotesk — The quick brown fox jumps over the lazy dog.
+          </p>
+          <p className="font-sans text-xl text-text-muted mb-1">
+            LINE Seed JP — 素早い茶色の狐が怠惰な犬を飛び越える。
+          </p>
+          <p className="text-xs text-text-muted font-mono">
+            --font-sans: "Hanken Grotesk", "LINE Seed JP", ui-sans-serif, system-ui, sans-serif
+          </p>
+          <p className="text-xs text-text-muted mt-1">Default typeface for UI and body text.</p>
+        </div>
+        <div className="py-4 border-b border-border">
+          <p className="font-serif text-xl text-text mb-1">
+            The quick brown fox jumps over the lazy dog.
+          </p>
+          <p className="text-xs text-text-muted font-mono">
+            --font-serif: ui-serif, Georgia, Cambria, "Times New Roman", serif
+          </p>
+          <p className="text-xs text-text-muted mt-1">Serif fallback for editorial content.</p>
+        </div>
+        <div className="py-4">
+          <p className="font-mono text-xl text-text mb-1">
+            The quick brown fox jumps over the lazy dog.
+          </p>
+          <p className="text-xs text-text-muted font-mono">
+            --font-mono: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace
+          </p>
+          <p className="text-xs text-text-muted mt-1">Monospace for code and technical content.</p>
+        </div>
+      </div>
+
+      <SectionTitle>Type scale</SectionTitle>
+
+      <SubsectionTitle>Heading</SubsectionTitle>
+      <p className="text-sm text-text-muted mb-3">
+        Used for page titles, section headers, and card headings. Uses semibold/bold weight with
+        snug/tight line height.
+      </p>
+      <div className="border border-border rounded-xl px-5">
+        <TypographyRow
+          name="heading-2xl"
+          description="Display titles"
+          tokens={{
+            size: '--text-heading-2xl-size',
+            leading: '--text-heading-2xl-leading',
+            weight: '--text-heading-2xl-weight',
+          }}
+          sampleText="Display Title"
+          sampleTextJa="表示タイトル"
+        />
+        <TypographyRow
+          name="heading-xl"
+          description="Page titles"
+          tokens={{
+            size: '--text-heading-xl-size',
+            leading: '--text-heading-xl-leading',
+            weight: '--text-heading-xl-weight',
+          }}
+          sampleText="Page Title"
+          sampleTextJa="ページタイトル"
+        />
+        <TypographyRow
+          name="heading-lg"
+          description="Section titles"
+          tokens={{
+            size: '--text-heading-lg-size',
+            leading: '--text-heading-lg-leading',
+            weight: '--text-heading-lg-weight',
+          }}
+          sampleText="Section Title"
+          sampleTextJa="セクションタイトル"
+        />
+        <TypographyRow
+          name="heading-md"
+          description="Subsection titles"
+          tokens={{
+            size: '--text-heading-md-size',
+            leading: '--text-heading-md-leading',
+            weight: '--text-heading-md-weight',
+          }}
+          sampleText="Subsection Title"
+          sampleTextJa="サブセクションタイトル"
+        />
+        <TypographyRow
+          name="heading-sm"
+          description="Card titles"
+          tokens={{
+            size: '--text-heading-sm-size',
+            leading: '--text-heading-sm-leading',
+            weight: '--text-heading-sm-weight',
+          }}
+          sampleText="Card Title"
+          sampleTextJa="カードタイトル"
+        />
+      </div>
+
+      <SubsectionTitle>Body</SubsectionTitle>
+      <p className="text-sm text-text-muted mb-3">
+        For paragraphs, descriptions, and general content. Uses normal weight with relaxed line
+        height for readability.
+      </p>
+      <div className="border border-border rounded-xl px-5">
+        <TypographyRow
+          name="body-lg"
+          description="Lead paragraphs and introductions"
+          tokens={{
+            size: '--text-body-lg-size',
+            leading: '--text-body-lg-leading',
+            weight: '--text-body-lg-weight',
+          }}
+          sampleText="Lead paragraphs and introductions for emphasis."
+          sampleTextJa="リード文や導入部分に使用する強調テキストです。"
+        />
+        <TypographyRow
+          name="body-md"
+          description="Default body text"
+          tokens={{
+            size: '--text-body-md-size',
+            leading: '--text-body-md-leading',
+            weight: '--text-body-md-weight',
+          }}
+          sampleText="The quick brown fox jumps over the lazy dog. This is the default body text used for most content throughout the application."
+          sampleTextJa="素早い茶色の狐が怠惰な犬を飛び越える。これはアプリケーション全体で使用される標準の本文テキストです。"
+        />
+        <TypographyRow
+          name="body-sm"
+          description="Secondary text and descriptions"
+          tokens={{
+            size: '--text-body-sm-size',
+            leading: '--text-body-sm-leading',
+            weight: '--text-body-sm-weight',
+          }}
+          sampleText="Secondary text for descriptions, helper text, and supporting content."
+          sampleTextJa="説明文、ヘルパーテキスト、補足コンテンツ用のセカンダリテキスト。"
+        />
+        <TypographyRow
+          name="body-xs"
+          description="Captions and footnotes"
+          tokens={{
+            size: '--text-body-xs-size',
+            leading: '--text-body-xs-leading',
+            weight: '--text-body-xs-weight',
+          }}
+          sampleText="Captions, footnotes, and fine print."
+          sampleTextJa="キャプション、脚注、注意書き。"
+        />
+      </div>
+
+      <SubsectionTitle>Label</SubsectionTitle>
+      <p className="text-sm text-text-muted mb-3">
+        For interactive elements — form labels, buttons, navigation, and badges. Uses medium weight
+        with tight line height.
+      </p>
+      <div className="border border-border rounded-xl px-5">
+        <TypographyRow
+          name="label-lg"
+          description="Navigation items"
+          tokens={{
+            size: '--text-label-lg-size',
+            leading: '--text-label-lg-leading',
+            weight: '--text-label-lg-weight',
+          }}
+          sampleText="Navigation Item"
+          sampleTextJa="ナビゲーション項目"
+        />
+        <TypographyRow
+          name="label-md"
+          description="Form labels and buttons"
+          tokens={{
+            size: '--text-label-md-size',
+            leading: '--text-label-md-leading',
+            weight: '--text-label-md-weight',
+          }}
+          sampleText="Form Label"
+          sampleTextJa="フォームラベル"
+        />
+        <TypographyRow
+          name="label-sm"
+          description="Tags and badges"
+          tokens={{
+            size: '--text-label-sm-size',
+            leading: '--text-label-sm-leading',
+            weight: '--text-label-sm-weight',
+          }}
+          sampleText="Badge Text"
+          sampleTextJa="バッジテキスト"
+        />
+        <TypographyRow
+          name="label-xs"
+          description="Overlines and micro labels"
+          tokens={{
+            size: '--text-label-xs-size',
+            leading: '--text-label-xs-leading',
+            weight: '--text-label-xs-weight',
+          }}
+          sampleText="OVERLINE TEXT"
+          sampleTextJa="オーバーライン"
+        />
+      </div>
+
+      <SectionTitle>Primitives</SectionTitle>
+
+      <SubsectionTitle>Font sizes</SubsectionTitle>
+      <div className="border border-border rounded-xl px-5">
+        <TokenRow
+          label="Extra Small"
+          token="--text-xs"
+          value="0.75rem (12px)"
+          style={{ fontSize: '0.75rem' }}
+        />
+        <TokenRow
+          label="Small"
+          token="--text-sm"
+          value="0.875rem (14px)"
+          style={{ fontSize: '0.875rem' }}
+        />
+        <TokenRow
+          label="Base"
+          token="--text-base"
+          value="1rem (16px)"
+          style={{ fontSize: '1rem' }}
+        />
+        <TokenRow
+          label="Large"
+          token="--text-lg"
+          value="1.125rem (18px)"
+          style={{ fontSize: '1.125rem' }}
+        />
+        <TokenRow
+          label="XL"
+          token="--text-xl"
+          value="1.25rem (20px)"
+          style={{ fontSize: '1.25rem' }}
+        />
+        <TokenRow
+          label="2XL"
+          token="--text-2xl"
+          value="1.5rem (24px)"
+          style={{ fontSize: '1.5rem' }}
+        />
+        <TokenRow
+          label="3XL"
+          token="--text-3xl"
+          value="1.875rem (30px)"
+          style={{ fontSize: '1.875rem' }}
+        />
+        <TokenRow
+          label="4XL"
+          token="--text-4xl"
+          value="2.25rem (36px)"
+          style={{ fontSize: '2.25rem' }}
+        />
+      </div>
+
+      <SubsectionTitle>Font weights</SubsectionTitle>
+      <div className="border border-border rounded-xl px-5">
+        <TokenRow label="Normal" token="--font-normal" value="400" style={{ fontWeight: 400 }} />
+        <TokenRow label="Medium" token="--font-medium" value="500" style={{ fontWeight: 500 }} />
+        <TokenRow
+          label="Semibold"
+          token="--font-semibold"
+          value="600"
+          style={{ fontWeight: 600 }}
+        />
+        <TokenRow label="Bold" token="--font-bold" value="700" style={{ fontWeight: 700 }} />
+      </div>
+
+      <SubsectionTitle>Line heights</SubsectionTitle>
+      <div className="border border-border rounded-xl px-5">
+        <TokenRow label="None" token="--leading-none" value="1" />
+        <TokenRow label="Tight" token="--leading-tight" value="1.25" />
+        <TokenRow label="Snug" token="--leading-snug" value="1.375" />
+        <TokenRow label="Normal" token="--leading-normal" value="1.5" />
+        <TokenRow label="Relaxed" token="--leading-relaxed" value="1.625" />
+        <TokenRow label="Loose" token="--leading-loose" value="2" />
+      </div>
+
+      <SubsectionTitle>Letter spacing</SubsectionTitle>
+      <div className="border border-border rounded-xl px-5">
+        <TokenRow label="Tighter" token="--tracking-tighter" value="-0.05em" />
+        <TokenRow label="Tight" token="--tracking-tight" value="-0.025em" />
+        <TokenRow label="Normal" token="--tracking-normal" value="0" />
+        <TokenRow label="Wide" token="--tracking-wide" value="0.025em" />
+        <TokenRow label="Wider" token="--tracking-wider" value="0.05em" />
+      </div>
+    </div>
+  ),
+}


### PR DESCRIPTION
## Summary
- Add **Foundation/Color** Storybook page with semantic colors, status colors, ink & paper palette, color scales, and seasonal theme previews
- Add **Foundation/Typography** Storybook page with font families (EN/JP samples), semantic type scale (Heading/Body/Label), and primitive token references
- Fix dark mode text visibility bug in `semantic.css` (`--color-text` referenced `--paper-white` which inverts to dark in `.dark` mode)

## Test plan
- [ ] Open Storybook and verify Foundation/Color page renders all color swatches
- [ ] Open Storybook and verify Foundation/Typography page renders all type samples including Japanese text
- [ ] Toggle Dark mode in Storybook toolbar and verify all text remains readable
- [ ] Toggle seasonal themes and verify primary color scale changes on Color page

🤖 Generated with [Claude Code](https://claude.com/claude-code)