### PR TITLE
fix: Input wrapper click focuses the input element

### DIFF
--- a/src/components/lv1/Input/Input.tsx
+++ b/src/components/lv1/Input/Input.tsx
@@ -1,6 +1,7 @@
 import { icons } from 'lucide-react'
-import { forwardRef, type InputHTMLAttributes, useId } from 'react'
+import { forwardRef, type InputHTMLAttributes, useId, useRef } from 'react'
 import { useFieldContext } from '../../../contexts/field'
+import { mergeRefs } from '../../../lib/merge-refs'
 import { cn } from '../../../lib/utils'
 import { type InputVariants, inputVariants, inputWrapperVariants } from '../../../variants/input'
 
@@ -50,12 +51,22 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
     const disabled = field?.disabled ?? disabledProp
     const ariaDescribedBy = field?.describedBy ?? ariaDescribedByProp
 
+    const inputRef = useRef<HTMLInputElement>(null)
+
     const isDateType = dateTypes.has(type ?? '')
     const LeftIcon = !textLeft && iconLeft ? icons[iconLeft] : null
     const RightIcon = !textRight && iconRight ? icons[iconRight] : null
     const iconSize = iconSizeMap[size ?? 'md']
 
+    const handleWrapperClick = () => {
+      if (!disabled) {
+        inputRef.current?.focus()
+      }
+    }
+
     return (
+      // biome-ignore lint/a11y/noStaticElementInteractions: Wrapper delegates focus to input
+      // biome-ignore lint/a11y/useKeyWithClickEvents: Input handles keyboard events
       <div
         className={cn(
           inputWrapperVariants({ size }),
@@ -65,6 +76,7 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
           disabled && 'cursor-not-allowed opacity-50',
           className,
         )}
+        onClick={handleWrapperClick}
       >
         {textLeft && <span className="text-foreground-muted shrink-0">{textLeft}</span>}
         {LeftIcon && (
@@ -77,7 +89,7 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
             inputVariants(),
             isDateType && '[&::-webkit-calendar-picker-indicator]:ml-auto',
           )}
-          ref={ref}
+          ref={mergeRefs(ref, inputRef)}
           disabled={disabled}
           aria-invalid={isError || undefined}
           aria-describedby={ariaDescribedBy}

--- a/src/lib/merge-refs.ts
+++ b/src/lib/merge-refs.ts
@@ -1,0 +1,17 @@
+import type { MutableRefObject, Ref, RefCallback } from 'react'
+
+/**
+ * Merges multiple refs into a single ref callback.
+ * Useful when you need to use both a forwarded ref and an internal ref.
+ */
+export function mergeRefs<T>(...refs: (Ref<T> | undefined)[]): RefCallback<T> {
+  return (value) => {
+    for (const ref of refs) {
+      if (typeof ref === 'function') {
+        ref(value)
+      } else if (ref != null) {
+        ;(ref as MutableRefObject<T | null>).current = value
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Fix: Clicking on the padding area of Input now focuses the input element
- The entire visual input area is now clickable

## Problem

Previously, clicking on the inner padding of the Input wrapper (the area between the border and the actual input) did not focus the input.

## Solution

- Add `onClick` handler to wrapper that focuses the input
- Add `mergeRefs` utility to combine forwarded ref with internal ref

## Changes

- `src/components/lv1/Input/Input.tsx` - Add onClick handler
- `src/lib/merge-refs.ts` - New utility for merging refs

🤖 Generated with [Claude Code](https://claude.com/claude-code)