### PR TITLE
feat: add alabaster color scale and improve button hover contrast

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -87,7 +87,10 @@ const preview: Preview = {
       }, [isDark, season])
 
       return (
-        <div className={`${isDark ? 'dark' : ''} bg-background p-8`}>
+        <div
+          className={`${isDark ? 'dark' : ''} p-8`}
+          style={{ backgroundColor: isDark ? undefined : '#fff' }}
+        >
           <Story />
         </div>
       )

--- a/src/core/tokens/base.css
+++ b/src/core/tokens/base.css
@@ -36,6 +36,7 @@
   --color-solid: var(--color-solid);
   --color-solid-hover: var(--color-solid-hover);
   --color-solid-foreground: var(--color-solid-foreground);
+  --color-solid-foreground-hover: var(--color-solid-foreground-hover);
 
   /* Destructive */
   --color-destructive: var(--color-destructive);

--- a/src/core/tokens/primitives.css
+++ b/src/core/tokens/primitives.css
@@ -19,12 +19,25 @@
   --gray-950: oklch(0.12 0 0);
 
   /* Ink scale - Japanese calligraphy inspired */
-  --ink-black: #1a1a1a;
-  --ink-dark: #2d2d2d;
+  --ink-black: var(--sumi-900);
+  --ink-dark: var(--sumi-700);
   --ink-medium: #4a4a4a;
   --ink-light: #6b6b6b;
 
-  /* Paper scale - washi paper inspired */
+  /* Alabaster (アラバスター) - warm white scale */
+  --alabaster-50: oklch(0.98 0.005 70);
+  --alabaster-100: oklch(0.96 0.008 70);
+  --alabaster-200: oklch(0.91 0.01 70);
+  --alabaster-300: oklch(0.83 0.01 70);
+  --alabaster-400: oklch(0.71 0.01 70);
+  --alabaster-500: oklch(0.58 0.01 70);
+  --alabaster-600: oklch(0.48 0.01 70);
+  --alabaster-700: oklch(0.37 0.01 70);
+  --alabaster-800: oklch(0.27 0.01 70);
+  --alabaster-900: oklch(0.18 0.01 70);
+  --alabaster-950: oklch(0.12 0.008 70);
+
+  /* Paper scale - washi paper inspired, for surfaces/backgrounds */
   --paper-white: #fafafa;
   --paper-warm: #f5f3f0;
   --paper-cream: #f0ede8;

--- a/src/core/tokens/semantic.css
+++ b/src/core/tokens/semantic.css
@@ -31,9 +31,10 @@
   --color-foreground-subtle: var(--ink-medium);
 
   /* Solid (filled component backgrounds) */
-  --color-solid: var(--ink-dark);
-  --color-solid-hover: var(--ink-black);
-  --color-solid-foreground: var(--paper-warm);
+  --color-solid: var(--alabaster-700);
+  --color-solid-hover: var(--alabaster-900);
+  --color-solid-foreground: var(--alabaster-100);
+  --color-solid-foreground-hover: var(--alabaster-300);
 
   /* Destructive */
   --color-destructive: var(--vermillion);
@@ -75,9 +76,10 @@
     --color-foreground-muted: var(--ink-light-inv);
     --color-foreground-subtle: var(--ink-medium-inv);
 
-    --color-solid: var(--ink-dark-inv);
-    --color-solid-hover: var(--ink-black-inv);
-    --color-solid-foreground: var(--paper-warm-inv);
+    --color-solid: var(--alabaster-300);
+    --color-solid-hover: var(--alabaster-100);
+    --color-solid-foreground: var(--alabaster-800);
+    --color-solid-foreground-hover: var(--alabaster-700);
 
     --color-destructive: var(--vermillion-dark);
     --color-destructive-hover: var(--vermillion-dark-hover);
@@ -106,9 +108,10 @@
   --color-foreground-muted: var(--ink-light-inv);
   --color-foreground-subtle: var(--ink-medium-inv);
 
