### PR TITLE
fix(vrt): improve story loading reliability

### DIFF
--- a/.claude/rules/vrt-spec-guideline.md
+++ b/.claude/rules/vrt-spec-guideline.md
@@ -1,0 +1,136 @@
+# VRT Spec Guideline
+
+## Overview
+
+Visual Regression Testing (VRT) specs use Playwright to capture screenshots of Storybook stories and compare them against baseline snapshots.
+
+## File Structure
+
+VRT spec files should be placed alongside the component:
+```
+src/components/lv1/ComponentName/
+├── ComponentName.tsx
+├── ComponentName.stories.tsx
+├── ComponentName.test.tsx
+├── ComponentName.vrt.spec.ts    # VRT spec
+└── __snapshots__/               # Auto-generated snapshots
+    ├── story-name-light.png
+    └── story-name-dark.png
+```
+
+## Template
+
+```typescript
+import { expect, test } from '@playwright/test'
+
+const STORY_ID_PREFIX = 'components-lv1-componentname'
+
+const stories = ['story-one', 'story-two'] as const
+
+const themes = ['light', 'dark'] as const
+
+function storyUrl(storyId: string, theme: string) {
+  return `/iframe.html?id=${STORY_ID_PREFIX}--${storyId}&globals=theme:${theme}&viewMode=story`
+}
+
+for (const story of stories) {
+  for (const theme of themes) {
+    test(`ComponentName / ${story} / ${theme}`, async ({ page }) => {
+      await page.goto(storyUrl(story, theme))
+      await page.waitForLoadState('networkidle')
+
+      const root = page.locator('#storybook-root')
+      await root.waitFor({ state: 'visible', timeout: 10_000 })
+      await page.waitForFunction(
+        () => {
+          const el = document.querySelector('#storybook-root')
+          return el && el.children.length > 0
+        },
+        { timeout: 10_000 },
+      )
+
+      await expect(root).toHaveScreenshot(`${story}-${theme}.png`)
+    })
+  }
+}
+```
+
+## Story ID Mapping
+
+Storybook converts story export names to kebab-case:
+- `AllVariants` → `all-variants`
+- `WithIcons` → `with-icons`
+- `ErrorState` → `error-state`
+
+The story ID prefix follows the Storybook title:
+- `title: 'Components/lv1/Button'` → `components-lv1-button`
+
+## Required Wait Logic
+
+Always include these waits for CI reliability:
+
+```typescript
+// 1. Wait for network to settle
+await page.waitForLoadState('networkidle')
+
+// 2. Wait for root element to be visible
+const root = page.locator('#storybook-root')
+await root.waitFor({ state: 'visible', timeout: 10_000 })
+
+// 3. Wait for content to render
+await page.waitForFunction(
+  () => {
+    const el = document.querySelector('#storybook-root')
+    return el && el.children.length > 0
+  },
+  { timeout: 10_000 },
+)
+```
+
+## Handling Animations
+
+For components with animations (e.g., Spinner), pause animations before screenshot:
+
+```typescript
+await page.addStyleTag({
+  content: `
+    *, *::before, *::after {
+      animation-play-state: paused !important;
+      animation-delay: -0.0001s !important;
+    }
+  `,
+})
+```
+
+## Story Selection
+
+Only include stories that represent distinct visual states:
+- Include: `AllVariants`, `Sizes`, `States`, `Disabled`, `ErrorState`
+- Exclude: `Playground` (interactive, not for VRT)
+
+## Running VRT Tests
+
+```bash
+# Run all VRT tests
+pnpm test:vrt
+
+# Update snapshots
+pnpm test:vrt:update
+
+# Run specific component
+pnpm test:vrt -- --grep "Button"
+```
+
+## Snapshot Naming
+
+Snapshots are named `{story}-{theme}.png`:
+- `all-variants-light.png`
+- `all-variants-dark.png`
+- `sizes-light.png`
+- etc.
+
+## CI Considerations
+
+- Timeout is set to 10s to handle slower CI environments
+- Use `networkidle` wait state for consistent font loading
+- Always test both light and dark themes

