### PR TITLE
chore: rebrand from yasmro to Schatten

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -2,7 +2,7 @@
   "$schema": "https://unpkg.com/@changesets/config@3.1.1/schema.json",
   "changelog": [
     "@changesets/changelog-github",
-    { "repo": "yasmro/yasmro-ui" }
+    { "repo": "yasmro/schatten" }
   ],
   "commit": false,
   "fixed": [],

--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -16,7 +16,7 @@ const config: StorybookConfig = {
     config.plugins.push(tailwindcss())
 
     if (process.env.GITHUB_ACTIONS) {
-      config.base = '/yasmro-ui/'
+      config.base = '/schatten/'
     }
 
     return config

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
-# CLAUDE.md — yasmro-ui
+# CLAUDE.md — schatten-ui
 
-Design system component library based on [shadcn/ui](https://ui.shadcn.com/), customized for the yasmro brand.
+Design system component library based on [shadcn/ui](https://ui.shadcn.com/), customized for the Schatten brand.
 When adding or modifying components, follow shadcn/ui conventions (Radix UI + CVA + cn utility) as the baseline.
 
 ## Tech Stack

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@schatten/ui",
+  "name": "@yasmro/schatten",
   "version": "0.0.1",
   "packageManager": "pnpm@9.15.0",
   "description": "Design system with CSS variants and React components",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@yasmro/ui",
+  "name": "@schatten/ui",
   "version": "0.0.1",
   "packageManager": "pnpm@9.15.0",
   "description": "Design system with CSS variants and React components",
@@ -114,7 +114,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/yasmro/yasmro-ui.git"
+    "url": "https://github.com/yasmro/schatten.git"
   },
   "keywords": [
     "design-system",

--- a/src/components/lv1/Spinner/Spinner.css
+++ b/src/components/lv1/Spinner/Spinner.css
@@ -1,9 +1,9 @@
 :root {
-  --yasmro-spinner-duration: 2.8s;
-  --yasmro-spinner-ripple-delay: 1.1s;
+  --schatten-spinner-duration: 2.8s;
+  --schatten-spinner-ripple-delay: 1.1s;
 }
 
-@keyframes yasmro-dot-breathe {
+@keyframes schatten-dot-breathe {
   0%,
   100% {
     opacity: 0.55;
@@ -15,7 +15,7 @@
   }
 }
 
-@keyframes yasmro-ripple-wave {
+@keyframes schatten-ripple-wave {
   0% {
     transform: scale(0.45);
     opacity: 0;
@@ -29,21 +29,21 @@
   }
 }
 
-.yasmro-spinner-dot {
-  animation: yasmro-dot-breathe var(--yasmro-spinner-duration) ease-in-out infinite;
+.schatten-spinner-dot {
+  animation: schatten-dot-breathe var(--schatten-spinner-duration) ease-in-out infinite;
   transform-origin: center;
 }
 
-.yasmro-spinner-ripple {
+.schatten-spinner-ripple {
   transform-box: fill-box;
   transform-origin: center;
 }
 
-.yasmro-spinner-ripple-1 {
-  animation: yasmro-ripple-wave var(--yasmro-spinner-duration) ease-out infinite;
+.schatten-spinner-ripple-1 {
+  animation: schatten-ripple-wave var(--schatten-spinner-duration) ease-out infinite;
 }
 
-.yasmro-spinner-ripple-2 {
-  animation: yasmro-ripple-wave var(--yasmro-spinner-duration) ease-out infinite
-    var(--yasmro-spinner-ripple-delay);
+.schatten-spinner-ripple-2 {
+  animation: schatten-ripple-wave var(--schatten-spinner-duration) ease-out infinite
+    var(--schatten-spinner-ripple-delay);
 }

--- a/src/components/lv1/Spinner/Spinner.tsx
+++ b/src/components/lv1/Spinner/Spinner.tsx
@@ -25,9 +25,9 @@ const DefaultSpinner = () => (
 
 const RippleSpinner = () => (
   <svg className="size-full" viewBox="0 0 72 72" fill="none" aria-hidden="true">
-    <circle className="yasmro-spinner-dot" cx="36" cy="36" r="2.6" fill="currentColor" />
+    <circle className="schatten-spinner-dot" cx="36" cy="36" r="2.6" fill="currentColor" />
     <circle
-      className="yasmro-spinner-ripple yasmro-spinner-ripple-1"
+      className="schatten-spinner-ripple schatten-spinner-ripple-1"
       cx="36"
       cy="36"
       r="10"
@@ -35,7 +35,7 @@ const RippleSpinner = () => (
       strokeWidth="1.4"
     />
     <circle
-      className="yasmro-spinner-ripple yasmro-spinner-ripple-2"
+      className="schatten-spinner-ripple schatten-spinner-ripple-2"
       cx="36"
       cy="36"
       r="10"

--- a/src/docs/Color.stories.tsx
+++ b/src/docs/Color.stories.tsx
@@ -53,8 +53,8 @@ export const Colors: Story = {
     <div className="max-w-3xl mx-auto px-8 py-12">
       <h1 className="text-4xl font-bold text-text mb-4">Colors</h1>
       <p className="text-base text-text-muted leading-relaxed mb-8">
-        yasmro's color system is inspired by Japanese calligraphy — ink on paper. The consistent use
-        of color in our design system keeps cognitive loads low and makes for a unified and
+        Schatten's color system is inspired by Japanese calligraphy — ink on paper. The consistent
+        use of color in our design system keeps cognitive loads low and makes for a unified and
         accessible user experience. Colors adapt automatically between light and dark mode.
       </p>
 

--- a/src/docs/Typography.stories.tsx
+++ b/src/docs/Typography.stories.tsx
@@ -85,7 +85,7 @@ export const Typography: Story = {
     <div className="max-w-3xl mx-auto px-8 py-12">
       <h1 className="text-4xl font-bold text-text mb-4">Typography</h1>
       <p className="text-base text-text-muted leading-relaxed mb-8">
-        yasmro's typography system provides consistent text styling across the design system.
+        Schatten's typography system provides consistent text styling across the design system.
         Semantic tokens bundle font size, line height, and weight into named roles — Heading, Body,
         and Label — so text styles are applied consistently without manual configuration.
       </p>


### PR DESCRIPTION
## Summary
- Rename npm package from `@yasmro/ui` to `@schatten/ui`
- Update repository URL to `yasmro/schatten`
- Update all CSS class/variable prefixes from `yasmro-*` to `schatten-*`
- Update Storybook GitHub Pages base path and documentation references

## Test plan
- [ ] Verify `pnpm build` succeeds
- [ ] Verify `pnpm lint` passes
- [ ] Verify Storybook renders correctly with updated class names
- [ ] Confirm Spinner ripple animation works with renamed CSS classes

🤖 Generated with [Claude Code](https://claude.com/claude-code)