### PR TITLE
feat: add Spinner component and Button isLoading prop

### DIFF
--- a/src/components/lv1/Button/Button.stories.tsx
+++ b/src/components/lv1/Button/Button.stories.tsx
@@ -52,6 +52,14 @@ const meta: Meta<typeof Button> = {
         defaultValue: { summary: 'false' },
       },
     },
+    isLoading: {
+      description: 'Shows a loading spinner and disables the button.',
+      control: 'boolean',
+      table: {
+        type: { summary: 'boolean' },
+        defaultValue: { summary: 'false' },
+      },
+    },
     disabled: {
       description: 'Disables the button and applies disabled styling.',
       control: 'boolean',
@@ -136,6 +144,24 @@ export const IconPositions: Story = {
       </Button>
       <Button icon="Send" size="lg" iconPosition="end">
         Send
+      </Button>
+    </div>
+  ),
+}
+
+export const Loading: Story = {
+  name: 'Loading',
+  render: () => (
+    <div className="flex flex-wrap gap-4">
+      <Button isLoading>Primary</Button>
+      <Button variant="secondary" isLoading>
+        Secondary
+      </Button>
+      <Button variant="tertiary" isLoading>
+        Tertiary
+      </Button>
+      <Button variant="destructive" isLoading>
+        Destructive
       </Button>
     </div>
   ),

--- a/src/components/lv1/Button/Button.test.tsx
+++ b/src/components/lv1/Button/Button.test.tsx
@@ -76,4 +76,39 @@ describe('Button', () => {
     const contentSpan = button.querySelector(':scope > span:last-child') as HTMLElement
     expect(contentSpan.querySelector('svg')).not.toBeInTheDocument()
   })
+
+  describe('isLoading', () => {
+    it('shows spinner when isLoading is true', () => {
+      render(<Button isLoading>Submit</Button>)
+      expect(screen.getByRole('status')).toBeInTheDocument()
+    })
+
+    it('disables button when isLoading is true', () => {
+      render(<Button isLoading>Submit</Button>)
+      expect(screen.getByRole('button')).toBeDisabled()
+    })
+
+    it('hides content when isLoading is true', () => {
+      render(<Button isLoading>Submit</Button>)
+      const button = screen.getByRole('button')
+      const contentSpan = button.querySelector(':scope > span:last-child') as HTMLElement
+      expect(contentSpan).toHaveClass('opacity-0')
+    })
+
+    it('shows spinner overlay with opacity-100 when loading', () => {
+      render(<Button isLoading>Submit</Button>)
+      const button = screen.getByRole('button')
+      const spinnerSpan = button.querySelector(':scope > span:first-child') as HTMLElement
+      expect(spinnerSpan).toHaveClass('opacity-100')
+    })
+
+    it('hides spinner when isLoading is false', () => {
+      render(<Button>Submit</Button>)
+      const button = screen.getByRole('button')
+      const spinnerSpan = button.querySelector(':scope > span:first-child') as HTMLElement
+      // Spinner overlay exists but is hidden with opacity-0
+      expect(spinnerSpan).toHaveClass('opacity-0')
+      expect(spinnerSpan).toHaveAttribute('aria-hidden', 'true')
+    })
+  })
 })

--- a/src/components/lv1/Button/Button.test.tsx
+++ b/src/components/lv1/Button/Button.test.tsx
@@ -39,31 +39,33 @@ describe('Button', () => {
   })
 
   it('renders icon at start position by default', () => {
-    render(<Button icon="Search">検索</Button>)
+    render(<Button icon="Search">Search</Button>)
     const button = screen.getByRole('button')
-    const svg = button.querySelector('svg')
+    const contentSpan = button.querySelector(':scope > span:last-child') as HTMLElement
+    const svg = contentSpan.querySelector('svg')
     expect(svg).toBeInTheDocument()
     expect(svg?.getAttribute('aria-hidden')).toBe('true')
-    expect(button.firstChild).toBe(svg)
+    expect(contentSpan.firstChild).toBe(svg)
   })
 
   it('renders icon at end position', () => {
     render(
       <Button icon="ArrowRight" iconPosition="end">
-        次へ
+        Next
       </Button>,
     )
     const button = screen.getByRole('button')
-    const svg = button.querySelector('svg')
+    const contentSpan = button.querySelector(':scope > span:last-child') as HTMLElement
+    const svg = contentSpan.querySelector('svg')
     expect(svg).toBeInTheDocument()
-    expect(button.lastChild).toBe(svg)
+    expect(contentSpan.lastChild).toBe(svg)
   })
 
   it('renders icon-only button with square aspect ratio', () => {
     render(<Button icon="Plus" aria-label="Add" />)
     const button = screen.getByRole('button', { name: 'Add' })
-    const svg = button.querySelector('svg')
-    expect(svg).toBeInTheDocument()
+    const contentSpan = button.querySelector(':scope > span:last-child') as HTMLElement
+    expect(contentSpan.querySelector('svg')).toBeInTheDocument()
     expect(button).toHaveClass('aspect-square')
     expect(button).toHaveClass('px-0')
   })