--- a/src/components/lv1/Badge/Badge.vrt.spec.ts
+++ b/src/components/lv1/Badge/Badge.vrt.spec.ts
@@ -14,10 +14,19 @@ for (const story of stories) {
   for (const theme of themes) {
     test(`Badge / ${story} / ${theme}`, async ({ page }) => {
       await page.goto(storyUrl(story, theme))
-      await page.waitForSelector('[data-storyloaded]', { timeout: 5_000 }).catch(() => {})
       await page.waitForLoadState('networkidle')
 
       const root = page.locator('#storybook-root')
+      await root.waitFor({ state: 'visible', timeout: 10_000 })
+      // Wait for content to render
+      await page.waitForFunction(
+        () => {
+          const el = document.querySelector('#storybook-root')
+          return el && el.children.length > 0
+        },
+        { timeout: 10_000 },
+      )
+
       await expect(root).toHaveScreenshot(`${story}-${theme}.png`)
     })
   }

--- a/src/components/lv1/Button/Button.vrt.spec.ts
+++ b/src/components/lv1/Button/Button.vrt.spec.ts
@@ -14,11 +14,18 @@ for (const story of stories) {
   for (const theme of themes) {
     test(`Button / ${story} / ${theme}`, async ({ page }) => {
       await page.goto(storyUrl(story, theme))
-      await page.waitForSelector('[data-storyloaded]', { timeout: 5_000 }).catch(() => {})
-      // Wait for fonts and rendering to settle
       await page.waitForLoadState('networkidle')
 
       const root = page.locator('#storybook-root')
+      await root.waitFor({ state: 'visible', timeout: 10_000 })
+      await page.waitForFunction(
+        () => {
+          const el = document.querySelector('#storybook-root')
+          return el && el.children.length > 0
+        },
+        { timeout: 10_000 },
+      )
+
       await expect(root).toHaveScreenshot(`${story}-${theme}.png`)
     })
   }

--- a/src/components/lv1/Checkbox/Checkbox.vrt.spec.ts
+++ b/src/components/lv1/Checkbox/Checkbox.vrt.spec.ts
@@ -21,10 +21,18 @@ for (const story of stories) {
   for (const theme of themes) {
     test(`Checkbox / ${story} / ${theme}`, async ({ page }) => {
       await page.goto(storyUrl(story, theme))
-      await page.waitForSelector('[data-storyloaded]', { timeout: 5_000 }).catch(() => {})
       await page.waitForLoadState('networkidle')
 
       const root = page.locator('#storybook-root')
+      await root.waitFor({ state: 'visible', timeout: 10_000 })
+      await page.waitForFunction(
+        () => {
+          const el = document.querySelector('#storybook-root')
+          return el && el.children.length > 0
+        },
+        { timeout: 10_000 },
+      )
+
       await expect(root).toHaveScreenshot(`${story}-${theme}.png`)
     })
   }

--- a/src/components/lv1/Input/Input.vrt.spec.ts
+++ b/src/components/lv1/Input/Input.vrt.spec.ts
@@ -14,10 +14,18 @@ for (const story of stories) {
   for (const theme of themes) {
     test(`Input / ${story} / ${theme}`, async ({ page }) => {
       await page.goto(storyUrl(story, theme))
-      await page.waitForSelector('[data-storyloaded]', { timeout: 5_000 }).catch(() => {})
       await page.waitForLoadState('networkidle')
 
       const root = page.locator('#storybook-root')
+      await root.waitFor({ state: 'visible', timeout: 10_000 })
+      await page.waitForFunction(
+        () => {
+          const el = document.querySelector('#storybook-root')
+          return el && el.children.length > 0
+        },
+        { timeout: 10_000 },
+      )
+
       await expect(root).toHaveScreenshot(`${story}-${theme}.png`)
     })
   }

--- a/src/components/lv1/Radio/Radio.vrt.spec.ts
+++ b/src/components/lv1/Radio/Radio.vrt.spec.ts
@@ -14,10 +14,18 @@ for (const story of stories) {
   for (const theme of themes) {
     test(`Radio / ${story} / ${theme}`, async ({ page }) => {
       await page.goto(storyUrl(story, theme))
-      await page.waitForSelector('[data-storyloaded]', { timeout: 5_000 }).catch(() => {})
       await page.waitForLoadState('networkidle')
 
       const root = page.locator('#storybook-root')
+      await root.waitFor({ state: 'visible', timeout: 10_000 })
+      await page.waitForFunction(
+        () => {
+          const el = document.querySelector('#storybook-root')
+          return el && el.children.length > 0
+        },
+        { timeout: 10_000 },
+      )
+
       await expect(root).toHaveScreenshot(`${story}-${theme}.png`)
     })
   }

--- a/src/components/lv1/Select/Select.vrt.spec.ts
+++ b/src/components/lv1/Select/Select.vrt.spec.ts
@@ -14,10 +14,18 @@ for (const story of stories) {
   for (const theme of themes) {
     test(`Select / ${story} / ${theme}`, async ({ page }) => {
       await page.goto(storyUrl(story, theme))
-      await page.waitForSelector('[data-storyloaded]', { timeout: 5_000 }).catch(() => {})
       await page.waitForLoadState('networkidle')
 
       const root = page.locator('#storybook-root')
+      await root.waitFor({ state: 'visible', timeout: 10_000 })
+      await page.waitForFunction(
+        () => {
+          const el = document.querySelector('#storybook-root')
+          return el && el.children.length > 0
+        },
+        { timeout: 10_000 },
+      )
+
       await expect(root).toHaveScreenshot(`${story}-${theme}.png`)
     })
   }

--- a/src/components/lv1/Spinner/Spinner.vrt.spec.ts
+++ b/src/components/lv1/Spinner/Spinner.vrt.spec.ts
@@ -14,9 +14,17 @@ for (const story of stories) {
   for (const theme of themes) {
     test(`Spinner / ${story} / ${theme}`, async ({ page }) => {
       await page.goto(storyUrl(story, theme))
-      await page.waitForSelector('[data-storyloaded]', { timeout: 5_000 }).catch(() => {})
-      // Wait for fonts and rendering to settle
       await page.waitForLoadState('networkidle')
+
+      const root = page.locator('#storybook-root')
+      await root.waitFor({ state: 'visible', timeout: 10_000 })
+      await page.waitForFunction(
+        () => {
+          const el = document.querySelector('#storybook-root')
+          return el && el.children.length > 0
+        },
+        { timeout: 10_000 },
+      )
 
       // Pause animations for consistent screenshots
       await page.addStyleTag({
@@ -28,7 +36,6 @@ for (const story of stories) {
         `,
       })
 
-      const root = page.locator('#storybook-root')
       await expect(root).toHaveScreenshot(`${story}-${theme}.png`)
     })
   }

--- a/src/components/lv1/Switch/Switch.vrt.spec.ts
+++ b/src/components/lv1/Switch/Switch.vrt.spec.ts
@@ -14,10 +14,18 @@ for (const story of stories) {
   for (const theme of themes) {
     test(`Switch / ${story} / ${theme}`, async ({ page }) => {
       await page.goto(storyUrl(story, theme))
-      await page.waitForSelector('[data-storyloaded]', { timeout: 5_000 }).catch(() => {})
       await page.waitForLoadState('networkidle')
 
       const root = page.locator('#storybook-root')
+      await root.waitFor({ state: 'visible', timeout: 10_000 })
+      await page.waitForFunction(
+        () => {
+          const el = document.querySelector('#storybook-root')
+          return el && el.children.length > 0
+        },
+        { timeout: 10_000 },
+      )
+
       await expect(root).toHaveScreenshot(`${story}-${theme}.png`)
     })
   }

--- a/src/components/lv1/Text/Text.vrt.spec.ts
+++ b/src/components/lv1/Text/Text.vrt.spec.ts
@@ -14,10 +14,18 @@ for (const story of stories) {
   for (const theme of themes) {
     test(`Text / ${story} / ${theme}`, async ({ page }) => {
       await page.goto(storyUrl(story, theme))
-      await page.waitForSelector('[data-storyloaded]', { timeout: 5_000 }).catch(() => {})
       await page.waitForLoadState('networkidle')
 
       const root = page.locator('#storybook-root')
+      await root.waitFor({ state: 'visible', timeout: 10_000 })
+      await page.waitForFunction(
+        () => {
+          const el = document.querySelector('#storybook-root')
+          return el && el.children.length > 0
+        },
+        { timeout: 10_000 },
+      )
+
       await expect(root).toHaveScreenshot(`${story}-${theme}.png`)
     })
   }

--- a/src/components/lv1/Textarea/Textarea.vrt.spec.ts
+++ b/src/components/lv1/Textarea/Textarea.vrt.spec.ts
@@ -14,10 +14,18 @@ for (const story of stories) {
   for (const theme of themes) {
     test(`Textarea / ${story} / ${theme}`, async ({ page }) => {
       await page.goto(storyUrl(story, theme))
-      await page.waitForSelector('[data-storyloaded]', { timeout: 5_000 }).catch(() => {})
       await page.waitForLoadState('networkidle')
 
       const root = page.locator('#storybook-root')
+      await root.waitFor({ state: 'visible', timeout: 10_000 })
+      await page.waitForFunction(
+        () => {
+          const el = document.querySelector('#storybook-root')
+          return el && el.children.length > 0
+        },
+        { timeout: 10_000 },
+      )
+
       await expect(root).toHaveScreenshot(`${story}-${theme}.png`)
     })
   }


### PR DESCRIPTION
## Summary

- Replace flaky `data-storyloaded` selector with proper visibility checks
- Wait for `#storybook-root` to be visible and have content before taking screenshots
- Increase timeout to 10s for CI environment

## Changes

All VRT test files updated with improved waiting logic:
- `root.waitFor({ state: 'visible', timeout: 10_000 })`
- `page.waitForFunction()` to ensure content is rendered

## Test plan

- [x] VRT tests pass locally (98/98)
- [ ] VRT tests pass in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)