### PR TITLE
feat: add standalone CSS build with Lightning CSS

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,13 @@
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {
+    ".": {
+      "style": "./dist/schatten.css"
+    },
+    "./schatten.css": {
+      "import": "./dist/schatten.css",
+      "require": "./dist/schatten.css"
+    },
     "./core/tokens": {
       "import": "./dist/core/tokens/index.css",
       "require": "./dist/core/tokens/index.css"
@@ -51,7 +58,9 @@
   ],
   "scripts": {
     "dev": "storybook dev -p 6006",
-    "build": "tsup",
+    "build": "pnpm build:js && pnpm build:css",
+    "build:js": "tsup",
+    "build:css": "lightningcss src/schatten.css -o dist/schatten.css --minify --bundle",
     "build:storybook": "storybook build",
     "test": "vitest",
     "test:ui": "vitest --ui",
@@ -95,6 +104,7 @@
     "jsdom": "24",
     "lefthook": "^2.1.4",
     "lightningcss": "^1.28.2",
+    "lightningcss-cli": "^1.32.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "storybook": "10.3.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -84,6 +84,9 @@ importers:
       lightningcss:
         specifier: ^1.28.2
         version: 1.32.0
+      lightningcss-cli:
+        specifier: ^1.32.0
+        version: 1.32.0
       react:
         specifier: ^19.0.0
         version: 19.2.4
@@ -2012,6 +2015,77 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [android]
+
+  lightningcss-cli-android-arm64@1.32.0:
+    resolution: {integrity: sha512-4O3QY+VdgpBZLIq4crcKOEPVAXX0p7zDoykuTVstRtyolg9XU8CntdtbxcMPSC4SkzAuM/W4KsnPAzmv6Jb5LA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [android]
+
+  lightningcss-cli-darwin-arm64@1.32.0:
+    resolution: {integrity: sha512-Xx+zeD7bDKJZwbd1N63TJfIUHEtYspf+tqObdnQEJEvZAwmGfA4iEGrkCRT8R57tDRBDSXg3XHMDDvo/cq7gBQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  lightningcss-cli-darwin-x64@1.32.0:
+    resolution: {integrity: sha512-fYWANZ8RJDpI0tBcPQ7oBOYihfXmgDBHR4lZ6d4z7rcRLlZAOeI00mTO0IXAKfSm/UgnatjM4aBuNlLh8L9noA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  lightningcss-cli-freebsd-x64@1.32.0:
+    resolution: {integrity: sha512-TJm7z1Ghvo9FKAza2KvfkFgH/9rcV1xAhCYQZlLrV0CiuTZ17uzLobBWb9oelGWUG+wTnEs6XEl4h/ve61YySg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  lightningcss-cli-linux-arm-gnueabihf@1.32.0:
+    resolution: {integrity: sha512-/jS9L5p3eexs5QJvARiDGxibz1umKJmmtff86fWXl3r7RbEUFrMAD4q1WhAR7DurRFgc1YWld6r0mX1YHEYttA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm]
+    os: [linux]
+
+  lightningcss-cli-linux-arm64-gnu@1.32.0:
+    resolution: {integrity: sha512-PSdjwcRtSrJpsaqnY3ebnCfDOJ5ePi8s/0ItL3CX1b1Eu0iy44xo7MjgES1ZOQ2ntOthPRqaGsbAiVBLbgFLYQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  lightningcss-cli-linux-arm64-musl@1.32.0:
+    resolution: {integrity: sha512-t6DdpXFtEdonZHzRgH8cmqhC2o4tl0KrD33cDBBniJz5TmWS20MJxb4YEr4WqBLksqW8GE399HJo+g8/YVuKcA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  lightningcss-cli-linux-x64-gnu@1.32.0:
+    resolution: {integrity: sha512-QMQllbHYkbkQ4N+v8OGExQlGHBc3YZIcKlVkYucQQj66thkFQsRjmv8p5q3iCB0inNsCoSZ8lBspugkU1iPlPg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+
+  lightningcss-cli-linux-x64-musl@1.32.0:
+    resolution: {integrity: sha512-dMSWdk4kMAi5f+J1xetxRCDQOvPix2whT0UdjuwP8r/5Xcdl2SQU/c80MQzu1S82kVDEANs1vHVEHp/+26LUnA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+
+  lightningcss-cli-win32-arm64-msvc@1.32.0:
+    resolution: {integrity: sha512-MJo22OqSp9FLV10nTRDJQhP6zkEBFqBFQe9mnjfCs+G1Ft+QimIPmC+gBqZHFXveOBOsjFLzU72q0FPvRWFmZQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  lightningcss-cli-win32-x64-msvc@1.32.0:
+    resolution: {integrity: sha512-nOBHLPeePXZpGR4Ptp+gkOIkr9pxlq2dFmO954ol5zBi/iOKxuD1hUTIQ7aG+ldKIx4eH9jwoTfZ6owUkm1paA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [win32]
+
+  lightningcss-cli@1.32.0:
+    resolution: {integrity: sha512-IFb/ChmSEbeWU3xeRybR6WFlJXCvfDS84//PUzLrRACgvoWrwRJBmcPS9azSo7LMh5QqEuyKanPBByhKM5z01Q==}
+    engines: {node: '>= 12.0.0'}
+    hasBin: true
 
   lightningcss-darwin-arm64@1.32.0:
     resolution: {integrity: sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==}
@@ -4630,6 +4704,55 @@ snapshots:
 
   lightningcss-android-arm64@1.32.0:
     optional: true
+
+  lightningcss-cli-android-arm64@1.32.0:
+    optional: true
+
+  lightningcss-cli-darwin-arm64@1.32.0:
+    optional: true
+
+  lightningcss-cli-darwin-x64@1.32.0:
+    optional: true
+
+  lightningcss-cli-freebsd-x64@1.32.0:
+    optional: true
+
+  lightningcss-cli-linux-arm-gnueabihf@1.32.0:
+    optional: true
+
+  lightningcss-cli-linux-arm64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-cli-linux-arm64-musl@1.32.0:
+    optional: true
+
+  lightningcss-cli-linux-x64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-cli-linux-x64-musl@1.32.0:
+    optional: true
+
+  lightningcss-cli-win32-arm64-msvc@1.32.0:
+    optional: true
+
+  lightningcss-cli-win32-x64-msvc@1.32.0:
+    optional: true
+
+  lightningcss-cli@1.32.0:
+    dependencies:
+      detect-libc: 2.1.2
+    optionalDependencies:
+      lightningcss-cli-android-arm64: 1.32.0
+      lightningcss-cli-darwin-arm64: 1.32.0
+      lightningcss-cli-darwin-x64: 1.32.0
+      lightningcss-cli-freebsd-x64: 1.32.0
+      lightningcss-cli-linux-arm-gnueabihf: 1.32.0
+      lightningcss-cli-linux-arm64-gnu: 1.32.0
+      lightningcss-cli-linux-arm64-musl: 1.32.0
+      lightningcss-cli-linux-x64-gnu: 1.32.0
+      lightningcss-cli-linux-x64-musl: 1.32.0
+      lightningcss-cli-win32-arm64-msvc: 1.32.0
+      lightningcss-cli-win32-x64-msvc: 1.32.0
 
   lightningcss-darwin-arm64@1.32.0:
     optional: true

--- a/src/schatten.css
+++ b/src/schatten.css
@@ -1,0 +1,54 @@
+/*
+ * Schatten CSS
+ *
+ * A standalone CSS file that can be used without any build tools.
+ * Just link this file via CDN or import it directly.
+ *
+ * Usage:
+ *   <link href="https://cdn.jsdelivr.net/npm/@yasmro/schatten/dist/schatten.css" rel="stylesheet" />
+ */
+
+/* === All @imports must come first === */
+
+/* Tokens */
+@import "./core/tokens/primitives.css";
+@import "./core/tokens/semantic.css";
+@import "./core/tokens/typography.css";
+@import "./core/tokens/spacing.css";
+
+/* Theme (Default) */
+@import "./themes/default/colors.css";
+
+/* Component Styles */
+@import "./components/lv1/Spinner/Spinner.css";
+
+/* === Styles === */
+
+/*
+ * Font Configuration
+ * Override --font-sans to use custom fonts:
+ *
+ *   :root {
+ *     --font-sans: "Your Font", var(--font-sans-fallback);
+ *   }
+ */
+:root {
+  --font-sans: var(--font-sans-fallback);
+}
+
+/* Base Styles */
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background-color: var(--color-background);
+  color: var(--color-foreground);
+  font-family: var(--font-sans);
+  line-height: var(--leading-normal);
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}


### PR DESCRIPTION
## 背景・課題意識

現状の schatten は React + Tailwind + CVA を前提とした構成になっており、導入にはビルド環境のセットアップが必要でした。

[Lism CSS](https://lism-css.com/) のように「CDNから1行で読み込むだけで使える」設計にすることで:

- 素のHTMLサイトでも利用可能に
- プロトタイピングや学習用途での導入障壁を下げる
- 将来的にフレームワーク非依存のエコシステム構築への第一歩

## 解決アプローチ

1. **CSS エントリーポイントの作成** (`src/schatten.css`)
   - tokens、theme、コンポーネントCSSを `@import` で集約
   - Tailwind専用の `@theme` ブロックを使用しない構成に

2. **Lightning CSS によるビルド**
   - `@import` を解決して単一ファイルにバンドル
   - minify で 11KB に圧縮
   - tsup（JS用）と並行して `build:css` スクリプトを追加

3. **package.json の exports 追加**
   - `@yasmro/schatten/schatten.css` でCSSを直接インポート可能に

## 使い方

```html
<link href="https://cdn.jsdelivr.net/npm/@yasmro/schatten/dist/schatten.css" rel="stylesheet" />
```

## 含まれるもの

- Design tokens（カラー、スペーシング、タイポグラフィ）
- ダークモード対応（`prefers-color-scheme` + `.dark` クラス）
- Spinner アニメーション
- ベーススタイル

## 今後の展開

- コンポーネントCSS（Button, Input等）を純粋CSSで追加
- data属性ベースのバリアントシステム構築
- Tailwind依存の段階的な剥離
- CLI / MCP パッケージの検討

## テスト計画

- [x] `pnpm build` が成功する
- [x] `dist/schatten.css` が生成される（11KB minified）
- [x] `@theme`（Tailwind専用構文）が出力に含まれない
- [ ] 手動テスト: 素のHTMLファイルでCSSを読み込んで確認

🤖 Generated with [Claude Code](https://claude.ai/code)