### PR TITLE
feat: add Badge component

### DIFF
--- a/src/components/lv1/Badge/Badge.stories.tsx
+++ b/src/components/lv1/Badge/Badge.stories.tsx
@@ -1,0 +1,133 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { Badge } from './Badge'
+
+const meta: Meta<typeof Badge> = {
+  title: 'Components/lv1/Badge',
+  component: Badge,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    variant: {
+      description: 'Visual style of the badge.',
+      control: 'select',
+      options: ['default', 'secondary', 'destructive', 'outline'],
+      table: {
+        type: { summary: '"default" | "secondary" | "destructive" | "outline"' },
+        defaultValue: { summary: 'default' },
+      },
+    },
+    size: {
+      description: 'Size of the badge.',
+      control: 'select',
+      options: ['sm', 'md', 'lg'],
+      table: {
+        type: { summary: '"sm" | "md" | "lg"' },
+        defaultValue: { summary: 'md' },
+      },
+    },
+    icon: {
+      description: 'Lucide icon name in PascalCase (e.g. "Check", "AlertCircle").',
+      control: 'text',
+      table: {
+        type: { summary: 'IconName' },
+        defaultValue: { summary: '-' },
+      },
+    },
+    iconPosition: {
+      description: 'Position of the icon relative to the label text.',
+      control: 'select',
+      options: ['start', 'end'],
+      table: {
+        type: { summary: '"start" | "end"' },
+        defaultValue: { summary: 'start' },
+      },
+    },
+    children: {
+      description: 'Content displayed inside the badge.',
+      control: 'text',
+      table: {
+        type: { summary: 'ReactNode' },
+      },
+    },
+  },
+}
+
+export default meta
+type Story = StoryObj<typeof Badge>
+
+export const Playground: Story = {
+  name: 'Playground',
+  args: {
+    variant: 'default',
+    size: 'md',
+    children: 'Badge',
+  },
+}
+
+export const AllVariants: Story = {
+  name: 'All Variants',
+  render: () => (
+    <div className="flex flex-wrap gap-4">
+      <Badge variant="default">Default</Badge>
+      <Badge variant="secondary">Secondary</Badge>
+      <Badge variant="destructive">Destructive</Badge>
+      <Badge variant="outline">Outline</Badge>
+    </div>
+  ),
+}
+
+export const Sizes: Story = {
+  name: 'Sizes',
+  render: () => (
+    <div className="flex items-center gap-4">
+      <Badge size="sm">Small</Badge>
+      <Badge size="md">Medium</Badge>
+      <Badge size="lg">Large</Badge>
+    </div>
+  ),
+}
+
+export const Icons: Story = {
+  name: 'Icons',
+  render: () => (
+    <div className="flex flex-wrap gap-4">
+      <Badge icon="Check">Success</Badge>
+      <Badge variant="destructive" icon="AlertCircle">
+        Error
+      </Badge>
+      <Badge variant="secondary" icon="Clock">
+        Pending
+      </Badge>
+      <Badge variant="outline" icon="Tag">
+        Label
+      </Badge>
+    </div>
+  ),
+}
+
+export const IconPositions: Story = {
+  name: 'Icon Positions',
+  render: () => (
+    <div className="flex items-center gap-4">
+      <Badge icon="ArrowLeft">Start</Badge>
+      <Badge icon="ArrowRight" iconPosition="end">
+        End
+      </Badge>
+    </div>
+  ),
+}
+
+export const IconOnly: Story = {
+  name: 'Icon Only',
+  render: () => (
+    <div className="flex items-center gap-4">
+      <Badge icon="Check" size="sm" aria-label="Success" />
+      <Badge icon="Check" aria-label="Success" />
+      <Badge icon="Check" size="lg" aria-label="Success" />
+      <Badge variant="destructive" icon="X" aria-label="Error" />
+      <Badge variant="outline" icon="Star" aria-label="Starred" />
+    </div>
+  ),
+}

