### PR TITLE
feat: add tooltip prop to Field component

### DIFF
--- a/src/components/lv1/Field/Field.stories.tsx
+++ b/src/components/lv1/Field/Field.stories.tsx
@@ -5,6 +5,7 @@ import { Radio, RadioGroup } from '../Radio/Radio'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../Select/Select'
 import { Switch } from '../Switch/Switch'
 import { Textarea } from '../Textarea/Textarea'
+import { TooltipProvider } from '../Tooltip/Tooltip'
 import { Field } from './Field'
 
 const meta: Meta<typeof Field> = {
@@ -14,6 +15,13 @@ const meta: Meta<typeof Field> = {
     layout: 'centered',
   },
   tags: ['autodocs'],
+  decorators: [
+    (Story) => (
+      <TooltipProvider delayDuration={100}>
+        <Story />
+      </TooltipProvider>
+    ),
+  ],
   argTypes: {
     label: {
       description: 'Label text for the field.',
@@ -24,6 +32,13 @@ const meta: Meta<typeof Field> = {
     },
     description: {
       description: 'Description text displayed above the input.',
+      control: 'text',
+      table: {
+        type: { summary: 'ReactNode' },
+      },
+    },
+    tooltip: {
+      description: 'Tooltip content displayed on hover of info icon next to label.',
       control: 'text',
       table: {
         type: { summary: 'ReactNode' },
@@ -182,6 +197,25 @@ export const WithRadioGroup: Story = {
           <Radio value="pro" label="Pro" />
           <Radio value="enterprise" label="Enterprise" />
         </RadioGroup>
+      </Field>
+    </div>
+  ),
+}
+
+export const WithTooltip: Story = {
+  name: 'With Tooltip',
+  render: () => (
+    <div className="flex flex-col gap-6 w-80">
+      <Field label="Email" tooltip="Used for account recovery and important notifications.">
+        <Input type="email" placeholder="you@example.com" />
+      </Field>
+      <Field
+        label="Password"
+        description="Must be at least 8 characters."
+        tooltip="Use a mix of letters, numbers, and symbols for better security."
+        required
+      >
+        <Input type="password" placeholder="Enter password" />
       </Field>
     </div>
   ),

--- a/src/components/lv1/Field/Field.tsx
+++ b/src/components/lv1/Field/Field.tsx
@@ -1,13 +1,17 @@
+import { Info } from 'lucide-react'
 import { type ReactNode, useId, useMemo } from 'react'
 import { FieldContext, type FieldContextValue } from '../../../contexts/field'
 import { useFieldSetContext } from '../../../contexts/fieldset'
 import { cn } from '../../../lib/utils'
+import { Tooltip, TooltipContent, TooltipTrigger } from '../Tooltip/Tooltip'
 
 export interface FieldProps {
   /** Label text for the field */
   label?: ReactNode
   /** Description text displayed above the input */
   description?: ReactNode
+  /** Tooltip content displayed on hover of info icon next to label */
+  tooltip?: ReactNode
   /** Error message to display */
   error?: string
   /** Explicitly set error state. If not provided, derived from error prop */
@@ -34,6 +38,7 @@ const flexShrinkClasses = { 0: 'shrink-0', 1: 'shrink' } as const
 export function Field({
   label,
   description,
+  tooltip,
   error,
   isError: isErrorProp,
   required = false,
@@ -76,10 +81,23 @@ export function Field({
         data-disabled={disabled || undefined}
       >
         {label && (
-          <label htmlFor={id} className="text-base font-bold text-foreground">
-            {label}
-            {required && <span className="text-destructive ml-0.5">*</span>}
-          </label>
+          <div className="flex items-center gap-1">
+            <label htmlFor={id} className="text-base font-bold text-foreground">
+              {label}
+              {required && <span className="text-destructive ml-0.5">*</span>}
+            </label>
+            {tooltip && (
+              <Tooltip>
+                <TooltipTrigger>
+                  <Info
+                    className="size-4 text-foreground-muted cursor-help"
+                    aria-label="More information"
+                  />
+                </TooltipTrigger>
+                <TooltipContent>{tooltip}</TooltipContent>
+              </Tooltip>
+            )}
+          </div>
         )}
         {description && (
           <label


### PR DESCRIPTION
## Summary

- Add `tooltip` prop to Field component for supplementary information
- Displays info icon (ⓘ) next to label, shows tooltip on hover

## Usage

```tsx
// Tooltip only
<Field label="Email" tooltip="Used for account recovery.">
  <Input />
</Field>

// Tooltip + Description
<Field 
  label="Password" 
  description="Must be at least 8 characters."
  tooltip="Use a mix of letters, numbers, and symbols."
>
  <Input type="password" />
</Field>
```

## UI

```
Email ⓘ              ← hover for tooltip
[________________]

Password ⓘ           ← hover for tooltip  
Must be at least...  ← description (always visible)
[________________]
```

## Changes

- `src/components/lv1/Field/Field.tsx` - Add tooltip prop and render logic
- `src/components/lv1/Field/Field.stories.tsx` - Add WithTooltip story and argType

🤖 Generated with [Claude Code](https://claude.com/claude-code)