@@ -71,6 +73,7 @@ describe('Button', () => {
   it('renders without icon when icon prop is not provided', () => {
     render(<Button>No Icon</Button>)
     const button = screen.getByRole('button')
-    expect(button.querySelector('svg')).not.toBeInTheDocument()
+    const contentSpan = button.querySelector(':scope > span:last-child') as HTMLElement
+    expect(contentSpan.querySelector('svg')).not.toBeInTheDocument()
   })
 })

--- a/src/components/lv1/Button/Button.tsx
+++ b/src/components/lv1/Button/Button.tsx
@@ -8,9 +8,11 @@ import { Spinner } from '../Spinner'
 export type IconName = keyof typeof icons
 
 export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement>, ButtonVariants {
+  /** Render as child element using Radix Slot. Note: `isLoading` is ignored when `asChild` is true. */
   asChild?: boolean
   icon?: IconName
   iconPosition?: 'start' | 'end'
+  /** Shows a loading spinner and disables the button. Ignored when `asChild` is true. */
   isLoading?: boolean
 }
 
@@ -35,6 +37,9 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
     const isIconOnly = !children && !!icon
 
     if (asChild) {
+      if (process.env.NODE_ENV !== 'production' && isLoading) {
+        console.warn('Button: `isLoading` prop is ignored when `asChild` is true.')
+      }
       return (
         <Comp className={cn(buttonVariants({ variant, size, className }))} ref={ref} {...props}>
           {children}

--- a/src/components/lv1/Button/Button.tsx
+++ b/src/components/lv1/Button/Button.tsx
@@ -3,6 +3,7 @@ import { icons } from 'lucide-react'
 import { type ButtonHTMLAttributes, forwardRef } from 'react'
 import { cn } from '../../../lib/utils'
 import { type ButtonVariants, buttonVariants } from '../../../variants/button'
+import { Spinner } from '../Spinner'
 
 export type IconName = keyof typeof icons
 
@@ -10,11 +11,23 @@ export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement>, Bu
   asChild?: boolean
   icon?: IconName
   iconPosition?: 'start' | 'end'
+  isLoading?: boolean
 }
 
 export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
   (
-    { className, variant, size, asChild = false, icon, iconPosition = 'start', children, ...props },
+    {
+      className,
+      variant,
+      size,
+      asChild = false,
+      icon,
+      iconPosition = 'start',
+      isLoading = false,
+      disabled,
+      children,
+      ...props
+    },
     ref,
   ) => {
     const Comp = asChild ? Slot : 'button'
@@ -36,11 +49,21 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
           isIconOnly && 'aspect-square px-0',
         )}
         ref={ref}
+        disabled={disabled || isLoading}
         {...props}
       >
-        {IconComponent && iconPosition === 'start' && <IconComponent aria-hidden="true" />}
-        {children}
-        {IconComponent && iconPosition === 'end' && <IconComponent aria-hidden="true" />}
+        {isLoading ? (
+          <>
+            <Spinner size="sm" className="size-[1em]" label="Loading" />
+            {children}
+          </>
+        ) : (
+          <>
+            {IconComponent && iconPosition === 'start' && <IconComponent aria-hidden="true" />}
+            {children}
+            {IconComponent && iconPosition === 'end' && <IconComponent aria-hidden="true" />}
+          </>
+        )}
       </Comp>
     )
   },

--- a/src/components/lv1/Button/Button.tsx
+++ b/src/components/lv1/Button/Button.tsx
@@ -47,23 +47,31 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
         className={cn(
           buttonVariants({ variant, size, className }),
           isIconOnly && 'aspect-square px-0',
+          'relative',
         )}
         ref={ref}
         disabled={disabled || isLoading}
         {...props}
       >