--- a/src/components/lv1/Badge/Badge.stories.tsx
+++ b/src/components/lv1/Badge/Badge.stories.tsx
@@ -12,10 +12,10 @@ const meta: Meta<typeof Badge> = {
     variant: {
       description: 'Visual style of the badge.',
       control: 'select',
-      options: ['default', 'secondary', 'destructive', 'outline'],
+      options: ['primary', 'secondary', 'destructive', 'outline'],
       table: {
-        type: { summary: '"default" | "secondary" | "destructive" | "outline"' },
-        defaultValue: { summary: 'default' },
+        type: { summary: '"primary" | "secondary" | "destructive" | "outline"' },
+        defaultValue: { summary: 'primary' },
       },
     },
     size: {
@@ -60,7 +60,7 @@ type Story = StoryObj<typeof Badge>
 export const Playground: Story = {
   name: 'Playground',
   args: {
-    variant: 'default',
+    variant: 'primary',
     size: 'md',
     children: 'Badge',
   },
@@ -70,7 +70,7 @@ export const AllVariants: Story = {
   name: 'All Variants',
   render: () => (
     <div className="flex flex-wrap gap-4">
-      <Badge variant="default">Default</Badge>
+      <Badge variant="primary">Primary</Badge>
       <Badge variant="secondary">Secondary</Badge>
       <Badge variant="destructive">Destructive</Badge>
       <Badge variant="outline">Outline</Badge>

--- a/src/components/lv1/Badge/Badge.tsx
+++ b/src/components/lv1/Badge/Badge.tsx
@@ -1,0 +1,36 @@
+import { icons } from 'lucide-react'
+import { forwardRef, type HTMLAttributes } from 'react'
+import { cn } from '../../../lib/utils'
+import { type BadgeVariants, badgeVariants } from '../../../variants/badge'
+
+export type IconName = keyof typeof icons
+
+export interface BadgeProps extends HTMLAttributes<HTMLDivElement>, BadgeVariants {
+  icon?: IconName
+  iconPosition?: 'start' | 'end'
+}
+
+export const Badge = forwardRef<HTMLDivElement, BadgeProps>(
+  ({ className, variant, size, icon, iconPosition = 'start', children, ...props }, ref) => {
+    const IconComponent = icon ? icons[icon] : null
+    const isIconOnly = !children && !!icon
+
+    return (
+      <div
+        className={cn(
+          badgeVariants({ variant, size }),
+          isIconOnly && 'aspect-square p-1',
+          className,
+        )}
+        ref={ref}
+        {...props}
+      >
+        {IconComponent && iconPosition === 'start' && <IconComponent aria-hidden="true" />}
+        {children}
+        {IconComponent && iconPosition === 'end' && <IconComponent aria-hidden="true" />}
+      </div>
+    )
+  },
+)
+
+Badge.displayName = 'Badge'

--- a/src/components/lv1/Badge/index.ts
+++ b/src/components/lv1/Badge/index.ts
@@ -1,0 +1,1 @@
+export { Badge, type BadgeProps } from './Badge'

--- a/src/components/lv1/index.ts
+++ b/src/components/lv1/index.ts
@@ -1,3 +1,4 @@
+export { Badge, type BadgeProps } from './Badge'
 export { Button, type ButtonProps } from './Button'
 export { Spinner, type SpinnerProps } from './Spinner'
 export { Text, type TextProps } from './Text'

--- a/src/variants/badge.ts
+++ b/src/variants/badge.ts
@@ -1,0 +1,26 @@
+import { cva, type VariantProps } from 'class-variance-authority'
+
+export const badgeVariants = cva(
+  'inline-flex items-center rounded-full border font-semibold leading-none transition-colors focus:outline-none focus:ring-2 focus:ring-ink-black focus:ring-offset-2 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg]:size-[1em]',
+  {
+    variants: {
+      variant: {
+        default: 'border-transparent bg-ink-dark text-paper-warm',
+        secondary: 'border-transparent bg-paper-cream text-ink-black',
+        destructive: 'border-transparent bg-vermillion text-paper-white',
+        outline: 'text-ink-black',
+      },
+      size: {
+        sm: 'px-2 py-1 text-[10px] gap-1',
+        md: 'px-2.5 py-1 text-xs gap-1.5',
+        lg: 'px-3 py-1.5 text-sm gap-1.5',
+      },
+    },
+    defaultVariants: {
+      variant: 'default',
+      size: 'md',
+    },
+  },
+)
+
+export type BadgeVariants = VariantProps<typeof badgeVariants>

--- a/src/variants/badge.ts
+++ b/src/variants/badge.ts
@@ -5,7 +5,7 @@ export const badgeVariants = cva(
   {
     variants: {
       variant: {
-        default: 'border-transparent bg-ink-dark text-paper-warm',
+        primary: 'border-transparent bg-ink-dark text-paper-warm',
         secondary: 'border-transparent bg-paper-cream text-ink-black',
         destructive: 'border-transparent bg-vermillion text-paper-white',
         outline: 'text-ink-black',
@@ -17,7 +17,7 @@ export const badgeVariants = cva(
       },
     },
     defaultVariants: {
-      variant: 'default',
+      variant: 'primary',
       size: 'md',
     },
   },

--- a/src/variants/index.ts
+++ b/src/variants/index.ts
@@ -1,3 +1,4 @@
+export { type BadgeVariants, badgeVariants } from './badge'
 export { type ButtonVariants, buttonVariants } from './button'
 export { type SpinnerVariants, spinnerVariants } from './spinner'
 export { type TextVariants, textVariants } from './text'


### PR DESCRIPTION
## Summary
- shadcn/ui ベースの Badge コンポーネントを追加
- 4つのバリアント（`default`, `secondary`, `destructive`, `outline`）
- 3つのサイズ（`sm`, `md`, `lg`）
- Lucide アイコン対応（`icon`, `iconPosition` props）
- アイコンのみの場合は正円表示

## Test plan
- [ ] Storybook で各バリアント・サイズの見た目を確認
- [ ] アイコン付き/アイコンのみの表示を確認
- [ ] ダークモードでの表示を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)