-  --color-solid: var(--ink-dark-inv);
-  --color-solid-hover: var(--ink-black-inv);
-  --color-solid-foreground: var(--paper-warm-inv);
+  --color-solid: var(--alabaster-300);
+  --color-solid-hover: var(--alabaster-100);
+  --color-solid-foreground: var(--alabaster-800);
+  --color-solid-foreground-hover: var(--alabaster-700);
 
   --color-destructive: var(--vermillion-dark);
   --color-destructive-hover: var(--vermillion-dark-hover);

--- a/src/docs/Welcome.stories.tsx
+++ b/src/docs/Welcome.stories.tsx
@@ -14,6 +14,16 @@ const meta: Meta = {
 export default meta
 type Story = StoryObj
 
+const navigateToStory = (e: React.MouseEvent, storyPath: string) => {
+  e.preventDefault()
+  const targetPath = `/docs/${storyPath}--docs`
+  if (window.parent !== window) {
+    window.parent.location.href = `${window.parent.location.origin}/?path=${targetPath}`
+  } else {
+    window.location.href = `/?path=${targetPath}`
+  }
+}
+
 const ComponentCard = ({
   name,
   description,
@@ -26,7 +36,8 @@ const ComponentCard = ({
   storyPath: string
 }) => (
   <a
-    href={`?path=/docs/${storyPath}--docs`}
+    href={`/docs/${storyPath}--docs`}
+    onClick={(e) => navigateToStory(e, storyPath)}
     className="group block border border-border rounded-xl overflow-hidden no-underline transition-shadow duration-200 hover:shadow-md"
   >
     <div className="flex items-center justify-center h-40 bg-surface">{children}</div>
@@ -136,7 +147,8 @@ export const Overview: Story = {
         <h2 className="text-xl font-bold text-foreground mb-4">Foundation</h2>
         <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-4">
           <a
-            href="?path=/docs/foundation-color--docs"
+            href="/docs/foundation-color--docs"
+            onClick={(e) => navigateToStory(e, 'foundation-color')}
             className="group block border border-border rounded-xl overflow-hidden no-underline transition-shadow duration-200 hover:shadow-md"
           >
             <div className="flex items-center justify-center h-40 bg-surface">
@@ -153,7 +165,8 @@ export const Overview: Story = {
           </a>
 
           <a
-            href="?path=/docs/foundation-typography--docs"
+            href="/docs/foundation-typography--docs"
+            onClick={(e) => navigateToStory(e, 'foundation-typography')}
             className="group block border border-border rounded-xl overflow-hidden no-underline transition-shadow duration-200 hover:shadow-md"
           >
             <div className="flex items-center justify-center h-40 bg-surface">

--- a/src/variants/button.ts
+++ b/src/variants/button.ts
@@ -5,7 +5,8 @@ export const buttonVariants = cva(
   {
     variants: {
       variant: {
-        primary: 'bg-solid text-solid-foreground not-disabled:hover:bg-solid-hover',
+        primary:
+          'bg-solid text-solid-foreground not-disabled:hover:bg-solid-hover not-disabled:hover:text-solid-foreground-hover',
         secondary:
           'border border-border-strong bg-transparent text-foreground not-disabled:hover:bg-surface-hover',
         tertiary: 'text-foreground not-disabled:hover:bg-surface-hover',


### PR DESCRIPTION
## Summary
- Add alabaster 50-950 warm white scale (oklch, hue 70) as primitive color tokens
- Migrate solid (button primary) bg/text colors from ink/paper to alabaster for unified warm tone
- Add `solid-foreground-hover` semantic token so button text also shifts on hover, improving hover visibility
- Map `ink-black`/`ink-dark` to sumi scale for consistency
- Set Storybook light mode background to `#fff` to reduce visual noise from cream bg

## Test plan
- [ ] Verify primary button default/hover contrast in Storybook (light & dark)
- [ ] Verify disabled state is visually distinct from default
- [ ] Check destructive button is unaffected
- [ ] VRT snapshot comparison

🤖 Generated with [Claude Code](https://claude.com/claude-code)