### PR TITLE
feat: add FieldSet component for grouping form fields

### DIFF
--- a/src/components/lv1/Field/Field.stories.tsx
+++ b/src/components/lv1/Field/Field.stories.tsx
@@ -59,6 +59,29 @@ const meta: Meta<typeof Field> = {
         defaultValue: { summary: 'false' },
       },
     },
+    flexGrow: {
+      description: 'Flex grow factor for layout within FieldSet.',
+      control: 'select',
+      options: [undefined, 0, 1],
+      table: {
+        type: { summary: '0 | 1' },
+      },
+    },
+    flexShrink: {
+      description: 'Flex shrink factor for layout within FieldSet.',
+      control: 'select',
+      options: [undefined, 0, 1],
+      table: {
+        type: { summary: '0 | 1' },
+      },
+    },
+    flexBasis: {
+      description: 'Flex basis for layout within FieldSet (CSS value).',
+      control: 'text',
+      table: {
+        type: { summary: 'string' },
+      },
+    },
   },
 }
 

--- a/src/components/lv1/Field/Field.test.tsx
+++ b/src/components/lv1/Field/Field.test.tsx
@@ -179,4 +179,100 @@ describe('Field', () => {
       expect(fieldDiv).toHaveAttribute('data-disabled', 'true')
     })
   })
+
+  describe('flex layout props', () => {
+    it('applies grow class when flexGrow is 1', () => {
+      const { container } = render(
+        <Field label="Email" flexGrow={1}>
+          <input />
+        </Field>,
+      )
+      const fieldDiv = container.firstChild as HTMLElement
+      expect(fieldDiv).toHaveClass('grow')
+    })
+
+    it('applies grow-0 class when flexGrow is 0', () => {
+      const { container } = render(
+        <Field label="Email" flexGrow={0}>
+          <input />
+        </Field>,
+      )
+      const fieldDiv = container.firstChild as HTMLElement
+      expect(fieldDiv).toHaveClass('grow-0')
+    })
+
+    it('does not apply grow class by default', () => {
+      const { container } = render(
+        <Field label="Email">
+          <input />
+        </Field>,
+      )
+      const fieldDiv = container.firstChild as HTMLElement
+      expect(fieldDiv).not.toHaveClass('grow')
+      expect(fieldDiv).not.toHaveClass('grow-0')
+    })
+
+    it('applies shrink-0 class when flexShrink is 0', () => {
+      const { container } = render(
+        <Field label="Email" flexShrink={0}>
+          <input />
+        </Field>,
+      )
+      const fieldDiv = container.firstChild as HTMLElement
+      expect(fieldDiv).toHaveClass('shrink-0')
+    })
+
+    it('applies shrink class when flexShrink is 1', () => {
+      const { container } = render(
+        <Field label="Email" flexShrink={1}>
+          <input />
+        </Field>,
+      )
+      const fieldDiv = container.firstChild as HTMLElement
+      expect(fieldDiv).toHaveClass('shrink')
+    })
+
+    it('does not apply shrink class by default', () => {
+      const { container } = render(
+        <Field label="Email">
+          <input />
+        </Field>,
+      )
+      const fieldDiv = container.firstChild as HTMLElement
+      expect(fieldDiv).not.toHaveClass('shrink')
+      expect(fieldDiv).not.toHaveClass('shrink-0')
+    })
+
+    it('applies flexBasis via inline style', () => {
+      const { container } = render(
+        <Field label="Email" flexBasis="200px">
+          <input />
+        </Field>,
+      )
+      const fieldDiv = container.firstChild as HTMLElement
+      expect(fieldDiv).toHaveStyle({ flexBasis: '200px' })
+    })
+
+    it('does not apply flexBasis style by default', () => {
+      const { container } = render(
+        <Field label="Email">
+          <input />
+        </Field>,
+      )
+      const fieldDiv = container.firstChild as HTMLElement
+      expect(fieldDiv.style.flexBasis).toBe('')
+    })
+
+    it('combines multiple flex props', () => {
+      const { container } = render(
+        <Field label="Email" flexGrow={1} flexShrink={0} flexBasis="50%">
+          <input />
+        </Field>,
+      )
+      const fieldDiv = container.firstChild as HTMLElement
+      expect(fieldDiv).toHaveClass('grow')
+      expect(fieldDiv).toHaveClass('shrink-0')
+      expect(fieldDiv).toHaveStyle({ flexBasis: '50%' })
+    })
+  })
 })

--- a/src/components/lv1/Field/Field.test.tsx
+++ b/src/components/lv1/Field/Field.test.tsx
@@ -142,17 +142,13 @@ describe('Field', () => {
     })
 
     it('provides describedBy with both ids when both are set', () => {
-      // Note: When both are set, only error is shown, but describedBy still references both
-      // Actually in current implementation, description is hidden when error exists
-      // So describedBy should only contain error id
       render(
         <Field label="Email" description="Help" error="Error">
           <ContextConsumer />
         </Field>,
       )
       const describedBy = screen.getByTestId('context-describedBy').textContent
-      // Since description is hidden when error exists, only error id is in DOM
-      // But describedBy calculation happens before render decision
+      expect(describedBy).toContain('-description')
       expect(describedBy).toContain('-error')
     })
   })

--- a/src/components/lv1/Field/Field.test.tsx
+++ b/src/components/lv1/Field/Field.test.tsx
@@ -45,13 +45,13 @@ describe('Field', () => {
     expect(screen.getByText('Invalid email')).toBeInTheDocument()
   })
 
