### PR TITLE
fix: inverse spinner for loading buttons and add antialiased

### DIFF
--- a/src/components/lv1/Button/Button.tsx
+++ b/src/components/lv1/Button/Button.tsx
@@ -20,7 +20,7 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
   (
     {
       className,
-      variant,
+      variant = 'primary',
       size,
       asChild = false,
       icon,
@@ -101,7 +101,12 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
           )}
           aria-hidden={!isLoading}
         >
-          <Spinner size="sm" className="size-[1em]" label="Loading" />
+          <Spinner
+            size="sm"
+            className="size-[1em]"
+            label="Loading"
+            variant={variant === 'primary' || variant === 'destructive' ? 'inverse' : 'default'}
+          />
         </span>
         <span
           className={cn(

--- a/src/variants/badge.ts
+++ b/src/variants/badge.ts
@@ -1,7 +1,7 @@
 import { cva, type VariantProps } from 'class-variance-authority'
 
 export const badgeVariants = cva(
-  'inline-flex items-center rounded-full border font-semibold leading-none transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg]:size-[1em]',
+  'inline-flex items-center rounded-full border font-semibold leading-none antialiased transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg]:size-[1em]',
   {
     variants: {
       variant: {

--- a/src/variants/button.ts
+++ b/src/variants/button.ts
@@ -1,7 +1,7 @@
 import { cva, type VariantProps } from 'class-variance-authority'
 
 export const buttonVariants = cva(
-  'btn inline-flex items-center justify-center gap-2 whitespace-nowrap leading-none font-medium hover:cursor-pointer no-underline transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-ring-offset disabled:cursor-not-allowed disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0',
+  'btn inline-flex items-center justify-center gap-2 whitespace-nowrap leading-none font-medium antialiased hover:cursor-pointer no-underline transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-ring-offset disabled:cursor-not-allowed disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0',
   {
     variants: {
       variant: {


### PR DESCRIPTION
## Summary
- primary / destructive ボタンの isLoading 時に Spinner を `variant="inverse"` で表示するように修正（暗い/赤い背景で見えなかった問題）
- Button の `variant` prop にデフォルト値 `'primary'` を設定し、CVA の defaultVariants と一致させた
- Button, Badge に `antialiased` を追加（Text は既に適用済み）

## Test plan
- [ ] Loading ストーリーで primary / destructive の Spinner が白く表示されることを確認
- [ ] secondary / tertiary の Spinner は暗い色のままであることを確認
- [ ] Button, Badge のテキストが antialiased で描画されていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)