### PR TITLE
feat: add variant prop to Spinner (default/inverse)

### DIFF
--- a/src/components/lv1/Spinner/Spinner.stories.tsx
+++ b/src/components/lv1/Spinner/Spinner.stories.tsx
@@ -9,6 +9,15 @@ const meta: Meta<typeof Spinner> = {
   },
   tags: ['autodocs'],
   argTypes: {
+    variant: {
+      description: 'Color variant of the spinner.',
+      control: 'select',
+      options: ['default', 'inverse'],
+      table: {
+        type: { summary: '"default" | "inverse"' },
+        defaultValue: { summary: 'default' },
+      },
+    },
     type: {
       description: 'Spinner animation type.',
       control: 'select',
@@ -74,9 +83,9 @@ export const Sizes: Story = {
 export const OnDarkBackground: Story = {
   name: 'On Dark Background',
   render: () => (
-    <div className="flex items-center gap-8 rounded-lg bg-ink-black p-8 text-paper-white">
-      <Spinner type="default" />
-      <Spinner type="ripple" />
+    <div className="flex items-center gap-8 rounded-lg bg-ink-black p-8">
+      <Spinner variant="inverse" type="default" />
+      <Spinner variant="inverse" type="ripple" />
     </div>
   ),
 }

--- a/src/components/lv1/Spinner/Spinner.tsx
+++ b/src/components/lv1/Spinner/Spinner.tsx
@@ -46,9 +46,14 @@ const RippleSpinner = () => (
 )
 
 export const Spinner = forwardRef<HTMLDivElement, SpinnerProps>(
-  ({ className, size, type, label = 'Loading', ...props }, ref) => {
+  ({ className, variant, size, type, label = 'Loading', ...props }, ref) => {
     return (
-      <div className={cn(spinnerVariants({ size, className }))} role="status" ref={ref} {...props}>
+      <div
+        className={cn(spinnerVariants({ variant, size, className }))}
+        role="status"
+        ref={ref}
+        {...props}
+      >
         {type === 'ripple' ? <RippleSpinner /> : <DefaultSpinner />}
         <span className="sr-only">{label}</span>
       </div>

--- a/src/variants/spinner.ts
+++ b/src/variants/spinner.ts
@@ -2,6 +2,10 @@ import { cva, type VariantProps } from 'class-variance-authority'
 
 export const spinnerVariants = cva('inline-flex items-center justify-center', {
   variants: {
+    variant: {
+      default: 'text-ink-black',
+      inverse: 'text-paper-white',
+    },
     size: {
       sm: 'size-4',
       md: 'size-6',
@@ -9,6 +13,7 @@ export const spinnerVariants = cva('inline-flex items-center justify-center', {
     },
   },
   defaultVariants: {
+    variant: 'default',
     size: 'md',
   },
 })


### PR DESCRIPTION
## Summary
- Spinner に `variant` prop を追加（`default` / `inverse`）
- `default`: `text-ink-black`（ライト背景用）
- `inverse`: `text-paper-white`（ダーク背景用）
- OnDarkBackground ストーリーを `variant="inverse"` に更新

## Test plan
- [ ] Storybook で default variant がライト背景で見えることを確認
- [ ] Storybook で inverse variant がダーク背景で見えることを確認
- [ ] ダークテーマ切替時の表示を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)