### PR TITLE
fix: FieldSet disabled state propagates to Field children

### DIFF
--- a/src/components/lv1/Field/Field.tsx
+++ b/src/components/lv1/Field/Field.tsx
@@ -55,6 +55,7 @@ export function Field({
   const errorId = `${id}-error`
 
   const isError = isErrorProp ?? (error ? true : undefined) ?? fieldSet?.isError ?? false
+  const effectiveDisabled = disabled || fieldSet?.disabled || false
 
   const describedBy = useMemo(() => {
     const ids: string[] = []
@@ -64,8 +65,8 @@ export function Field({
   }, [description, error, descriptionId, errorId])
 
   const contextValue = useMemo<FieldContextValue>(
-    () => ({ id, isError, disabled, describedBy }),
-    [id, isError, disabled, describedBy],
+    () => ({ id, isError, disabled: effectiveDisabled, describedBy }),
+    [id, isError, effectiveDisabled, describedBy],
   )
 
   return (
@@ -78,7 +79,7 @@ export function Field({
           className,
         )}
         style={flexBasis ? { flexBasis } : undefined}
-        data-disabled={disabled || undefined}
+        data-disabled={effectiveDisabled || undefined}
       >
         {label && (
           <div className="flex items-center gap-1">

--- a/src/components/lv1/FieldSet/FieldSet.tsx
+++ b/src/components/lv1/FieldSet/FieldSet.tsx
@@ -47,7 +47,10 @@ export function FieldSet({
     return ids.length > 0 ? ids.join(' ') : undefined
   }, [description, error, descriptionId, errorId])
 
-  const contextValue = useMemo<FieldSetContextValue>(() => ({ isError }), [isError])
+  const contextValue = useMemo<FieldSetContextValue>(
+    () => ({ isError, disabled }),
+    [isError, disabled],
+  )
 
   const hasHeader = legend || description
 

--- a/src/contexts/fieldset.ts
+++ b/src/contexts/fieldset.ts
@@ -3,6 +3,8 @@ import { createContext, useContext } from 'react'
 export interface FieldSetContextValue {
   /** Error state from the parent FieldSet */
   isError: boolean
+  /** Disabled state from the parent FieldSet */
+  disabled: boolean
 }
 
 export const FieldSetContext = createContext<FieldSetContextValue | null>(null)


### PR DESCRIPTION
## Summary

Fix: FieldSet's `disabled` prop now propagates to all child Field components via context.

## Problem

When setting `disabled` on FieldSet, the child Field components did not inherit the disabled state.

```tsx
<FieldSet disabled>
  <Field label="Name"><Input /></Field>  {/* Input was NOT disabled */}
</FieldSet>
```

## Solution

- Add `disabled` to `FieldSetContextValue`
- Update FieldSet to include `disabled` in context
- Update Field to inherit `disabled` from FieldSet context

## Changes

- `src/contexts/fieldset.ts` - Add disabled to interface
- `src/components/lv1/FieldSet/FieldSet.tsx` - Include disabled in context
- `src/components/lv1/Field/Field.tsx` - Inherit disabled from FieldSet

🤖 Generated with [Claude Code](https://claude.com/claude-code)