-  it('hides description when error is present', () => {
+  it('shows both description and error when both are present', () => {
     render(
       <Field label="Email" description="Enter your email" error="Invalid email">
         <input />
       </Field>,
     )
-    expect(screen.queryByText('Enter your email')).not.toBeInTheDocument()
+    expect(screen.getByText('Enter your email')).toBeInTheDocument()
     expect(screen.getByText('Invalid email')).toBeInTheDocument()
   })
 

--- a/src/components/lv1/Field/Field.tsx
+++ b/src/components/lv1/Field/Field.tsx
@@ -1,5 +1,6 @@
 import { type ReactNode, useId, useMemo } from 'react'
 import { FieldContext, type FieldContextValue } from '../../../contexts/field'
+import { useFieldSetContext } from '../../../contexts/fieldset'
 import { cn } from '../../../lib/utils'
 
 export interface FieldProps {
@@ -31,11 +32,12 @@ export function Field({
   children,
   className,
 }: FieldProps) {
+  const fieldSet = useFieldSetContext()
   const id = useId()
   const descriptionId = `${id}-description`
   const errorId = `${id}-error`
 
-  const isError = isErrorProp ?? !!error
+  const isError = isErrorProp ?? (error ? true : undefined) ?? fieldSet?.isError ?? false
 
   const describedBy = useMemo(() => {
     const ids: string[] = []

--- a/src/components/lv1/Field/Field.tsx
+++ b/src/components/lv1/Field/Field.tsx
@@ -17,17 +17,19 @@ export interface FieldProps {
   /** Disable the field */
   disabled?: boolean
   /** Flex grow factor for layout within FieldSet */
-  grow?: 0 | 1
+  flexGrow?: 0 | 1
   /** Flex shrink factor for layout within FieldSet */
-  shrink?: 0 | 1
+  flexShrink?: 0 | 1
+  /** Flex basis for layout within FieldSet (CSS value) */
+  flexBasis?: string
   /** Field content (input element) */
   children: ReactNode
   /** Additional CSS classes */
   className?: string
 }
 
-const growClasses = { 0: 'grow-0', 1: 'grow' } as const
-const shrinkClasses = { 0: 'shrink-0', 1: 'shrink' } as const
+const flexGrowClasses = { 0: 'grow-0', 1: 'grow' } as const
+const flexShrinkClasses = { 0: 'shrink-0', 1: 'shrink' } as const
 
 export function Field({
   label,
@@ -36,8 +38,9 @@ export function Field({
   isError: isErrorProp,
   required = false,
   disabled = false,
-  grow,
-  shrink,
+  flexGrow,
+  flexShrink,
+  flexBasis,
   children,
   className,
 }: FieldProps) {
@@ -65,10 +68,11 @@ export function Field({
       <div
         className={cn(
           'flex flex-col gap-1.5',
-          grow !== undefined && growClasses[grow],
-          shrink !== undefined && shrinkClasses[shrink],
+          flexGrow !== undefined && flexGrowClasses[flexGrow],
+          flexShrink !== undefined && flexShrinkClasses[flexShrink],
           className,
         )}
+        style={flexBasis ? { flexBasis } : undefined}
         data-disabled={disabled || undefined}
       >
         {label && (

--- a/src/components/lv1/Field/Field.tsx
+++ b/src/components/lv1/Field/Field.tsx
@@ -76,7 +76,7 @@ export function Field({
         data-disabled={disabled || undefined}
       >
         {label && (
-          <label htmlFor={id} className="text-base font-medium text-foreground">
+          <label htmlFor={id} className="text-base font-bold text-foreground">
             {label}
             {required && <span className="text-destructive ml-0.5">*</span>}
           </label>

--- a/src/components/lv1/Field/Field.tsx
+++ b/src/components/lv1/Field/Field.tsx
@@ -81,7 +81,7 @@ export function Field({
             {required && <span className="text-destructive ml-0.5">*</span>}
           </label>
         )}
-        {description && !error && (
+        {description && (
           <label
             htmlFor={id}
             id={descriptionId}

--- a/src/components/lv1/Field/Field.tsx
+++ b/src/components/lv1/Field/Field.tsx
@@ -16,11 +16,18 @@ export interface FieldProps {
   required?: boolean
   /** Disable the field */
   disabled?: boolean
+  /** Flex grow factor for layout within FieldSet */
+  grow?: 0 | 1
+  /** Flex shrink factor for layout within FieldSet */
+  shrink?: 0 | 1
   /** Field content (input element) */
   children: ReactNode
   /** Additional CSS classes */
   className?: string
 }
+
+const growClasses = { 0: 'grow-0', 1: 'grow' } as const
+const shrinkClasses = { 0: 'shrink-0', 1: 'shrink' } as const
 
 export function Field({
   label,
@@ -29,6 +36,8 @@ export function Field({
   isError: isErrorProp,
   required = false,
   disabled = false,
+  grow,
+  shrink,
   children,
   className,
 }: FieldProps) {
@@ -53,7 +62,15 @@ export function Field({
 
   return (
     <FieldContext.Provider value={contextValue}>
-      <div className={cn('flex flex-col gap-1.5', className)} data-disabled={disabled || undefined}>
+      <div
+        className={cn(
+          'flex flex-col gap-1.5',
+          grow !== undefined && growClasses[grow],
+          shrink !== undefined && shrinkClasses[shrink],
+          className,
+        )}
+        data-disabled={disabled || undefined}
+      >
         {label && (
           <label htmlFor={id} className="text-base font-medium text-foreground">
             {label}

--- a/src/components/lv1/FieldSet/FieldSet.stories.tsx
+++ b/src/components/lv1/FieldSet/FieldSet.stories.tsx
@@ -1,0 +1,210 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { Field } from '../Field/Field'
+import { Input } from '../Input/Input'
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../Select/Select'
+import { FieldSet } from './FieldSet'
+
+const meta: Meta<typeof FieldSet> = {
+  title: 'Components/lv1/FieldSet',
+  component: FieldSet,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    legend: {
+      description: 'Legend text for the fieldset.',
+      control: 'text',
+      table: {
+        type: { summary: 'ReactNode' },
+      },
+    },
+    description: {
+      description: 'Description text displayed below the legend.',
+      control: 'text',
+      table: {
+        type: { summary: 'ReactNode' },
+      },
+    },
+    error: {
+      description: 'Error message to display (group-level).',
+      control: 'text',
+      table: {
+        type: { summary: 'string' },
+      },
+    },
+    isError: {
+      description: 'Explicitly set error state. If not provided, derived from error prop presence.',
+      control: 'boolean',
+      table: {
+        type: { summary: 'boolean' },
+      },
+    },
+    disabled: {
+      description: 'Disable all child fields. Uses native fieldset disabled behavior.',
+      control: 'boolean',
+      table: {
+        type: { summary: 'boolean' },
+        defaultValue: { summary: 'false' },
+      },
+    },
+  },
+}
+
+export default meta
+type Story = StoryObj<typeof FieldSet>
+
+export const Playground: Story = {
+  name: 'Playground',
+  args: {
+    legend: 'Personal Information',
+    description: 'Please enter your personal details.',
+  },
+  render: (args) => (
+    <FieldSet {...args}>
+      <div className="flex flex-col gap-4 w-80">
+        <Field label="First Name">
+          <Input placeholder="John" />
+        </Field>
+        <Field label="Last Name">
+          <Input placeholder="Doe" />
+        </Field>
+      </div>
+    </FieldSet>
+  ),
+}
+
+export const DateRange: Story = {
+  name: 'Date Range',
+  render: () => (
+    <FieldSet legend="Event Period" description="Select the start and end dates for your event.">
+      <div className="flex gap-4">
+        <Field label="Start Date">
+          <Input type="date" className="w-40" />
+        </Field>
+        <Field label="End Date">
+          <Input type="date" className="w-40" />
+        </Field>
+      </div>
+    </FieldSet>
+  ),
+}
+
+export const Address: Story = {
+  name: 'Address',
+  render: () => (
+    <FieldSet legend="Shipping Address" description="Enter your delivery address.">
+      <div className="flex flex-col gap-4 w-96">
+        <Field label="Street Address" required>
+          <Input placeholder="123 Main St" />
+        </Field>
+        <div className="flex gap-4">
+          <Field label="City" required>
+            <Input placeholder="Tokyo" />
+          </Field>
+          <Field label="Postal Code" required>
+            <Input placeholder="100-0001" className="w-32" />
+          </Field>
+        </div>
+        <Field label="Country">
+          <Select defaultValue="jp">
+            <SelectTrigger>
+              <SelectValue placeholder="Select a country" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="jp">Japan</SelectItem>
+              <SelectItem value="us">United States</SelectItem>
+              <SelectItem value="uk">United Kingdom</SelectItem>
+            </SelectContent>
+          </Select>
+        </Field>
+      </div>
+    </FieldSet>
+  ),
+}
+
+export const ErrorState: Story = {
+  name: 'Error',
+  render: () => (
+    <div className="flex flex-col gap-8">
+      <FieldSet
+        legend="Date Range"
+        error="End date must be after start date."
+        description="Select the start and end dates."
+      >
+        <div className="flex gap-4">
+          <Field label="Start Date">
+            <Input type="date" defaultValue="2024-12-31" className="w-40" />
+          </Field>
+          <Field label="End Date">
+            <Input type="date" defaultValue="2024-01-01" className="w-40" />
+          </Field>
+        </div>
+      </FieldSet>
+
+      <FieldSet legend="Password Confirmation" error="Passwords do not match.">
+        <div className="flex flex-col gap-4 w-80">
+          <Field label="Password">
+            <Input type="password" defaultValue="password123" />
+          </Field>
+          <Field label="Confirm Password">
+            <Input type="password" defaultValue="password456" />
+          </Field>
+        </div>
+      </FieldSet>
+    </div>
+  ),
+}
+
+export const Disabled: Story = {
+  name: 'Disabled',
+  render: () => (
+    <FieldSet legend="Account Settings" description="These settings are currently locked." disabled>
+      <div className="flex flex-col gap-4 w-80">
+        <Field label="Username">
+          <Input defaultValue="johndoe" />
+        </Field>
+        <Field label="Email">
+          <Input type="email" defaultValue="john@example.com" />
+        </Field>
+      </div>
+    </FieldSet>
+  ),
+}
+
+export const NestedFields: Story = {
+  name: 'Nested Fields',
+  render: () => (
+    <div className="flex flex-col gap-8">
+      <FieldSet legend="Contact Information">
+        <div className="flex flex-col gap-4 w-80">
+          <Field label="Email" required description="We'll use this for account recovery.">
+            <Input type="email" placeholder="you@example.com" />
+          </Field>
+          <Field label="Phone" description="Optional contact number.">
+            <Input type="tel" placeholder="+81 90-1234-5678" />
+          </Field>
+        </div>
+      </FieldSet>
+
+      <FieldSet legend="Billing Details" description="Enter your payment information.">
+        <div className="flex flex-col gap-4 w-80">
+          <Field label="Cardholder Name" required>
+            <Input placeholder="John Doe" />
+          </Field>
+          <Field label="Card Number" required>
+            <Input placeholder="1234 5678 9012 3456" />
+          </Field>
+          <div className="flex gap-4">
+            <Field label="Expiry" required>
+              <Input placeholder="MM/YY" className="w-24" />
+            </Field>
+            <Field label="CVV" required>
+              <Input placeholder="123" className="w-20" />
+            </Field>
+          </div>
+        </div>
+      </FieldSet>
+    </div>
+  ),
+}

--- a/src/components/lv1/FieldSet/FieldSet.stories.tsx
+++ b/src/components/lv1/FieldSet/FieldSet.stories.tsx
@@ -208,3 +208,71 @@ export const NestedFields: Story = {
     </div>
   ),
 }
+
+export const ErrorPropagation: Story = {
+  name: 'Error Propagation',
+  render: () => (
+    <div className="flex flex-col gap-8">
+      <div>
+        <p className="text-sm text-foreground-muted mb-4">
+          When FieldSet has isError, all child Inputs show error styles automatically.
+        </p>
+        <FieldSet legend="Date Range" isError error="End date must be after start date.">
+          <div className="flex gap-4">
+            <Field label="Start Date">
+              <Input type="date" defaultValue="2024-12-31" className="w-40" />
+            </Field>
+            <Field label="End Date">
+              <Input type="date" defaultValue="2024-01-01" className="w-40" />
+            </Field>
+          </div>
+        </FieldSet>
+      </div>
+
+      <div>
+        <p className="text-sm text-foreground-muted mb-4">
+          Individual Field can override FieldSet&apos;s isError.
+        </p>
+        <FieldSet legend="Mixed States" isError>
+          <div className="flex flex-col gap-4 w-80">
+            <Field label="Has Error (inherited)">
+              <Input placeholder="Error style from FieldSet" />
+            </Field>
+            <Field label="No Error (overridden)" isError={false}>
+              <Input placeholder="Explicitly set isError=false" />
+            </Field>
+          </div>
+        </FieldSet>
+      </div>
+    </div>
+  ),
+}
+
+export const NestedFieldSets: Story = {
+  name: 'Nested FieldSets',
+  render: () => (
+    <FieldSet legend="Checkout Form" description="Complete your order.">
+      <FieldSet legend="Shipping Address">
+        <div className="flex flex-col gap-4 w-80">
+          <Field label="Street" required>
+            <Input placeholder="123 Main St" />
+          </Field>
+          <Field label="City" required>
+            <Input placeholder="Tokyo" />
+          </Field>
+        </div>
+      </FieldSet>
+
+      <FieldSet legend="Billing Address" isError error="Please complete billing address.">
+        <div className="flex flex-col gap-4 w-80">
+          <Field label="Street" required>
+            <Input placeholder="456 Oak Ave" />
+          </Field>
+          <Field label="City" required>
+            <Input placeholder="Osaka" />
+          </Field>
+        </div>
+      </FieldSet>
+    </FieldSet>
+  ),
+}

--- a/src/components/lv1/FieldSet/FieldSet.stories.tsx
+++ b/src/components/lv1/FieldSet/FieldSet.stories.tsx
@@ -299,26 +299,99 @@ export const LayoutVariants: Story = {
   name: 'Layout Variants',
   render: () => (
     <div className="flex flex-col gap-8">
-      <FieldSet legend="Row Direction" direction="row">
-        <Field label="First" flexGrow={1}>
-          <Input placeholder="Grows to fill" />
-        </Field>
-        <Field label="Second" flexShrink={0}>
-          <Input placeholder="Fixed" className="w-24" />
-        </Field>
-      </FieldSet>
+      <div>
+        <p className="text-sm text-foreground-muted mb-4">
+          Use direction=&quot;row&quot; with Field flex props for horizontal layouts.
+        </p>
+        <FieldSet legend="Row Direction" direction="row">
+          <Field label="First" flexGrow={1}>
+            <Input placeholder="Grows to fill" />
+          </Field>
+          <Field label="Second" flexShrink={0}>
+            <Input placeholder="Fixed" className="w-24" />
+          </Field>
+        </FieldSet>
+      </div>
 
-      <FieldSet legend="Row with Wrap" direction="row" wrap className="w-80">
-        <Field label="Field 1">
-          <Input placeholder="Input" className="w-32" />
-        </Field>
-        <Field label="Field 2">
-          <Input placeholder="Input" className="w-32" />
-        </Field>
-        <Field label="Field 3">
-          <Input placeholder="Input" className="w-32" />
-        </Field>
-      </FieldSet>
+      <div>
+        <p className="text-sm text-foreground-muted mb-4">
+          Use wrap for responsive layouts that wrap on smaller screens.
+        </p>
+        <FieldSet legend="Row with Wrap" direction="row" wrap className="w-80">
+          <Field label="Field 1">
+            <Input placeholder="Input" className="w-32" />
+          </Field>
+          <Field label="Field 2">
+            <Input placeholder="Input" className="w-32" />
+          </Field>
+          <Field label="Field 3">
+            <Input placeholder="Input" className="w-32" />
+          </Field>
+        </FieldSet>
+      </div>
+    </div>
+  ),
+}
+
+export const FlexPropsPatterns: Story = {
+  name: 'Flex Props Patterns',
+  render: () => (
+    <div className="flex flex-col gap-8">
+      <div>
+        <p className="text-sm text-foreground-muted mb-4">
+          <strong>flexGrow:</strong> Field expands to fill available space.
+        </p>
+        <FieldSet legend="flexGrow Example" direction="row" className="w-96">
+          <Field label="Flexible" flexGrow={1}>
+            <Input placeholder="flexGrow={1}" />
+          </Field>
+          <Field label="Fixed">
+            <Input placeholder="No flex props" className="w-24" />
+          </Field>
+        </FieldSet>
+      </div>
+
+      <div>
+        <p className="text-sm text-foreground-muted mb-4">
+          <strong>flexShrink:</strong> Prevent field from shrinking below its content.
+        </p>
+        <FieldSet legend="flexShrink Example" direction="row" className="w-64">
+          <Field label="Shrinks">
+            <Input placeholder="Shrinks" />
+          </Field>
+          <Field label="No Shrink" flexShrink={0}>
+            <Input placeholder="flexShrink={0}" className="w-32" />
+          </Field>
+        </FieldSet>
+      </div>
+
+      <div>
+        <p className="text-sm text-foreground-muted mb-4">
+          <strong>flexBasis:</strong> Set initial size before flex grow/shrink.
+        </p>
+        <FieldSet legend="flexBasis Example" direction="row" className="w-96">
+          <Field label="60%" flexBasis="60%">
+            <Input placeholder="flexBasis='60%'" />
+          </Field>
+          <Field label="40%" flexBasis="40%">
+            <Input placeholder="flexBasis='40%'" />
+          </Field>
+        </FieldSet>
+      </div>
+
+      <div>
+        <p className="text-sm text-foreground-muted mb-4">
+          <strong>Combined:</strong> Use multiple props for precise control.
+        </p>
+        <FieldSet legend="Combined Example" direction="row" className="w-96">
+          <Field label="Main" flexGrow={1} flexShrink={1}>
+            <Input placeholder="Flexible" />
+          </Field>
+          <Field label="Side" flexGrow={0} flexShrink={0} flexBasis="100px">
+            <Input placeholder="Fixed 100px" />
+          </Field>
+        </FieldSet>
+      </div>
     </div>
   ),
 }

--- a/src/components/lv1/FieldSet/FieldSet.stories.tsx
+++ b/src/components/lv1/FieldSet/FieldSet.stories.tsx
@@ -13,7 +13,7 @@ const meta: Meta<typeof FieldSet> = {
   tags: ['autodocs'],
   argTypes: {
     legend: {
-      description: 'Legend text for the fieldset.',
+      description: 'Legend text for the fieldset. Omit for layout-only grouping.',
       control: 'text',
       table: {
         type: { summary: 'ReactNode' },
@@ -115,7 +115,7 @@ export const Address: Story = {
       <Field label="Street Address" required>
         <Input placeholder="123 Main St" />
       </Field>
-      <FieldSet direction="row" legend="">
+      <FieldSet direction="row">
         <Field label="City" required flexGrow={1}>
           <Input placeholder="Tokyo" />
         </Field>
@@ -212,7 +212,7 @@ export const NestedFields: Story = {
         <Field label="Card Number" required>
           <Input placeholder="1234 5678 9012 3456" />
         </Field>
-        <FieldSet direction="row" legend="">
+        <FieldSet direction="row">
           <Field label="Expiry" required>
             <Input placeholder="MM/YY" className="w-24" />
           </Field>
@@ -328,6 +328,94 @@ export const LayoutVariants: Story = {
             <Input placeholder="Input" className="w-32" />
           </Field>
         </FieldSet>
+      </div>
+    </div>
+  ),
+}
+
+export const LayoutOnlyFieldSet: Story = {
+  name: 'Layout Only (No Legend)',
+  render: () => (
+    <div className="flex flex-col gap-8">
+      <div>
+        <p className="text-sm text-foreground-muted mb-4">
+          Omit legend for layout-only grouping. Useful for arranging fields in a row without
+          creating a semantic group.
+        </p>
+        <FieldSet direction="row">
+          <Field label="First Name" flexGrow={1}>
+            <Input placeholder="John" />
+          </Field>
+          <Field label="Last Name" flexGrow={1}>
+            <Input placeholder="Doe" />
+          </Field>
+        </FieldSet>
+      </div>
+
+      <div>
+        <p className="text-sm text-foreground-muted mb-4">
+          Nested layout-only FieldSet within a labeled FieldSet.
+        </p>
+        <FieldSet legend="Contact Information" className="w-96">
+          <Field label="Email">
+            <Input placeholder="you@example.com" />
+          </Field>
+          <FieldSet direction="row">
+            <Field label="Country Code" flexShrink={0}>
+              <Input placeholder="+81" className="w-16" />
+            </Field>
+            <Field label="Phone" flexGrow={1}>
+              <Input placeholder="90-1234-5678" />
+            </Field>
+          </FieldSet>
+        </FieldSet>
+      </div>
+    </div>
+  ),
+}
+
+export const DescriptionWithError: Story = {
+  name: 'Description with Error',
+  render: () => (
+    <div className="flex flex-col gap-8">
+      <div>
+        <p className="text-sm text-foreground-muted mb-4">
+          <strong>FieldSet:</strong> Shows both description AND error. The description provides
+          context for the group, while the error indicates validation failure.
+        </p>
+        <FieldSet
+          legend="Date Range"
+          description="Select the start and end dates for your event."
+          error="End date must be after start date."
+          direction="row"
+        >
+          <Field label="Start Date">
+            <Input type="date" defaultValue="2024-12-31" className="w-40" />
+          </Field>
+          <Field label="End Date">
+            <Input type="date" defaultValue="2024-01-01" className="w-40" />
+          </Field>
+        </FieldSet>
+      </div>
+
+      <div>
+        <p className="text-sm text-foreground-muted mb-4">
+          <strong>Field:</strong> Shows description OR error (mutually exclusive). The error
+          replaces the helper text since they serve the same purpose for individual inputs.
+        </p>
+        <div className="flex gap-8">
+          <Field label="Email" description="We'll send a verification link." className="w-60">
+            <Input placeholder="No error" />
+          </Field>
+          <Field
+            label="Email"
+            description="We'll send a verification link."
+            error="Invalid email address."
+            className="w-60"
+          >
+            <Input placeholder="With error" />
+          </Field>
+        </div>
       </div>
     </div>
   ),

--- a/src/components/lv1/FieldSet/FieldSet.stories.tsx
+++ b/src/components/lv1/FieldSet/FieldSet.stories.tsx
@@ -127,10 +127,10 @@ export const Address: Story = {
         <Input placeholder="123 Main St" />
       </Field>
       <FieldSet direction="row" gap={4} legend="">
-        <Field label="City" required grow={1}>
+        <Field label="City" required flexGrow={1}>
           <Input placeholder="Tokyo" />
         </Field>
-        <Field label="Postal Code" required shrink={0}>
+        <Field label="Postal Code" required flexShrink={0}>
           <Input placeholder="100-0001" className="w-32" />
         </Field>
       </FieldSet>
@@ -313,10 +313,10 @@ export const LayoutVariants: Story = {
   render: () => (
     <div className="flex flex-col gap-8">
       <FieldSet legend="Row Direction" direction="row" gap={4}>
-        <Field label="First" grow={1}>
+        <Field label="First" flexGrow={1}>
           <Input placeholder="Grows to fill" />
         </Field>
-        <Field label="Second" shrink={0}>
+        <Field label="Second" flexShrink={0}>
           <Input placeholder="Fixed" className="w-24" />
         </Field>
       </FieldSet>

--- a/src/components/lv1/FieldSet/FieldSet.stories.tsx
+++ b/src/components/lv1/FieldSet/FieldSet.stories.tsx
@@ -65,15 +65,6 @@ const meta: Meta<typeof FieldSet> = {
         defaultValue: { summary: 'false' },
       },
     },
-    gap: {
-      description: 'Gap between children (Tailwind spacing scale).',
-      control: 'select',
-      options: [0, 1, 2, 3, 4, 5, 6, 8, 10, 12],
-      table: {
-        type: { summary: '0 | 1 | 2 | 3 | 4 | 5 | 6 | 8 | 10 | 12' },
-        defaultValue: { summary: '4' },
-      },
-    },
   },
 }
 
@@ -86,7 +77,6 @@ export const Playground: Story = {
     legend: 'Personal Information',
     description: 'Please enter your personal details.',
     direction: 'column',
-    gap: 4,
   },
   render: (args) => (
     <FieldSet {...args} className="w-80">
@@ -107,7 +97,6 @@ export const DateRange: Story = {
       legend="Event Period"
       description="Select the start and end dates for your event."
       direction="row"
-      gap={4}
     >
       <Field label="Start Date">
         <Input type="date" className="w-40" />
@@ -126,7 +115,7 @@ export const Address: Story = {
       <Field label="Street Address" required>
         <Input placeholder="123 Main St" />
       </Field>
-      <FieldSet direction="row" gap={4} legend="">
+      <FieldSet direction="row" legend="">
         <Field label="City" required flexGrow={1}>
           <Input placeholder="Tokyo" />
         </Field>
@@ -159,7 +148,6 @@ export const ErrorState: Story = {
         error="End date must be after start date."
         description="Select the start and end dates."
         direction="row"
-        gap={4}
       >
         <Field label="Start Date">
           <Input type="date" defaultValue="2024-12-31" className="w-40" />
@@ -224,7 +212,7 @@ export const NestedFields: Story = {
         <Field label="Card Number" required>
           <Input placeholder="1234 5678 9012 3456" />
         </Field>
-        <FieldSet direction="row" gap={4} legend="">
+        <FieldSet direction="row" legend="">
           <Field label="Expiry" required>
             <Input placeholder="MM/YY" className="w-24" />
           </Field>
@@ -250,7 +238,6 @@ export const ErrorPropagation: Story = {
           isError
           error="End date must be after start date."
           direction="row"
-          gap={4}
         >
           <Field label="Start Date">
             <Input type="date" defaultValue="2024-12-31" className="w-40" />
@@ -312,7 +299,7 @@ export const LayoutVariants: Story = {
   name: 'Layout Variants',
   render: () => (
     <div className="flex flex-col gap-8">
-      <FieldSet legend="Row Direction" direction="row" gap={4}>
+      <FieldSet legend="Row Direction" direction="row">
         <Field label="First" flexGrow={1}>
           <Input placeholder="Grows to fill" />
         </Field>
@@ -321,7 +308,7 @@ export const LayoutVariants: Story = {
         </Field>
       </FieldSet>
 
-      <FieldSet legend="Row with Wrap" direction="row" wrap gap={4} className="w-80">
+      <FieldSet legend="Row with Wrap" direction="row" wrap className="w-80">
         <Field label="Field 1">
           <Input placeholder="Input" className="w-32" />
         </Field>
@@ -330,15 +317,6 @@ export const LayoutVariants: Story = {
         </Field>
         <Field label="Field 3">
           <Input placeholder="Input" className="w-32" />
-        </Field>
-      </FieldSet>
-
-      <FieldSet legend="Custom Gap (gap=2)" gap={2} className="w-80">
-        <Field label="Tight spacing">
-          <Input placeholder="gap-2" />
-        </Field>
-        <Field label="Between fields">
-          <Input placeholder="8px gap" />
         </Field>
       </FieldSet>
     </div>

--- a/src/components/lv1/FieldSet/FieldSet.stories.tsx
+++ b/src/components/lv1/FieldSet/FieldSet.stories.tsx
@@ -48,6 +48,32 @@ const meta: Meta<typeof FieldSet> = {
         defaultValue: { summary: 'false' },
       },
     },
+    direction: {
+      description: 'Flex direction for children layout.',
+      control: 'select',
+      options: ['row', 'column'],
+      table: {
+        type: { summary: '"row" | "column"' },
+        defaultValue: { summary: '"column"' },
+      },
+    },
+    wrap: {
+      description: 'Enable flex wrap for children.',
+      control: 'boolean',
+      table: {
+        type: { summary: 'boolean' },
+        defaultValue: { summary: 'false' },
+      },
+    },
+    gap: {
+      description: 'Gap between children (Tailwind spacing scale).',
+      control: 'select',
+      options: [0, 1, 2, 3, 4, 5, 6, 8, 10, 12],
+      table: {
+        type: { summary: '0 | 1 | 2 | 3 | 4 | 5 | 6 | 8 | 10 | 12' },
+        defaultValue: { summary: '4' },
+      },
+    },
   },
 }
 
@@ -59,17 +85,17 @@ export const Playground: Story = {
   args: {
     legend: 'Personal Information',
     description: 'Please enter your personal details.',
+    direction: 'column',
+    gap: 4,
   },
   render: (args) => (
-    <FieldSet {...args}>
-      <div className="flex flex-col gap-4 w-80">
-        <Field label="First Name">
-          <Input placeholder="John" />
-        </Field>
-        <Field label="Last Name">
-          <Input placeholder="Doe" />
-        </Field>
-      </div>
+    <FieldSet {...args} className="w-80">
+      <Field label="First Name">
+        <Input placeholder="John" />
+      </Field>
+      <Field label="Last Name">
+        <Input placeholder="Doe" />
+      </Field>
     </FieldSet>
   ),
 }
@@ -77,15 +103,18 @@ export const Playground: Story = {
 export const DateRange: Story = {
   name: 'Date Range',
   render: () => (
-    <FieldSet legend="Event Period" description="Select the start and end dates for your event.">
-      <div className="flex gap-4">
-        <Field label="Start Date">
-          <Input type="date" className="w-40" />
-        </Field>
-        <Field label="End Date">
-          <Input type="date" className="w-40" />
-        </Field>
-      </div>
+    <FieldSet
+      legend="Event Period"
+      description="Select the start and end dates for your event."
+      direction="row"
+      gap={4}
+    >
+      <Field label="Start Date">
+        <Input type="date" className="w-40" />
+      </Field>
+      <Field label="End Date">
+        <Input type="date" className="w-40" />
+      </Field>
     </FieldSet>
   ),
 }
@@ -93,32 +122,30 @@ export const DateRange: Story = {
 export const Address: Story = {
   name: 'Address',
   render: () => (
-    <FieldSet legend="Shipping Address" description="Enter your delivery address.">
-      <div className="flex flex-col gap-4 w-96">
-        <Field label="Street Address" required>
-          <Input placeholder="123 Main St" />
+    <FieldSet legend="Shipping Address" description="Enter your delivery address." className="w-96">
+      <Field label="Street Address" required>
+        <Input placeholder="123 Main St" />
+      </Field>
+      <FieldSet direction="row" gap={4} legend="">
+        <Field label="City" required grow={1}>
+          <Input placeholder="Tokyo" />
         </Field>
-        <div className="flex gap-4">
-          <Field label="City" required>
-            <Input placeholder="Tokyo" />
-          </Field>
-          <Field label="Postal Code" required>
-            <Input placeholder="100-0001" className="w-32" />
-          </Field>
-        </div>
-        <Field label="Country">
-          <Select defaultValue="jp">
-            <SelectTrigger>
-              <SelectValue placeholder="Select a country" />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="jp">Japan</SelectItem>
-              <SelectItem value="us">United States</SelectItem>
-              <SelectItem value="uk">United Kingdom</SelectItem>
-            </SelectContent>
-          </Select>
+        <Field label="Postal Code" required shrink={0}>
+          <Input placeholder="100-0001" className="w-32" />
         </Field>
-      </div>
+      </FieldSet>
+      <Field label="Country">
+        <Select defaultValue="jp">
+          <SelectTrigger>
+            <SelectValue placeholder="Select a country" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="jp">Japan</SelectItem>
+            <SelectItem value="us">United States</SelectItem>
+            <SelectItem value="uk">United Kingdom</SelectItem>
+          </SelectContent>
+        </Select>
+      </Field>
     </FieldSet>
   ),
 }
@@ -131,26 +158,24 @@ export const ErrorState: Story = {
         legend="Date Range"
         error="End date must be after start date."
         description="Select the start and end dates."
+        direction="row"
+        gap={4}
       >
-        <div className="flex gap-4">
-          <Field label="Start Date">
-            <Input type="date" defaultValue="2024-12-31" className="w-40" />
-          </Field>
-          <Field label="End Date">
-            <Input type="date" defaultValue="2024-01-01" className="w-40" />
-          </Field>
-        </div>
+        <Field label="Start Date">
+          <Input type="date" defaultValue="2024-12-31" className="w-40" />
+        </Field>
+        <Field label="End Date">
+          <Input type="date" defaultValue="2024-01-01" className="w-40" />
+        </Field>
       </FieldSet>
 
-      <FieldSet legend="Password Confirmation" error="Passwords do not match.">
-        <div className="flex flex-col gap-4 w-80">
-          <Field label="Password">
-            <Input type="password" defaultValue="password123" />
-          </Field>
-          <Field label="Confirm Password">
-            <Input type="password" defaultValue="password456" />
-          </Field>
-        </div>
+      <FieldSet legend="Password Confirmation" error="Passwords do not match." className="w-80">
+        <Field label="Password">
+          <Input type="password" defaultValue="password123" />
+        </Field>
+        <Field label="Confirm Password">
+          <Input type="password" defaultValue="password456" />
+        </Field>
       </FieldSet>
     </div>
   ),
@@ -159,15 +184,18 @@ export const ErrorState: Story = {
 export const Disabled: Story = {
   name: 'Disabled',
   render: () => (
-    <FieldSet legend="Account Settings" description="These settings are currently locked." disabled>
-      <div className="flex flex-col gap-4 w-80">
-        <Field label="Username">
-          <Input defaultValue="johndoe" />
-        </Field>
-        <Field label="Email">
-          <Input type="email" defaultValue="john@example.com" />
-        </Field>
-      </div>
+    <FieldSet
+      legend="Account Settings"
+      description="These settings are currently locked."
+      disabled
+      className="w-80"
+    >
+      <Field label="Username">
+        <Input defaultValue="johndoe" />
+      </Field>
+      <Field label="Email">
+        <Input type="email" defaultValue="john@example.com" />
+      </Field>
     </FieldSet>
   ),
 }
@@ -176,34 +204,34 @@ export const NestedFields: Story = {
   name: 'Nested Fields',
   render: () => (
     <div className="flex flex-col gap-8">
-      <FieldSet legend="Contact Information">
-        <div className="flex flex-col gap-4 w-80">
-          <Field label="Email" required description="We'll use this for account recovery.">
-            <Input type="email" placeholder="you@example.com" />
-          </Field>
-          <Field label="Phone" description="Optional contact number.">
-            <Input type="tel" placeholder="+81 90-1234-5678" />
-          </Field>
-        </div>
+      <FieldSet legend="Contact Information" className="w-80">
+        <Field label="Email" required description="We'll use this for account recovery.">
+          <Input type="email" placeholder="you@example.com" />
+        </Field>
+        <Field label="Phone" description="Optional contact number.">
+          <Input type="tel" placeholder="+81 90-1234-5678" />
+        </Field>
       </FieldSet>
 
-      <FieldSet legend="Billing Details" description="Enter your payment information.">
-        <div className="flex flex-col gap-4 w-80">
-          <Field label="Cardholder Name" required>
-            <Input placeholder="John Doe" />
+      <FieldSet
+        legend="Billing Details"
+        description="Enter your payment information."
+        className="w-80"
+      >
+        <Field label="Cardholder Name" required>
+          <Input placeholder="John Doe" />
+        </Field>
+        <Field label="Card Number" required>
+          <Input placeholder="1234 5678 9012 3456" />
+        </Field>
+        <FieldSet direction="row" gap={4} legend="">
+          <Field label="Expiry" required>
+            <Input placeholder="MM/YY" className="w-24" />
           </Field>
-          <Field label="Card Number" required>
-            <Input placeholder="1234 5678 9012 3456" />
+          <Field label="CVV" required>
+            <Input placeholder="123" className="w-20" />
           </Field>
-          <div className="flex gap-4">
-            <Field label="Expiry" required>
-              <Input placeholder="MM/YY" className="w-24" />
-            </Field>
-            <Field label="CVV" required>
-              <Input placeholder="123" className="w-20" />
-            </Field>
-          </div>
-        </div>
+        </FieldSet>
       </FieldSet>
     </div>
   ),
@@ -217,15 +245,19 @@ export const ErrorPropagation: Story = {
         <p className="text-sm text-foreground-muted mb-4">
           When FieldSet has isError, all child Inputs show error styles automatically.
         </p>
-        <FieldSet legend="Date Range" isError error="End date must be after start date.">
-          <div className="flex gap-4">
-            <Field label="Start Date">
-              <Input type="date" defaultValue="2024-12-31" className="w-40" />
-            </Field>
-            <Field label="End Date">
-              <Input type="date" defaultValue="2024-01-01" className="w-40" />
-            </Field>
-          </div>
+        <FieldSet
+          legend="Date Range"
+          isError
+          error="End date must be after start date."
+          direction="row"
+          gap={4}
+        >
+          <Field label="Start Date">
+            <Input type="date" defaultValue="2024-12-31" className="w-40" />
+          </Field>
+          <Field label="End Date">
+            <Input type="date" defaultValue="2024-01-01" className="w-40" />
+          </Field>
         </FieldSet>
       </div>
 
@@ -233,15 +265,13 @@ export const ErrorPropagation: Story = {
         <p className="text-sm text-foreground-muted mb-4">
           Individual Field can override FieldSet&apos;s isError.
         </p>
-        <FieldSet legend="Mixed States" isError>
-          <div className="flex flex-col gap-4 w-80">
-            <Field label="Has Error (inherited)">
-              <Input placeholder="Error style from FieldSet" />
-            </Field>
-            <Field label="No Error (overridden)" isError={false}>
-              <Input placeholder="Explicitly set isError=false" />
-            </Field>
-          </div>
+        <FieldSet legend="Mixed States" isError className="w-80">
+          <Field label="Has Error (inherited)">
+            <Input placeholder="Error style from FieldSet" />
+          </Field>
+          <Field label="No Error (overridden)" isError={false}>
+            <Input placeholder="Explicitly set isError=false" />
+          </Field>
         </FieldSet>
       </div>
     </div>
@@ -252,27 +282,65 @@ export const NestedFieldSets: Story = {
   name: 'Nested FieldSets',
   render: () => (
     <FieldSet legend="Checkout Form" description="Complete your order.">
-      <FieldSet legend="Shipping Address">
-        <div className="flex flex-col gap-4 w-80">
-          <Field label="Street" required>
-            <Input placeholder="123 Main St" />
-          </Field>
-          <Field label="City" required>
-            <Input placeholder="Tokyo" />
-          </Field>
-        </div>
+      <FieldSet legend="Shipping Address" className="w-80">
+        <Field label="Street" required>
+          <Input placeholder="123 Main St" />
+        </Field>
+        <Field label="City" required>
+          <Input placeholder="Tokyo" />
+        </Field>
       </FieldSet>
 
-      <FieldSet legend="Billing Address" isError error="Please complete billing address.">
-        <div className="flex flex-col gap-4 w-80">
-          <Field label="Street" required>
-            <Input placeholder="456 Oak Ave" />
-          </Field>
-          <Field label="City" required>
-            <Input placeholder="Osaka" />
-          </Field>
-        </div>
+      <FieldSet
+        legend="Billing Address"
+        isError
+        error="Please complete billing address."
+        className="w-80"
+      >
+        <Field label="Street" required>
+          <Input placeholder="456 Oak Ave" />
+        </Field>
+        <Field label="City" required>
+          <Input placeholder="Osaka" />
+        </Field>
       </FieldSet>
     </FieldSet>
+  ),
+}
+
+export const LayoutVariants: Story = {
+  name: 'Layout Variants',
+  render: () => (
+    <div className="flex flex-col gap-8">
+      <FieldSet legend="Row Direction" direction="row" gap={4}>
+        <Field label="First" grow={1}>
+          <Input placeholder="Grows to fill" />
+        </Field>
+        <Field label="Second" shrink={0}>
+          <Input placeholder="Fixed" className="w-24" />
+        </Field>
+      </FieldSet>
+
+      <FieldSet legend="Row with Wrap" direction="row" wrap gap={4} className="w-80">
+        <Field label="Field 1">
+          <Input placeholder="Input" className="w-32" />
+        </Field>
+        <Field label="Field 2">
+          <Input placeholder="Input" className="w-32" />
+        </Field>
+        <Field label="Field 3">
+          <Input placeholder="Input" className="w-32" />
+        </Field>
+      </FieldSet>
+
+      <FieldSet legend="Custom Gap (gap=2)" gap={2} className="w-80">
+        <Field label="Tight spacing">
+          <Input placeholder="gap-2" />
+        </Field>
+        <Field label="Between fields">
+          <Input placeholder="8px gap" />
+        </Field>
+      </FieldSet>
+    </div>
   ),
 }

--- a/src/components/lv1/FieldSet/FieldSet.stories.tsx
+++ b/src/components/lv1/FieldSet/FieldSet.stories.tsx
@@ -380,8 +380,8 @@ export const DescriptionWithError: Story = {
     <div className="flex flex-col gap-8">
       <div>
         <p className="text-sm text-foreground-muted mb-4">
-          <strong>FieldSet:</strong> Shows both description AND error. The description provides
-          context for the group, while the error indicates validation failure.
+          Both Field and FieldSet show description AND error together. Description appears above the
+          input, error appears below.
         </p>
         <FieldSet
           legend="Date Range"
@@ -399,23 +399,15 @@ export const DescriptionWithError: Story = {
       </div>
 
       <div>
-        <p className="text-sm text-foreground-muted mb-4">
-          <strong>Field:</strong> Shows description OR error (mutually exclusive). The error
-          replaces the helper text since they serve the same purpose for individual inputs.
-        </p>
-        <div className="flex gap-8">
-          <Field label="Email" description="We'll send a verification link." className="w-60">
-            <Input placeholder="No error" />
-          </Field>
-          <Field
-            label="Email"
-            description="We'll send a verification link."
-            error="Invalid email address."
-            className="w-60"
-          >
-            <Input placeholder="With error" />
-          </Field>
-        </div>
+        <p className="text-sm text-foreground-muted mb-4">Field with both description and error.</p>
+        <Field
+          label="Email"
+          description="We'll send a verification link."
+          error="Invalid email address."
+          className="w-60"
+        >
+          <Input defaultValue="invalid" />
+        </Field>
       </div>
     </div>
   ),

--- a/src/components/lv1/FieldSet/FieldSet.test.tsx
+++ b/src/components/lv1/FieldSet/FieldSet.test.tsx
@@ -406,4 +406,80 @@ describe('FieldSet', () => {
       expect(childrenWrapper).toHaveClass('flex-wrap')
     })
   })
+
+  describe('optional legend', () => {
+    it('renders without legend when not provided', () => {
+      const { container } = render(
+        <FieldSet>
+          <input data-testid="input" />
+        </FieldSet>,
+      )
+      expect(container.querySelector('legend')).not.toBeInTheDocument()
+      expect(screen.getByTestId('input')).toBeInTheDocument()
+    })
+
+    it('does not apply mt-4 to children wrapper when no header', () => {
+      const { container } = render(
+        <FieldSet>
+          <input />
+        </FieldSet>,
+      )
+      const childrenWrapper = container.querySelector('fieldset > div')
+      expect(childrenWrapper).not.toHaveClass('mt-4')
+    })
+
+    it('applies mt-4 to children wrapper when legend is provided', () => {
+      const { container } = render(
+        <FieldSet legend="Test">
+          <input />
+        </FieldSet>,
+      )
+      const childrenWrapper = container.querySelector('fieldset > div')
+      expect(childrenWrapper).toHaveClass('mt-4')
+    })
+
+    it('applies mt-4 to children wrapper when description is provided without legend', () => {
+      const { container } = render(
+        <FieldSet description="Help text">
+          <input />
+        </FieldSet>,
+      )
+      const childrenWrapper = container.querySelector('fieldset > div')
+      expect(childrenWrapper).toHaveClass('mt-4')
+    })
+  })
+
+  describe('disabled styling', () => {
+    it('applies opacity-50 to legend when disabled', () => {
+      const { container } = render(
+        <FieldSet legend="Test" disabled>
+          <input />
+        </FieldSet>,
+      )
+      const legend = container.querySelector('legend')
+      expect(legend).toHaveClass('opacity-50')
+    })
+
+    it('applies opacity-50 to description when disabled', () => {
+      render(
+        <FieldSet legend="Test" description="Help text" disabled>
+          <input />
+        </FieldSet>,
+      )
+      const description = screen.getByText('Help text')
+      expect(description).toHaveClass('opacity-50')
+    })
+
+    it('does not apply opacity-50 when not disabled', () => {
+      const { container } = render(
+        <FieldSet legend="Test" description="Help text">
+          <input />
+        </FieldSet>,
+      )
+      const legend = container.querySelector('legend')
+      const description = screen.getByText('Help text')
+      expect(legend).not.toHaveClass('opacity-50')
+      expect(description).not.toHaveClass('opacity-50')
+    })
+  })
 })

--- a/src/components/lv1/FieldSet/FieldSet.test.tsx
+++ b/src/components/lv1/FieldSet/FieldSet.test.tsx
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest'
 import { useFieldContext } from '../../../contexts/field'
 import { useFieldSetContext } from '../../../contexts/fieldset'
 import { Field } from '../Field/Field'
+import { Input } from '../Input/Input'
 import { FieldSet } from './FieldSet'
 
 // Test component to verify FieldSetContext values
@@ -220,6 +221,37 @@ describe('FieldSet', () => {
       const fieldset = container.querySelector('fieldset')
       expect(fieldset).toHaveAttribute('data-error', 'true')
     })
+
+    it('sets aria-invalid when isError is true', () => {
+      const { container } = render(
+        <FieldSet legend="Test" isError>
+          <input />
+        </FieldSet>,
+      )
+      const fieldset = container.querySelector('fieldset')
+      expect(fieldset).toHaveAttribute('aria-invalid', 'true')
+    })
+
+    it('does not set aria-invalid when isError is false', () => {
+      const { container } = render(
+        <FieldSet legend="Test">
+          <input />
+        </FieldSet>,
+      )
+      const fieldset = container.querySelector('fieldset')
+      expect(fieldset).not.toHaveAttribute('aria-invalid')
+    })
+
+    it('legend is direct first child of fieldset (HTML spec compliance)', () => {
+      const { container } = render(
+        <FieldSet legend="Test" description="Description">
+          <input />
+        </FieldSet>,
+      )
+      const fieldset = container.querySelector('fieldset')
+      const firstChild = fieldset?.firstElementChild
+      expect(firstChild?.tagName.toLowerCase()).toBe('legend')
+    })
   })
 
   describe('standalone Field', () => {
@@ -240,6 +272,83 @@ describe('FieldSet', () => {
         </Field>,
       )
       expect(screen.getByTestId('field-context-isError').textContent).toBe('true')
+    })
+  })
+
+  describe('nested FieldSet', () => {
+    it('inner FieldSet creates its own context', () => {
+      render(
+        <FieldSet legend="Outer" isError>
+          <FieldSet legend="Inner">
+            <FieldSetContextConsumer />
+          </FieldSet>
+        </FieldSet>,
+      )
+      // Inner FieldSet has its own context with isError=false
+      expect(screen.getByTestId('fieldset-context-isError').textContent).toBe('false')
+    })
+
+    it('inner FieldSet can override parent isError', () => {
+      render(
+        <FieldSet legend="Outer" isError={false}>
+          <FieldSet legend="Inner" isError>
+            <FieldSetContextConsumer />
+          </FieldSet>
+        </FieldSet>,
+      )
+      expect(screen.getByTestId('fieldset-context-isError').textContent).toBe('true')
+    })
+  })
+
+  describe('Input integration', () => {
+    it('Input receives isError through FieldSet → Field chain', () => {
+      render(
+        <FieldSet legend="Test" isError>
+          <Field label="Name">
+            <Input data-testid="input" />
+          </Field>
+        </FieldSet>,
+      )
+      const input = screen.getByTestId('input')
+      // Input wrapper should have error styles (aria-invalid is on the input element)
+      expect(input).toHaveAttribute('aria-invalid', 'true')
+    })
+
+    it('Field isError prop overrides FieldSet context for Input', () => {
+      render(
+        <FieldSet legend="Test" isError>
+          <Field label="Name" isError={false}>
+            <Input data-testid="input" />
+          </Field>
+        </FieldSet>,
+      )
+      const input = screen.getByTestId('input')
+      // Field's isError=false overrides FieldSet's isError=true
+      expect(input).not.toHaveAttribute('aria-invalid')
+    })
+  })
+
+  describe('className', () => {
+    it('applies className to fieldset element', () => {
+      const { container } = render(
+        <FieldSet legend="Test" className="custom-class">
+          <input />
+        </FieldSet>,
+      )
+      const fieldset = container.querySelector('fieldset')
+      expect(fieldset).toHaveClass('custom-class')
+    })
+  })
+
+  describe('description and error', () => {
+    it('shows both description and error when both are provided', () => {
+      render(
+        <FieldSet legend="Test" description="Help text" error="Error text">
+          <input />
+        </FieldSet>,
+      )
+      expect(screen.getByText('Help text')).toBeInTheDocument()
+      expect(screen.getByText('Error text')).toBeInTheDocument()
     })
   })
 })

--- a/src/components/lv1/FieldSet/FieldSet.test.tsx
+++ b/src/components/lv1/FieldSet/FieldSet.test.tsx
@@ -448,38 +448,4 @@ describe('FieldSet', () => {
       expect(childrenWrapper).toHaveClass('mt-4')
     })
   })
-
-  describe('disabled styling', () => {
-    it('applies opacity-50 to legend when disabled', () => {
-      const { container } = render(
-        <FieldSet legend="Test" disabled>
-          <input />
-        </FieldSet>,
-      )
-      const legend = container.querySelector('legend')
-      expect(legend).toHaveClass('opacity-50')
-    })
-
-    it('applies opacity-50 to description when disabled', () => {
-      render(
-        <FieldSet legend="Test" description="Help text" disabled>
-          <input />
-        </FieldSet>,
-      )
-      const description = screen.getByText('Help text')
-      expect(description).toHaveClass('opacity-50')
-    })
-
-    it('does not apply opacity-50 when not disabled', () => {
-      const { container } = render(
-        <FieldSet legend="Test" description="Help text">
-          <input />
-        </FieldSet>,
-      )
-      const legend = container.querySelector('legend')
-      const description = screen.getByText('Help text')
-      expect(legend).not.toHaveClass('opacity-50')
-      expect(description).not.toHaveClass('opacity-50')
-    })
-  })
 })

--- a/src/components/lv1/FieldSet/FieldSet.test.tsx
+++ b/src/components/lv1/FieldSet/FieldSet.test.tsx
@@ -1,0 +1,245 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import { useFieldContext } from '../../../contexts/field'
+import { useFieldSetContext } from '../../../contexts/fieldset'
+import { Field } from '../Field/Field'
+import { FieldSet } from './FieldSet'
+
+// Test component to verify FieldSetContext values
+function FieldSetContextConsumer() {
+  const context = useFieldSetContext()
+  return (
+    <div data-testid="fieldset-context-consumer">
+      <span data-testid="fieldset-context-isError">{String(context?.isError ?? 'null')}</span>
+    </div>
+  )
+}
+
+// Test component to verify FieldContext values within FieldSet
+function FieldContextConsumer() {
+  const context = useFieldContext()
+  return (
+    <div data-testid="field-context-consumer">
+      <span data-testid="field-context-isError">{String(context?.isError)}</span>
+      <span data-testid="field-context-disabled">{String(context?.disabled)}</span>
+    </div>
+  )
+}
+
+describe('FieldSet', () => {
+  it('renders legend and children', () => {
+    render(
+      <FieldSet legend="Personal Info">
+        <input data-testid="input" />
+      </FieldSet>,
+    )
+    expect(screen.getByText('Personal Info')).toBeInTheDocument()
+    expect(screen.getByTestId('input')).toBeInTheDocument()
+  })
+
+  it('renders description when provided', () => {
+    render(
+      <FieldSet legend="Personal Info" description="Enter your details">
+        <input />
+      </FieldSet>,
+    )
+    expect(screen.getByText('Enter your details')).toBeInTheDocument()
+  })
+
+  it('renders error message when provided', () => {
+    render(
+      <FieldSet legend="Date Range" error="Invalid date range">
+        <input />
+      </FieldSet>,
+    )
+    expect(screen.getByText('Invalid date range')).toBeInTheDocument()
+  })
+
+  describe('FieldSetContext', () => {
+    it('provides isError=true when error prop is set', () => {
+      render(
+        <FieldSet legend="Test" error="Error message">
+          <FieldSetContextConsumer />
+        </FieldSet>,
+      )
+      expect(screen.getByTestId('fieldset-context-isError').textContent).toBe('true')
+    })
+
+    it('provides isError=false when no error', () => {
+      render(
+        <FieldSet legend="Test">
+          <FieldSetContextConsumer />
+        </FieldSet>,
+      )
+      expect(screen.getByTestId('fieldset-context-isError').textContent).toBe('false')
+    })
+
+    it('provides isError from isError prop even without error message', () => {
+      render(
+        <FieldSet legend="Test" isError>
+          <FieldSetContextConsumer />
+        </FieldSet>,
+      )
+      expect(screen.getByTestId('fieldset-context-isError').textContent).toBe('true')
+    })
+
+    it('returns null when used outside of FieldSet', () => {
+      render(<FieldSetContextConsumer />)
+      expect(screen.getByTestId('fieldset-context-isError').textContent).toBe('null')
+    })
+  })
+
+  describe('disabled state', () => {
+    it('sets disabled attribute on fieldset element', () => {
+      const { container } = render(
+        <FieldSet legend="Test" disabled>
+          <input data-testid="input" />
+        </FieldSet>,
+      )
+      const fieldset = container.querySelector('fieldset')
+      expect(fieldset).toHaveAttribute('disabled')
+    })
+
+    it('sets data-disabled attribute when disabled', () => {
+      const { container } = render(
+        <FieldSet legend="Test" disabled>
+          <input />
+        </FieldSet>,
+      )
+      const fieldset = container.querySelector('fieldset')
+      expect(fieldset).toHaveAttribute('data-disabled', 'true')
+    })
+
+    it('does not set disabled attribute by default', () => {
+      const { container } = render(
+        <FieldSet legend="Test">
+          <input />
+        </FieldSet>,
+      )
+      const fieldset = container.querySelector('fieldset')
+      expect(fieldset).not.toHaveAttribute('disabled')
+    })
+  })
+
+  describe('Field integration', () => {
+    it('Field receives isError from FieldSet context', () => {
+      render(
+        <FieldSet legend="Test" isError>
+          <Field label="Name">
+            <FieldContextConsumer />
+          </Field>
+        </FieldSet>,
+      )
+      expect(screen.getByTestId('field-context-isError').textContent).toBe('true')
+    })
+
+    it('Field isError prop takes precedence over FieldSet context', () => {
+      render(
+        <FieldSet legend="Test" isError>
+          <Field label="Name" isError={false}>
+            <FieldContextConsumer />
+          </Field>
+        </FieldSet>,
+      )
+      expect(screen.getByTestId('field-context-isError').textContent).toBe('false')
+    })
+
+    it('Field error prop takes precedence over FieldSet context', () => {
+      render(
+        <FieldSet legend="Test" isError={false}>
+          <Field label="Name" error="Field error">
+            <FieldContextConsumer />
+          </Field>
+        </FieldSet>,
+      )
+      expect(screen.getByTestId('field-context-isError').textContent).toBe('true')
+    })
+  })
+
+  describe('accessibility', () => {
+    it('uses semantic fieldset and legend elements', () => {
+      const { container } = render(
+        <FieldSet legend="Personal Info">
+          <input />
+        </FieldSet>,
+      )
+      expect(container.querySelector('fieldset')).toBeInTheDocument()
+      expect(container.querySelector('legend')).toBeInTheDocument()
+    })
+
+    it('sets aria-describedby with description id when description is set', () => {
+      const { container } = render(
+        <FieldSet legend="Test" description="Help text">
+          <input />
+        </FieldSet>,
+      )
+      const fieldset = container.querySelector('fieldset')
+      const describedBy = fieldset?.getAttribute('aria-describedby')
+      expect(describedBy).toContain('-description')
+    })
+
+    it('sets aria-describedby with error id when error is set', () => {
+      const { container } = render(
+        <FieldSet legend="Test" error="Error text">
+          <input />
+        </FieldSet>,
+      )
+      const fieldset = container.querySelector('fieldset')
+      const describedBy = fieldset?.getAttribute('aria-describedby')
+      expect(describedBy).toContain('-error')
+    })
+
+    it('sets aria-describedby with both ids when both are set', () => {
+      const { container } = render(
+        <FieldSet legend="Test" description="Help" error="Error">
+          <input />
+        </FieldSet>,
+      )
+      const fieldset = container.querySelector('fieldset')
+      const describedBy = fieldset?.getAttribute('aria-describedby')
+      expect(describedBy).toContain('-description')
+      expect(describedBy).toContain('-error')
+    })
+
+    it('does not set aria-describedby when neither description nor error is set', () => {
+      const { container } = render(
+        <FieldSet legend="Test">
+          <input />
+        </FieldSet>,
+      )
+      const fieldset = container.querySelector('fieldset')
+      expect(fieldset).not.toHaveAttribute('aria-describedby')
+    })
+
+    it('sets data-error attribute when isError is true', () => {
+      const { container } = render(
+        <FieldSet legend="Test" isError>
+          <input />
+        </FieldSet>,
+      )
+      const fieldset = container.querySelector('fieldset')
+      expect(fieldset).toHaveAttribute('data-error', 'true')
+    })
+  })
+
+  describe('standalone Field', () => {
+    it('Field works without FieldSet', () => {
+      render(
+        <Field label="Email">
+          <FieldContextConsumer />
+        </Field>,
+      )
+      expect(screen.getByTestId('field-context-isError').textContent).toBe('false')
+      expect(screen.getByTestId('field-context-disabled').textContent).toBe('false')
+    })
+
+    it('standalone Field with error has isError=true', () => {
+      render(
+        <Field label="Email" error="Invalid email">
+          <FieldContextConsumer />
+        </Field>,
+      )
+      expect(screen.getByTestId('field-context-isError').textContent).toBe('true')
+    })
+  })
+})

--- a/src/components/lv1/FieldSet/FieldSet.test.tsx
+++ b/src/components/lv1/FieldSet/FieldSet.test.tsx
@@ -351,4 +351,59 @@ describe('FieldSet', () => {
       expect(screen.getByText('Error text')).toBeInTheDocument()
     })
   })
+
+  describe('layout props', () => {
+    it('applies flex-row when direction is row', () => {
+      const { container } = render(
+        <FieldSet legend="Test" direction="row">
+          <input />
+        </FieldSet>,
+      )
+      const childrenWrapper = container.querySelector('fieldset > div')
+      expect(childrenWrapper).toHaveClass('flex-row')
+      expect(childrenWrapper).not.toHaveClass('flex-col')
+    })
+
+    it('applies flex-col when direction is column (default)', () => {
+      const { container } = render(
+        <FieldSet legend="Test">
+          <input />
+        </FieldSet>,
+      )
+      const childrenWrapper = container.querySelector('fieldset > div')
+      expect(childrenWrapper).toHaveClass('flex-col')
+      expect(childrenWrapper).not.toHaveClass('flex-row')
+    })
+
+    it('applies flex-wrap when wrap is true', () => {
+      const { container } = render(
+        <FieldSet legend="Test" wrap>
+          <input />
+        </FieldSet>,
+      )
+      const childrenWrapper = container.querySelector('fieldset > div')
+      expect(childrenWrapper).toHaveClass('flex-wrap')
+    })
+
+    it('does not apply flex-wrap by default', () => {
+      const { container } = render(
+        <FieldSet legend="Test">
+          <input />
+        </FieldSet>,
+      )
+      const childrenWrapper = container.querySelector('fieldset > div')
+      expect(childrenWrapper).not.toHaveClass('flex-wrap')
+    })
+
+    it('combines direction and wrap props', () => {
+      const { container } = render(
+        <FieldSet legend="Test" direction="row" wrap>
+          <input />
+        </FieldSet>,
+      )
+      const childrenWrapper = container.querySelector('fieldset > div')
+      expect(childrenWrapper).toHaveClass('flex-row')
+      expect(childrenWrapper).toHaveClass('flex-wrap')
+    })
+  })
 })

--- a/src/components/lv1/FieldSet/FieldSet.tsx
+++ b/src/components/lv1/FieldSet/FieldSet.tsx
@@ -1,0 +1,74 @@
+import { type ReactNode, useId, useMemo } from 'react'
+import { FieldSetContext, type FieldSetContextValue } from '../../../contexts/fieldset'
+import { cn } from '../../../lib/utils'
+
+export interface FieldSetProps {
+  /** Legend text for the fieldset */
+  legend: ReactNode
+  /** Description text displayed below the legend */
+  description?: ReactNode
+  /** Error message to display (group-level) */
+  error?: string
+  /** Explicitly set error state. If not provided, derived from error prop */
+  isError?: boolean
+  /** Disable all child fields */
+  disabled?: boolean
+  /** FieldSet content (Field elements) */
+  children: ReactNode
+  /** Additional CSS classes */
+  className?: string
+}
+
+export function FieldSet({
+  legend,
+  description,
+  error,
+  isError: isErrorProp,
+  disabled = false,
+  children,
+  className,
+}: FieldSetProps) {
+  const id = useId()
+  const descriptionId = `${id}-description`
+  const errorId = `${id}-error`
+
+  const isError = isErrorProp ?? !!error
+
+  const describedBy = useMemo(() => {
+    const ids: string[] = []
+    if (description) ids.push(descriptionId)
+    if (error) ids.push(errorId)
+    return ids.length > 0 ? ids.join(' ') : undefined
+  }, [description, error, descriptionId, errorId])
+
+  const contextValue = useMemo<FieldSetContextValue>(() => ({ isError }), [isError])
+
+  return (
+    <FieldSetContext.Provider value={contextValue}>
+      <fieldset
+        className={cn('flex flex-col gap-4', className)}
+        disabled={disabled}
+        aria-describedby={describedBy}
+        data-disabled={disabled || undefined}
+        data-error={isError || undefined}
+      >
+        <div className="flex flex-col gap-0">
+          <legend className="text-base font-medium text-foreground">{legend}</legend>
+          {description && (
+            <p id={descriptionId} className="text-sm text-foreground-muted">
+              {description}
+            </p>
+          )}
+        </div>
+        {children}
+        {error && (
+          <p id={errorId} className="text-sm text-destructive">
+            {error}
+          </p>
+        )}
+      </fieldset>
+    </FieldSetContext.Provider>
+  )
+}
+
+FieldSet.displayName = 'FieldSet'

--- a/src/components/lv1/FieldSet/FieldSet.tsx
+++ b/src/components/lv1/FieldSet/FieldSet.tsx
@@ -62,7 +62,7 @@ export function FieldSet({
         data-error={isError || undefined}
       >
         {legend && (
-          <legend className={cn('text-lg font-medium text-foreground', disabled && 'opacity-50')}>
+          <legend className={cn('text-lg font-bold text-foreground', disabled && 'opacity-50')}>
             {legend}
           </legend>
         )}

--- a/src/components/lv1/FieldSet/FieldSet.tsx
+++ b/src/components/lv1/FieldSet/FieldSet.tsx
@@ -17,26 +17,11 @@ export interface FieldSetProps {
   direction?: 'row' | 'column'
   /** Enable flex wrap for children */
   wrap?: boolean
-  /** Gap between children (Tailwind spacing scale: 0, 1, 2, 3, 4, etc.) */
-  gap?: 0 | 1 | 2 | 3 | 4 | 5 | 6 | 8 | 10 | 12
   /** FieldSet content (Field elements) */
   children: ReactNode
   /** Additional CSS classes */
   className?: string
 }
-
-const gapClasses = {
-  0: 'gap-0',
-  1: 'gap-1',
-  2: 'gap-2',
-  3: 'gap-3',
-  4: 'gap-4',
-  5: 'gap-5',
-  6: 'gap-6',
-  8: 'gap-8',
-  10: 'gap-10',
-  12: 'gap-12',
-} as const
 
 export function FieldSet({
   legend,
@@ -46,7 +31,6 @@ export function FieldSet({
   disabled = false,
   direction = 'column',
   wrap = false,
-  gap = 4,
   children,
   className,
 }: FieldSetProps) {
@@ -83,10 +67,9 @@ export function FieldSet({
         )}
         <div
           className={cn(
-            'mt-4 flex',
+            'mt-4 flex gap-4',
             direction === 'row' ? 'flex-row' : 'flex-col',
             wrap && 'flex-wrap',
-            gapClasses[gap],
           )}
         >
           {children}

--- a/src/components/lv1/FieldSet/FieldSet.tsx
+++ b/src/components/lv1/FieldSet/FieldSet.tsx
@@ -13,11 +13,30 @@ export interface FieldSetProps {
   isError?: boolean
   /** Disable all child fields */
   disabled?: boolean
+  /** Flex direction for children layout */
+  direction?: 'row' | 'column'
+  /** Enable flex wrap for children */
+  wrap?: boolean
+  /** Gap between children (Tailwind spacing scale: 0, 1, 2, 3, 4, etc.) */
+  gap?: 0 | 1 | 2 | 3 | 4 | 5 | 6 | 8 | 10 | 12
   /** FieldSet content (Field elements) */
   children: ReactNode
   /** Additional CSS classes */
   className?: string
 }
+
+const gapClasses = {
+  0: 'gap-0',
+  1: 'gap-1',
+  2: 'gap-2',
+  3: 'gap-3',
+  4: 'gap-4',
+  5: 'gap-5',
+  6: 'gap-6',
+  8: 'gap-8',
+  10: 'gap-10',
+  12: 'gap-12',
+} as const
 
 export function FieldSet({
   legend,
@@ -25,6 +44,9 @@ export function FieldSet({
   error,
   isError: isErrorProp,
   disabled = false,
+  direction = 'column',
+  wrap = false,
+  gap = 4,
   children,
   className,
 }: FieldSetProps) {
@@ -59,7 +81,16 @@ export function FieldSet({
             {description}
           </p>
         )}
-        <div className="mt-4 flex flex-col gap-4">{children}</div>
+        <div
+          className={cn(
+            'mt-4 flex',
+            direction === 'row' ? 'flex-row' : 'flex-col',
+            wrap && 'flex-wrap',
+            gapClasses[gap],
+          )}
+        >
+          {children}
+        </div>
         {error && (
           <p id={errorId} className="mt-4 text-sm text-destructive">
             {error}

--- a/src/components/lv1/FieldSet/FieldSet.tsx
+++ b/src/components/lv1/FieldSet/FieldSet.tsx
@@ -62,7 +62,7 @@ export function FieldSet({
         data-error={isError || undefined}
       >
         {legend && (
-          <legend className={cn('text-base font-medium text-foreground', disabled && 'opacity-50')}>
+          <legend className={cn('text-lg font-medium text-foreground', disabled && 'opacity-50')}>
             {legend}
           </legend>
         )}

--- a/src/components/lv1/FieldSet/FieldSet.tsx
+++ b/src/components/lv1/FieldSet/FieldSet.tsx
@@ -46,23 +46,22 @@ export function FieldSet({
   return (
     <FieldSetContext.Provider value={contextValue}>
       <fieldset
-        className={cn('flex flex-col gap-4', className)}
+        className={cn('flex flex-col', className)}
         disabled={disabled}
         aria-describedby={describedBy}
+        aria-invalid={isError || undefined}
         data-disabled={disabled || undefined}
         data-error={isError || undefined}
       >
-        <div className="flex flex-col gap-0">
-          <legend className="text-base font-medium text-foreground">{legend}</legend>
-          {description && (
-            <p id={descriptionId} className="text-sm text-foreground-muted">
-              {description}
-            </p>
-          )}
-        </div>
-        {children}
+        <legend className="text-base font-medium text-foreground">{legend}</legend>
+        {description && (
+          <p id={descriptionId} className="text-sm text-foreground-muted">
+            {description}
+          </p>
+        )}
+        <div className="mt-4 flex flex-col gap-4">{children}</div>
         {error && (
-          <p id={errorId} className="text-sm text-destructive">
+          <p id={errorId} className="mt-4 text-sm text-destructive">
             {error}
           </p>
         )}

--- a/src/components/lv1/FieldSet/FieldSet.tsx
+++ b/src/components/lv1/FieldSet/FieldSet.tsx
@@ -61,16 +61,9 @@ export function FieldSet({
         data-disabled={disabled || undefined}
         data-error={isError || undefined}
       >
-        {legend && (
-          <legend className={cn('text-lg font-bold text-foreground', disabled && 'opacity-50')}>
-            {legend}
-          </legend>
-        )}
+        {legend && <legend className="text-lg font-bold text-foreground">{legend}</legend>}
         {description && (
-          <p
-            id={descriptionId}
-            className={cn('text-sm text-foreground-muted', disabled && 'opacity-50')}
-          >
+          <p id={descriptionId} className="text-sm text-foreground-muted">
             {description}
           </p>
         )}

--- a/src/components/lv1/FieldSet/FieldSet.tsx
+++ b/src/components/lv1/FieldSet/FieldSet.tsx
@@ -3,8 +3,8 @@ import { FieldSetContext, type FieldSetContextValue } from '../../../contexts/fi
 import { cn } from '../../../lib/utils'
 
 export interface FieldSetProps {
-  /** Legend text for the fieldset */
-  legend: ReactNode
+  /** Legend text for the fieldset. Omit for layout-only grouping. */
+  legend?: ReactNode
   /** Description text displayed below the legend */
   description?: ReactNode
   /** Error message to display (group-level) */
@@ -49,6 +49,8 @@ export function FieldSet({
 
   const contextValue = useMemo<FieldSetContextValue>(() => ({ isError }), [isError])
 
+  const hasHeader = legend || description
+
   return (
     <FieldSetContext.Provider value={contextValue}>
       <fieldset
@@ -59,15 +61,23 @@ export function FieldSet({
         data-disabled={disabled || undefined}
         data-error={isError || undefined}
       >
-        <legend className="text-base font-medium text-foreground">{legend}</legend>
+        {legend && (
+          <legend className={cn('text-base font-medium text-foreground', disabled && 'opacity-50')}>
+            {legend}
+          </legend>
+        )}
         {description && (
-          <p id={descriptionId} className="text-sm text-foreground-muted">
+          <p
+            id={descriptionId}
+            className={cn('text-sm text-foreground-muted', disabled && 'opacity-50')}
+          >
             {description}
           </p>
         )}
         <div
           className={cn(
-            'mt-4 flex gap-4',
+            'flex gap-4',
+            hasHeader && 'mt-4',
             direction === 'row' ? 'flex-row' : 'flex-col',
             wrap && 'flex-wrap',
           )}

--- a/src/components/lv1/FieldSet/index.ts
+++ b/src/components/lv1/FieldSet/index.ts
@@ -1,0 +1,2 @@
+export { type FieldSetContextValue, useFieldSetContext } from '../../../contexts/fieldset'
+export { FieldSet, type FieldSetProps } from './FieldSet'

--- a/src/components/lv1/index.ts
+++ b/src/components/lv1/index.ts
@@ -2,6 +2,12 @@ export { Badge, type BadgeProps } from './Badge'
 export { Button, type ButtonProps } from './Button'
 export { Checkbox, type CheckboxProps } from './Checkbox'
 export { Field, type FieldContextValue, type FieldProps, useFieldContext } from './Field'
+export {
+  FieldSet,
+  type FieldSetContextValue,
+  type FieldSetProps,
+  useFieldSetContext,
+} from './FieldSet'
 export { Input, type InputProps } from './Input'
 export { Radio, RadioGroup, type RadioGroupProps, type RadioProps } from './Radio'
 export {

--- a/src/contexts/fieldset.ts
+++ b/src/contexts/fieldset.ts
@@ -1,0 +1,16 @@
+import { createContext, useContext } from 'react'
+
+export interface FieldSetContextValue {
+  /** Error state from the parent FieldSet */
+  isError: boolean
+}
+
+export const FieldSetContext = createContext<FieldSetContextValue | null>(null)
+
+/**
+ * Hook to access FieldSet context values.
+ * Returns null when used outside of a FieldSet component.
+ */
+export function useFieldSetContext() {
+  return useContext(FieldSetContext)
+}

--- a/src/contexts/index.ts
+++ b/src/contexts/index.ts
@@ -1,1 +1,2 @@
 export { FieldContext, type FieldContextValue, useFieldContext } from './field'
+export { FieldSetContext, type FieldSetContextValue, useFieldSetContext } from './fieldset'

--- a/src/docs/Welcome.stories.tsx
+++ b/src/docs/Welcome.stories.tsx
@@ -3,6 +3,7 @@ import { Badge } from '../components/lv1/Badge'
 import { Button } from '../components/lv1/Button'
 import { Checkbox } from '../components/lv1/Checkbox'
 import { Field } from '../components/lv1/Field'
+import { FieldSet } from '../components/lv1/FieldSet'
 import { Input } from '../components/lv1/Input'
 import { Radio, RadioGroup } from '../components/lv1/Radio'
 import {
@@ -176,6 +177,19 @@ export const Overview: Story = {
             <Field label="Email" description="Your email address.">
               <Input placeholder="you@example.com" className="w-40" />
             </Field>
+          </ComponentCard>
+
+          <ComponentCard
+            name="FieldSet"
+            description="Groups related form fields."
+            storyPath="components-lv1-fieldset"
+          >
+            <FieldSet legend="Name">
+              <div className="flex gap-2">
+                <Input placeholder="First" className="w-20" />
+                <Input placeholder="Last" className="w-20" />
+              </div>
+            </FieldSet>
           </ComponentCard>
 
           <ComponentCard

--- a/src/docs/Welcome.stories.tsx
+++ b/src/docs/Welcome.stories.tsx
@@ -184,11 +184,10 @@ export const Overview: Story = {
             description="Groups related form fields."
             storyPath="components-lv1-fieldset"
           >
-            <FieldSet legend="Name">
-              <div className="flex gap-2">
-                <Input placeholder="First" className="w-20" />
-                <Input placeholder="Last" className="w-20" />
-              </div>
+            <FieldSet legend="Contact">
+              <Field label="Email">
+                <Input placeholder="you@example.com" className="w-40" />
+              </Field>
             </FieldSet>
           </ComponentCard>
 


### PR DESCRIPTION
## Summary

- Add `FieldSet` component using semantic `<fieldset>` + `<legend>` for accessible form field grouping
- Add `FieldSetContext` to propagate `isError` state to child `Field` components
- Add layout props: `direction`, `wrap` for FieldSet, `flexGrow`, `flexShrink`, `flexBasis` for Field
- Native `<fieldset disabled>` handles automatic child disabling
- Legend is optional for layout-only grouping

Closes #35

## Test plan

- [ ] Run `pnpm test` and verify all 78 tests pass
- [ ] Run `pnpm storybook` and check FieldSet stories (15 stories)
- [ ] Verify Tab key navigation works correctly within FieldSet
- [ ] Test screen reader announces legend correctly

🤖 Generated with [Claude Code](https://claude.ai/code)