-        {isLoading ? (
-          <>
-            <Spinner size="sm" className="size-[1em]" label="Loading" />
-            {children}
-          </>
-        ) : (
-          <>
-            {IconComponent && iconPosition === 'start' && <IconComponent aria-hidden="true" />}
-            {children}
-            {IconComponent && iconPosition === 'end' && <IconComponent aria-hidden="true" />}
-          </>
-        )}
+        <span
+          className={cn(
+            'absolute inset-0 flex items-center justify-center transition-opacity duration-300',
+            isLoading ? 'opacity-100' : 'opacity-0',
+          )}
+          aria-hidden={!isLoading}
+        >
+          <Spinner size="sm" className="size-[1em]" label="Loading" />
+        </span>
+        <span
+          className={cn(
+            'inline-flex items-center gap-2 transition-opacity duration-300',
+            isLoading ? 'opacity-0' : 'opacity-100',
+          )}
+        >
+          {IconComponent && iconPosition === 'start' && <IconComponent aria-hidden="true" />}
+          {children}
+          {IconComponent && iconPosition === 'end' && <IconComponent aria-hidden="true" />}
+        </span>
       </Comp>
     )
   },

--- a/src/components/lv1/Spinner/Spinner.css
+++ b/src/components/lv1/Spinner/Spinner.css
@@ -1,0 +1,43 @@
+@keyframes yasmro-dot-breathe {
+  0%,
+  100% {
+    opacity: 0.55;
+    transform: scale(0.9);
+  }
+  50% {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
+@keyframes yasmro-ripple-wave {
+  0% {
+    transform: scale(0.45);
+    opacity: 0;
+  }
+  18% {
+    opacity: 0.35;
+  }
+  100% {
+    transform: scale(3.2);
+    opacity: 0;
+  }
+}
+
+.yasmro-spinner-dot {
+  animation: yasmro-dot-breathe 2.8s ease-in-out infinite;
+  transform-origin: center;
+}
+
+.yasmro-spinner-ripple {
+  transform-box: fill-box;
+  transform-origin: center;
+}
+
+.yasmro-spinner-ripple-1 {
+  animation: yasmro-ripple-wave 2.8s ease-out infinite;
+}
+
+.yasmro-spinner-ripple-2 {
+  animation: yasmro-ripple-wave 2.8s ease-out infinite 1.1s;
+}

--- a/src/components/lv1/Spinner/Spinner.css
+++ b/src/components/lv1/Spinner/Spinner.css
@@ -1,3 +1,8 @@
+:root {
+  --yasmro-spinner-duration: 2.8s;
+  --yasmro-spinner-ripple-delay: 1.1s;
+}
+
 @keyframes yasmro-dot-breathe {
   0%,
   100% {
@@ -25,7 +30,7 @@
 }
 
 .yasmro-spinner-dot {
-  animation: yasmro-dot-breathe 2.8s ease-in-out infinite;
+  animation: yasmro-dot-breathe var(--yasmro-spinner-duration) ease-in-out infinite;
   transform-origin: center;
 }
 
@@ -35,9 +40,10 @@
 }
 
 .yasmro-spinner-ripple-1 {
-  animation: yasmro-ripple-wave 2.8s ease-out infinite;
+  animation: yasmro-ripple-wave var(--yasmro-spinner-duration) ease-out infinite;
 }
 
 .yasmro-spinner-ripple-2 {
-  animation: yasmro-ripple-wave 2.8s ease-out infinite 1.1s;
+  animation: yasmro-ripple-wave var(--yasmro-spinner-duration) ease-out infinite
+    var(--yasmro-spinner-ripple-delay);
 }

--- a/src/components/lv1/Spinner/Spinner.stories.tsx
+++ b/src/components/lv1/Spinner/Spinner.stories.tsx
@@ -1,0 +1,82 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { Spinner } from './Spinner'
+
+const meta: Meta<typeof Spinner> = {
+  title: 'Components/lv1/Spinner',
+  component: Spinner,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    type: {
+      description: 'Spinner animation type.',
+      control: 'select',
+      options: ['default', 'ripple'],
+      table: {
+        type: { summary: '"default" | "ripple"' },
+        defaultValue: { summary: 'default' },
+      },
+    },
+    size: {
+      description: 'Size of the spinner.',
+      control: 'select',
+      options: ['sm', 'md', 'lg'],
+      table: {
+        type: { summary: '"sm" | "md" | "lg"' },
+        defaultValue: { summary: 'md' },
+      },
+    },
+    label: {
+      description: 'Accessible label for screen readers.',
+      control: 'text',
+      table: {
+        type: { summary: 'string' },
+        defaultValue: { summary: 'Loading' },
+      },
+    },
+  },
+}
+
+export default meta
+type Story = StoryObj<typeof Spinner>
+
+export const Playground: Story = {
+  name: 'Playground',
+  args: {
+    type: 'default',
+    size: 'md',
+    label: 'Loading',
+  },
+}
+
+export const AllTypes: Story = {
+  name: 'All Types',
+  render: () => (
+    <div className="flex items-center gap-8">
+      <Spinner type="default" />
+      <Spinner type="ripple" />
+    </div>
+  ),
+}
+
+export const Sizes: Story = {
+  name: 'Sizes',
+  render: () => (
+    <div className="flex items-center gap-8">
+      <Spinner size="sm" />
+      <Spinner size="md" />
+      <Spinner size="lg" />
+    </div>
+  ),
+}
+
+export const OnDarkBackground: Story = {
+  name: 'On Dark Background',
+  render: () => (
+    <div className="flex items-center gap-8 rounded-lg bg-ink-black p-8 text-paper-white">
+      <Spinner type="default" />
+      <Spinner type="ripple" />
+    </div>
+  ),
+}

--- a/src/components/lv1/Spinner/Spinner.tsx
+++ b/src/components/lv1/Spinner/Spinner.tsx
@@ -1,0 +1,61 @@
+import { forwardRef, type HTMLAttributes } from 'react'
+import { cn } from '../../../lib/utils'
+import { type SpinnerVariants, spinnerVariants } from '../../../variants/spinner'
+import './Spinner.css'
+
+export interface SpinnerProps
+  extends HTMLAttributes<HTMLDivElement>,
+    Omit<SpinnerVariants, 'type'> {
+  /** Accessible label for screen readers. */
+  label?: string
+  /** Spinner animation type. */
+  type?: 'default' | 'ripple'
+}
+
+const DefaultSpinner = () => (
+  <svg className="size-full animate-spin" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+    <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="3" />
+    <path
+      className="opacity-75"
+      d="M22 12a10 10 0 0 0-10-10"
+      stroke="currentColor"
+      strokeWidth="3"
+      strokeLinecap="round"
+    />
+  </svg>
+)
+
+const RippleSpinner = () => (
+  <svg className="size-full" viewBox="0 0 72 72" fill="none" aria-hidden="true">
+    <circle className="yasmro-spinner-dot" cx="36" cy="36" r="2.6" fill="currentColor" />
+    <circle
+      className="yasmro-spinner-ripple yasmro-spinner-ripple-1"
+      cx="36"
+      cy="36"
+      r="10"
+      stroke="currentColor"
+      strokeWidth="1.4"
+    />
+    <circle
+      className="yasmro-spinner-ripple yasmro-spinner-ripple-2"
+      cx="36"
+      cy="36"
+      r="10"
+      stroke="currentColor"
+      strokeWidth="1.2"
+    />
+  </svg>
+)
+
+export const Spinner = forwardRef<HTMLDivElement, SpinnerProps>(
+  ({ className, size, type, label = 'Loading', ...props }, ref) => {
+    return (
+      <div className={cn(spinnerVariants({ size, className }))} role="status" ref={ref} {...props}>
+        {type === 'ripple' ? <RippleSpinner /> : <DefaultSpinner />}
+        <span className="sr-only">{label}</span>
+      </div>
+    )
+  },
+)
+
+Spinner.displayName = 'Spinner'

--- a/src/components/lv1/Spinner/Spinner.tsx
+++ b/src/components/lv1/Spinner/Spinner.tsx
@@ -3,9 +3,7 @@ import { cn } from '../../../lib/utils'
 import { type SpinnerVariants, spinnerVariants } from '../../../variants/spinner'
 import './Spinner.css'
 
-export interface SpinnerProps
-  extends HTMLAttributes<HTMLDivElement>,
-    Omit<SpinnerVariants, 'type'> {
+export interface SpinnerProps extends HTMLAttributes<HTMLDivElement>, SpinnerVariants {
   /** Accessible label for screen readers. */
   label?: string
   /** Spinner animation type. */

--- a/src/components/lv1/Spinner/Spinner.vrt.spec.ts
+++ b/src/components/lv1/Spinner/Spinner.vrt.spec.ts
@@ -1,8 +1,8 @@
 import { expect, test } from '@playwright/test'
 
-const STORY_ID_PREFIX = 'components-lv1-button'
+const STORY_ID_PREFIX = 'components-lv1-spinner'
 
-const stories = ['all-variants', 'sizes', 'icons', 'icon-positions', 'loading', 'disabled'] as const
+const stories = ['all-types', 'sizes', 'on-dark-background'] as const
 
 const themes = ['light', 'dark'] as const
 
@@ -12,11 +12,21 @@ function storyUrl(storyId: string, theme: string) {
 
 for (const story of stories) {
   for (const theme of themes) {
-    test(`Button / ${story} / ${theme}`, async ({ page }) => {
+    test(`Spinner / ${story} / ${theme}`, async ({ page }) => {
       await page.goto(storyUrl(story, theme))
       await page.waitForSelector('[data-storyloaded]', { timeout: 5_000 }).catch(() => {})
       // Wait for fonts and rendering to settle
       await page.waitForLoadState('networkidle')
+
+      // Pause animations for consistent screenshots
+      await page.addStyleTag({
+        content: `
+          *, *::before, *::after {
+            animation-play-state: paused !important;
+            animation-delay: -0.0001s !important;
+          }
+        `,
+      })
 
       const root = page.locator('#storybook-root')
       await expect(root).toHaveScreenshot(`${story}-${theme}.png`)

--- a/src/components/lv1/Spinner/index.ts
+++ b/src/components/lv1/Spinner/index.ts
@@ -1,0 +1,1 @@
+export { Spinner, type SpinnerProps } from './Spinner'

--- a/src/components/lv1/index.ts
+++ b/src/components/lv1/index.ts
@@ -1,2 +1,3 @@
 export { Button, type ButtonProps } from './Button'
+export { Spinner, type SpinnerProps } from './Spinner'
 export { Text, type TextProps } from './Text'

--- a/src/variants/index.ts
+++ b/src/variants/index.ts
@@ -1,2 +1,3 @@
 export { type ButtonVariants, buttonVariants } from './button'
+export { type SpinnerVariants, spinnerVariants } from './spinner'
 export { type TextVariants, textVariants } from './text'

--- a/src/variants/spinner.ts
+++ b/src/variants/spinner.ts
@@ -7,14 +7,9 @@ export const spinnerVariants = cva('inline-flex items-center justify-center', {
       md: 'size-6',
       lg: 'size-8',
     },
-    type: {
-      default: '',
-      ripple: '',
-    },
   },
   defaultVariants: {
     size: 'md',
-    type: 'default',
   },
 })
 

--- a/src/variants/spinner.ts
+++ b/src/variants/spinner.ts
@@ -1,0 +1,21 @@
+import { cva, type VariantProps } from 'class-variance-authority'
+
+export const spinnerVariants = cva('inline-flex items-center justify-center', {
+  variants: {
+    size: {
+      sm: 'size-4',
+      md: 'size-6',
+      lg: 'size-8',
+    },
+    type: {
+      default: '',
+      ripple: '',
+    },
+  },
+  defaultVariants: {
+    size: 'md',
+    type: 'default',
+  },
+})
+
+export type SpinnerVariants = VariantProps<typeof spinnerVariants>


### PR DESCRIPTION
## Summary
- Add `Spinner` component (`lv1`) with two animation types: `default` (rotating arc) and `ripple` (expanding wave), switchable via `type` prop
- Add `isLoading` prop to `Button` that shows a centered Spinner with a dissolve (cross-fade) transition, preserving button width
- CVA variants for `size` (`sm` / `md` / `lg`) and `type` (`default` / `ripple`)

## Test plan
- [ ] Verify Spinner renders correctly at all sizes in Storybook (`Components/lv1/Spinner`)
- [ ] Verify both `default` and `ripple` types animate as expected
- [ ] Verify Button `isLoading` shows Spinner centered with smooth fade transition
- [ ] Verify Button width does not shift when toggling `isLoading`
- [ ] Verify existing Button stories (Icons, Icon Positions, Disabled) are not broken

🤖 Generated with [Claude Code](https://claude.com/claude-code)