### PR TITLE
feat: add state semantic tokens (error, info) and complete success/warning

### DIFF
--- a/.changeset/state-semantic-tokens.md
+++ b/.changeset/state-semantic-tokens.md
@@ -1,0 +1,9 @@
+---
+'@yasmro/schatten': minor
+---
+
+Add full state semantic tokens (`error`, `success`, `warning`, `info`), each with `{ base, hover, foreground, subtle }`.
+
+- New tokens: `error-*`, `info-*`, plus completed `success-foreground` / `success-subtle` / `warning-foreground` / `warning-subtle`.
+- Form components (`Input`, `Textarea`, `Select`, `Field`) now reference `error-*` instead of `destructive-*`. `destructive` remains for destructive actions (Button, Badge). `error` and `destructive` share vermillion under the hood, so visuals are unchanged.
+- `success` and `warning` base shades shifted from `500/400` to `600/500` (light/dark) for consistency with `destructive` / `error` / `info`. No component currently surfaces these visually outside Storybook docs.

--- a/.claude/rules/state-token-guideline.md
+++ b/.claude/rules/state-token-guideline.md
@@ -1,0 +1,100 @@
+# State Token Guideline
+
+## Overview
+
+State semantics (`error`, `success`, `warning`, `info`) and the `destructive` action color
+follow a unified 4-token shape so that every component that needs to express "this is a state"
+has a consistent, predictable surface to draw from.
+
+## Three-layer hierarchy
+
+Components consume **only Layer 2**. Never reference primitive scales (`vermillion-*`, `green-*`,
+…) directly inside a component.
+
+```
+Layer 1: Primitive (raw OKLCH scales — same in light/dark)
+   vermillion-*  green-*  amber-*  blue-*  ...
+
+Layer 2: Semantic (meaning — light/dark mapping happens here)
+   destructive ◀── vermillion ──▶ error
+   success     ◀── green
+   warning     ◀── amber
+   info        ◀── blue (independent of `primary`)
+
+Layer 3: Components (consume semantic only)
+   bg-error / text-error / border-error / ring-error / bg-error-subtle ...
+```
+
+## The 4-token shape
+
+Every state defines exactly four tokens:
+
+| Token | Role | Typical use |
+|---|---|---|
+| `base` | main color (saturated) | fills, borders, icons, text |
+| `hover` | base's interactive sibling | hover/active state of `base` |
+| `foreground` | on-`base` text/icon color | readable text atop `base` |
+| `subtle` | faint tinted background | soft state surfaces (e.g. error input bg) |
+
+The tokens form two natural treatment pairs:
+
+- **Filled** — `bg-{state}` + `text-{state}-foreground`. Used for buttons, toasts, badges.
+- **Soft** — `bg-{state}-subtle` + `text-{state}` (often + `border-{state}`). Used for error
+  input backgrounds, info banners.
+
+## `destructive` vs `error`
+
+They share the **same primitive** (vermillion) so they look identical, but are **semantically
+distinct**:
+
+| | `destructive` | `error` |
+|---|---|---|
+| Meaning | An action with destructive intent | A state representing an error |
+| Used by | Button(destructive), Badge(destructive) | Input/Textarea/Select/Radio/Checkbox/Switch (`isError`), Field error msg + required `*`, FieldSet error msg, Toast(error) |
+
+If we ever decide error red ≠ destructive red, only the semantic mapping needs to change —
+no component churn.
+
+**Rule**: form components and notification components reference `error-*`. Action surfaces
+reference `destructive-*`.
+
+## `info` independence from `primary`
+
+`info` references `blue-*` directly rather than `primary-*`. Themes that retune `primary`
+(seasonal themes, custom brand themes) **must not** drift `info`'s meaning. Keep `info`
+pinned to blue.
+
+## Light / dark mapping
+
+Each state shifts shades between modes:
+
+| Mode | `base` | `hover` | `foreground` | `subtle` |
+|---|---|---|---|---|
+| Light | `*-600` | `*-700` | `paper-white` | `*-50` |
+| Dark | `*-500` | `*-400` | `paper-white-inv` | `*-900` |
+
+The dark-mode `foreground = paper-white-inv` (`#1a1a1a`) is intentional: in dark mode the
+state `base` shifts brighter (e.g. `vermillion-500`), and dark text on a bright saturated
+fill achieves higher WCAG contrast than white-on-bright. Verify visually in `Foundation/Color`
+→ "Filled Treatments (a11y audit)" before introducing new state-driven UI.
+
+## Adding a new component that needs state colors
+
+1. **Reach for an existing semantic.** Don't introduce a new state semantic (e.g. `notice`,
+   `caution`) unless you can articulate a meaning that `error / success / warning / info`
+   genuinely cannot cover.
+2. **Decide treatment**: filled (`bg + foreground`) or soft (`bg-subtle + base text`)?
+   Components like Toast may support both via a variant.
+3. **Always use semantic tokens.** Never hardcode `bg-vermillion-600` in a component.
+4. **Audit contrast** by adding the new component to the `Filled / Subtle Treatments` story
+   sections, or by toggling light/dark in your component's own story.
+
+## Adding a new state semantic (rarely needed)
+
+1. Add `--color-{state}`, `-hover`, `-foreground`, `-subtle` in `src/core/tokens/semantic.css`
+   for `:root`, `@media (prefers-color-scheme: dark)`, and `.dark`.
+2. Register all four in `@theme` inside `src/core/tokens/base.css` so Tailwind utilities
+   (`bg-{state}`, `bg-{state}-subtle`, …) become available.
+3. Add a subsection to `src/docs/Color.stories.tsx`.
+4. Add rows to the "Filled Treatments" and "Subtle Treatments" audit sections.
+5. Add a changeset (typically `minor` — additive feature).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,3 +27,6 @@ When adding or modifying components, follow shadcn/ui conventions (Radix UI + CV
 ## Guidelines
 
 - See [.claude/rules/storybook-guideline.md](.claude/rules/storybook-guideline.md) for Storybook conventions
+- See [.claude/rules/field-context-guideline.md](.claude/rules/field-context-guideline.md) for Field context integration patterns
+- See [.claude/rules/state-token-guideline.md](.claude/rules/state-token-guideline.md) for state semantic tokens (error / success / warning / info / destructive) and the 4-token shape
+- See [.claude/rules/vrt-spec-guideline.md](.claude/rules/vrt-spec-guideline.md) for VRT spec conventions

--- a/src/components/lv1/Checkbox/Checkbox.stories.tsx
+++ b/src/components/lv1/Checkbox/Checkbox.stories.tsx
@@ -44,7 +44,7 @@ const meta: Meta<typeof Checkbox> = {
       },
     },
     isError: {
-      description: 'Displays the checkbox in an error state with destructive border and ring.',
+      description: 'Displays the checkbox in an error state with error border and ring.',
       control: 'boolean',
       table: {
         type: { summary: 'boolean' },

--- a/src/components/lv1/Checkbox/Checkbox.tsx
+++ b/src/components/lv1/Checkbox/Checkbox.tsx
@@ -13,7 +13,7 @@ import { type CheckboxVariants, checkboxVariants } from '../../../variants/check
 export interface CheckboxProps
   extends Omit<ComponentPropsWithoutRef<typeof CheckboxPrimitive.Root>, 'size'>,
     CheckboxVariants {
-  /** Displays the checkbox in an error state with destructive border and ring. */
+  /** Displays the checkbox in an error state with error border and ring. */
   isError?: boolean
   /** Label text displayed next to the checkbox. Automatically associates via id. */
   label?: ReactNode
@@ -67,7 +67,7 @@ export const Checkbox = forwardRef<ElementRef<typeof CheckboxPrimitive.Root>, Ch
           id={id}
           className={cn(
             checkboxVariants({ size }),
-            isError && 'border-destructive bg-destructive-subtle focus-visible:ring-destructive',
+            isError && 'border-error bg-error-subtle focus-visible:ring-error',
           )}
           aria-invalid={isError || undefined}
           aria-describedby={ariaDescribedBy}

--- a/src/components/lv1/Field/Field.tsx
+++ b/src/components/lv1/Field/Field.tsx
@@ -85,7 +85,7 @@ export function Field({
           <div className="flex items-center gap-1">
             <label htmlFor={id} className="text-base font-bold text-foreground">
               {label}
-              {required && <span className="text-destructive ml-0.5">*</span>}
+              {required && <span className="text-error ml-0.5">*</span>}
             </label>
             {tooltip && (
               <Tooltip>
@@ -111,7 +111,7 @@ export function Field({
         )}
         {children}
         {error && (
-          <p id={errorId} className="text-sm text-destructive">
+          <p id={errorId} className="text-sm text-error">
             {error}
           </p>
         )}

--- a/src/components/lv1/FieldSet/FieldSet.tsx
+++ b/src/components/lv1/FieldSet/FieldSet.tsx
@@ -81,7 +81,7 @@ export function FieldSet({
           {children}
         </div>
         {error && (
-          <p id={errorId} className="mt-4 text-sm text-destructive">
+          <p id={errorId} className="mt-4 text-sm text-error">
             {error}
           </p>
         )}

--- a/src/components/lv1/Input/Input.stories.tsx
+++ b/src/components/lv1/Input/Input.stories.tsx
@@ -19,7 +19,7 @@ const meta: Meta<typeof Input> = {
       },
     },
     isError: {
-      description: 'Displays the input in an error state with destructive border and ring.',
+      description: 'Displays the input in an error state with error border and ring.',
       control: 'boolean',
       table: {
         type: { summary: 'boolean' },

--- a/src/components/lv1/Input/Input.tsx
+++ b/src/components/lv1/Input/Input.tsx
@@ -71,7 +71,7 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
         className={cn(
           inputWrapperVariants({ size }),
           isError
-            ? 'border-destructive bg-destructive-subtle has-focus-visible:ring-destructive'
+            ? 'border-error bg-error-subtle has-focus-visible:ring-error'
             : 'border-border-strong',
           disabled ? 'cursor-not-allowed opacity-50' : 'cursor-text',
           className,

--- a/src/components/lv1/Radio/Radio.stories.tsx
+++ b/src/components/lv1/Radio/Radio.stories.tsx
@@ -33,7 +33,7 @@ const meta: Meta<typeof Radio> = {
       },
     },
     isError: {
-      description: 'Displays the radio in an error state with destructive border and ring.',
+      description: 'Displays the radio in an error state with error border and ring.',
       control: 'boolean',
       table: {
         type: { summary: 'boolean' },

--- a/src/components/lv1/Radio/Radio.tsx
+++ b/src/components/lv1/Radio/Radio.tsx
@@ -122,7 +122,7 @@ export const Radio = forwardRef<ElementRef<typeof RadioGroupPrimitive.Item>, Rad
           id={id}
           className={cn(
             radioVariants({ size }),
-            isError && 'border-destructive bg-destructive-subtle focus-visible:ring-destructive',
+            isError && 'border-error bg-error-subtle focus-visible:ring-error',
           )}
           aria-invalid={isError || undefined}
           disabled={disabled}

--- a/src/components/lv1/Select/Select.stories.tsx
+++ b/src/components/lv1/Select/Select.stories.tsx
@@ -28,8 +28,7 @@ const meta: Meta<typeof SelectTrigger> = {
       },
     },
     isError: {
-      description:
-        'Displays the select trigger in an error state with destructive border and ring.',
+      description: 'Displays the select trigger in an error state with error border and ring.',
       control: 'boolean',
       table: {
         type: { summary: 'boolean' },

--- a/src/components/lv1/Select/Select.tsx
+++ b/src/components/lv1/Select/Select.tsx
@@ -57,7 +57,7 @@ const SelectTrigger = forwardRef<ComponentRef<typeof SelectPrimitive.Trigger>, S
         className={cn(
           selectTriggerVariants({ size }),
           isError
-            ? 'border-destructive bg-destructive-subtle focus-visible:ring-destructive'
+            ? 'border-error bg-error-subtle focus-visible:ring-error'
             : 'border-border-strong',
           className,
         )}

--- a/src/components/lv1/Switch/Switch.stories.tsx
+++ b/src/components/lv1/Switch/Switch.stories.tsx
@@ -42,7 +42,7 @@ const meta: Meta<typeof Switch> = {
       },
     },
     isError: {
-      description: 'Displays the switch in an error state with destructive border and ring.',
+      description: 'Displays the switch in an error state with error border and ring.',
       control: 'boolean',
       table: {
         type: { summary: 'boolean' },

--- a/src/components/lv1/Switch/Switch.tsx
+++ b/src/components/lv1/Switch/Switch.tsx
@@ -13,7 +13,7 @@ import { type SwitchVariants, switchThumbVariants, switchVariants } from '../../
 export interface SwitchProps
   extends Omit<ComponentPropsWithoutRef<typeof SwitchPrimitive.Root>, 'size'>,
     SwitchVariants {
-  /** Displays the switch in an error state with destructive border and ring. */
+  /** Displays the switch in an error state with error border and ring. */
   isError?: boolean
   /** Label text displayed next to the switch. Automatically associates via id. */
   label?: ReactNode
@@ -75,7 +75,7 @@ export const Switch = forwardRef<ElementRef<typeof SwitchPrimitive.Root>, Switch
             'group',
             switchVariants({ size }),
             isError &&
-              'border-destructive bg-destructive-subtle focus-visible:ring-destructive data-[state=checked]:border-destructive data-[state=checked]:bg-destructive',
+              'border-error bg-error-subtle focus-visible:ring-error data-[state=checked]:border-error data-[state=checked]:bg-error',
           )}
           aria-invalid={isError || undefined}
           aria-describedby={ariaDescribedBy}

--- a/src/components/lv1/Textarea/Textarea.stories.tsx
+++ b/src/components/lv1/Textarea/Textarea.stories.tsx
@@ -19,7 +19,7 @@ const meta: Meta<typeof Textarea> = {
       },
     },
     isError: {
-      description: 'Displays the textarea in an error state with destructive border and ring.',
+      description: 'Displays the textarea in an error state with error border and ring.',
       control: 'boolean',
       table: {
         type: { summary: 'boolean' },

--- a/src/components/lv1/Textarea/Textarea.tsx
+++ b/src/components/lv1/Textarea/Textarea.tsx
@@ -36,7 +36,7 @@ export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
         className={cn(
           textareaVariants({ size }),
           isError
-            ? 'border-destructive bg-destructive-subtle focus-visible:ring-destructive'
+            ? 'border-error bg-error-subtle focus-visible:ring-error'
             : 'border-border-strong',
           className,
         )}

--- a/src/core/tokens/base.css
+++ b/src/core/tokens/base.css
@@ -60,11 +60,26 @@
   /* Inverse */
   --color-inverse-foreground: var(--color-inverse-foreground);
 
-  /* States */
+  /* States — each provides { base, hover, foreground, subtle } */
+  --color-error: var(--color-error);
+  --color-error-hover: var(--color-error-hover);
+  --color-error-foreground: var(--color-error-foreground);
+  --color-error-subtle: var(--color-error-subtle);
+
   --color-success: var(--color-success);
   --color-success-hover: var(--color-success-hover);
+  --color-success-foreground: var(--color-success-foreground);
+  --color-success-subtle: var(--color-success-subtle);
+
   --color-warning: var(--color-warning);
   --color-warning-hover: var(--color-warning-hover);
+  --color-warning-foreground: var(--color-warning-foreground);
+  --color-warning-subtle: var(--color-warning-subtle);
+
+  --color-info: var(--color-info);
+  --color-info-hover: var(--color-info-hover);
+  --color-info-foreground: var(--color-info-foreground);
+  --color-info-subtle: var(--color-info-subtle);
 
   /* ===== Primitive Scales (for theme authoring & docs) ===== */
 

--- a/src/core/tokens/semantic.css
+++ b/src/core/tokens/semantic.css
@@ -36,7 +36,7 @@
   --color-solid-foreground: var(--alabaster-100);
   --color-solid-foreground-hover: var(--alabaster-300);
 
-  /* Destructive */
+  /* Destructive — destructive actions (delete, remove). Shares vermillion with `error`. */
   --color-destructive: var(--vermillion-600);
   --color-destructive-hover: var(--vermillion-700);
   --color-destructive-foreground: var(--paper-white);
@@ -57,11 +57,37 @@
   /* Inverse (for content on dark-background containers) */
   --color-inverse-foreground: var(--paper-white);
 
-  /* States */
-  --color-success: var(--green-500);
-  --color-success-hover: var(--green-600);
-  --color-warning: var(--amber-500);
-  --color-warning-hover: var(--amber-600);
+  /*
+   * State tokens — each provides { base, hover, foreground, subtle }.
+   *   base       : main color (saturated)         — fills, borders, icons, text
+   *   hover      : darker/lighter sibling of base — interactive hover
+   *   foreground : on-base text/icon color        — readable atop base
+   *   subtle     : faint tinted background        — soft state surfaces
+   */
+
+  /* Error — form validation, error notifications (visually shares vermillion with destructive) */
+  --color-error: var(--vermillion-600);
+  --color-error-hover: var(--vermillion-700);
+  --color-error-foreground: var(--paper-white);
+  --color-error-subtle: var(--vermillion-50);
+
+  /* Success */
+  --color-success: var(--green-600);
+  --color-success-hover: var(--green-700);
+  --color-success-foreground: var(--paper-white);
+  --color-success-subtle: var(--green-50);
+
+  /* Warning */
+  --color-warning: var(--amber-600);
+  --color-warning-hover: var(--amber-700);
+  --color-warning-foreground: var(--paper-white);
+  --color-warning-subtle: var(--amber-50);
+
+  /* Info — references blue directly so themes that retune `primary` do not affect info */
+  --color-info: var(--blue-600);
+  --color-info-hover: var(--blue-700);
+  --color-info-foreground: var(--paper-white);
+  --color-info-subtle: var(--blue-50);
 }
 
 /* Dark mode - System preference fallback */
@@ -96,11 +122,27 @@
 
     --color-inverse-foreground: var(--paper-white-inv);
 
-    /* States */
-    --color-success: var(--green-400);
-    --color-success-hover: var(--green-300);
-    --color-warning: var(--amber-400);
-    --color-warning-hover: var(--amber-300);
+    /* State tokens — dark mode mappings */
+
+    --color-error: var(--vermillion-500);
+    --color-error-hover: var(--vermillion-400);
+    --color-error-foreground: var(--paper-white-inv);
+    --color-error-subtle: var(--vermillion-900);
+
+    --color-success: var(--green-500);
+    --color-success-hover: var(--green-400);
+    --color-success-foreground: var(--paper-white-inv);
+    --color-success-subtle: var(--green-900);
+
+    --color-warning: var(--amber-500);
+    --color-warning-hover: var(--amber-400);
+    --color-warning-foreground: var(--paper-white-inv);
+    --color-warning-subtle: var(--amber-900);
+
+    --color-info: var(--blue-500);
+    --color-info-hover: var(--blue-400);
+    --color-info-foreground: var(--paper-white-inv);
+    --color-info-subtle: var(--blue-900);
   }
 }
 
@@ -135,9 +177,25 @@
 
   --color-inverse-foreground: var(--paper-white-inv);
 
-  /* States */
-  --color-success: var(--green-400);
-  --color-success-hover: var(--green-300);
-  --color-warning: var(--amber-400);
-  --color-warning-hover: var(--amber-300);
+  /* State tokens — dark mode mappings */
+
+  --color-error: var(--vermillion-500);
+  --color-error-hover: var(--vermillion-400);
+  --color-error-foreground: var(--paper-white-inv);
+  --color-error-subtle: var(--vermillion-900);
+
+  --color-success: var(--green-500);
+  --color-success-hover: var(--green-400);
+  --color-success-foreground: var(--paper-white-inv);
+  --color-success-subtle: var(--green-900);
+
+  --color-warning: var(--amber-500);
+  --color-warning-hover: var(--amber-400);
+  --color-warning-foreground: var(--paper-white-inv);
+  --color-warning-subtle: var(--amber-900);
+
+  --color-info: var(--blue-500);
+  --color-info-hover: var(--blue-400);
+  --color-info-foreground: var(--paper-white-inv);
+  --color-info-subtle: var(--blue-900);
 }

--- a/src/docs/Color.stories.tsx
+++ b/src/docs/Color.stories.tsx
@@ -144,23 +144,94 @@ export const Colors: Story = {
         <ColorRow name="ring" description="Focus ring color" className="bg-ring" />
       </div>
 
-      <SubsectionTitle>Status</SubsectionTitle>
+      <SubsectionTitle>State Tokens</SubsectionTitle>
+      <p className="text-sm text-foreground-muted mb-3">
+        Each state provides four tokens — <code>base</code> (main color), <code>hover</code>{' '}
+        (interactive sibling), <code>foreground</code> (text on base) and <code>subtle</code> (faint
+        tinted background).
+      </p>
+
+      <SubsectionTitle>Error</SubsectionTitle>
+      <p className="text-sm text-foreground-muted mb-3">
+        Form validation and error notifications. Visually shares vermillion with{' '}
+        <code>destructive</code>, but is semantically distinct.
+      </p>
       <div className="border border-border rounded-xl px-5">
-        <ColorRow name="success" description="Positive actions and states" className="bg-success" />
+        <ColorRow name="error" description="Error base color" className="bg-error" />
         <ColorRow
-          name="warning"
-          description="Caution states that need attention"
-          className="bg-warning"
+          name="error-hover"
+          description="Hover state for error"
+          className="bg-error-hover"
         />
         <ColorRow
-          name="destructive"
-          description="Destructive actions and error states"
-          className="bg-destructive"
+          name="error-foreground"
+          description="Text on error base"
+          className="bg-error-foreground border border-border"
         />
         <ColorRow
-          name="destructive-subtle"
+          name="error-subtle"
           description="Subtle background for error states"
-          className="bg-destructive-subtle border border-border"
+          className="bg-error-subtle border border-border"
+        />
+      </div>
+
+      <SubsectionTitle>Success</SubsectionTitle>
+      <div className="border border-border rounded-xl px-5">
+        <ColorRow name="success" description="Success base color" className="bg-success" />
+        <ColorRow
+          name="success-hover"
+          description="Hover state for success"
+          className="bg-success-hover"
+        />
+        <ColorRow
+          name="success-foreground"
+          description="Text on success base"
+          className="bg-success-foreground border border-border"
+        />
+        <ColorRow
+          name="success-subtle"
+          description="Subtle background for success states"
+          className="bg-success-subtle border border-border"
+        />
+      </div>
+
+      <SubsectionTitle>Warning</SubsectionTitle>
+      <div className="border border-border rounded-xl px-5">
+        <ColorRow name="warning" description="Warning base color" className="bg-warning" />
+        <ColorRow
+          name="warning-hover"
+          description="Hover state for warning"
+          className="bg-warning-hover"
+        />
+        <ColorRow
+          name="warning-foreground"
+          description="Text on warning base"
+          className="bg-warning-foreground border border-border"
+        />
+        <ColorRow
+          name="warning-subtle"
+          description="Subtle background for warning states"
+          className="bg-warning-subtle border border-border"
+        />
+      </div>
+
+      <SubsectionTitle>Info</SubsectionTitle>
+      <p className="text-sm text-foreground-muted mb-3">
+        Informational notifications. References blue directly so themes that retune{' '}
+        <code>primary</code> do not affect info.
+      </p>
+      <div className="border border-border rounded-xl px-5">
+        <ColorRow name="info" description="Info base color" className="bg-info" />
+        <ColorRow name="info-hover" description="Hover state for info" className="bg-info-hover" />
+        <ColorRow
+          name="info-foreground"
+          description="Text on info base"
+          className="bg-info-foreground border border-border"
+        />
+        <ColorRow
+          name="info-subtle"
+          description="Subtle background for info states"
+          className="bg-info-subtle border border-border"
         />
       </div>
 

--- a/src/docs/Color.stories.tsx
+++ b/src/docs/Color.stories.tsx
@@ -235,6 +235,58 @@ export const Colors: Story = {
         />
       </div>
 
+      <SubsectionTitle>Filled Treatments (a11y audit)</SubsectionTitle>
+      <p className="text-sm text-foreground-muted mb-3">
+        Each row shows a state's <code>bg-X</code> with <code>text-X-foreground</code> applied — the
+        canonical "filled" treatment used by Toast / Alert / Button. Toggle Storybook between light
+        and dark themes to verify text remains readable in both modes.
+      </p>
+      <div className="flex flex-col gap-2">
+        {(
+          [
+            { name: 'destructive', bg: 'bg-destructive', fg: 'text-destructive-foreground' },
+            { name: 'error', bg: 'bg-error', fg: 'text-error-foreground' },
+            { name: 'success', bg: 'bg-success', fg: 'text-success-foreground' },
+            { name: 'warning', bg: 'bg-warning', fg: 'text-warning-foreground' },
+            { name: 'info', bg: 'bg-info', fg: 'text-info-foreground' },
+          ] as const
+        ).map((s) => (
+          <div
+            key={s.name}
+            className={`flex items-center gap-3 rounded-lg px-4 py-3 ${s.bg} ${s.fg}`}
+          >
+            <span className="font-mono text-xs opacity-70">{s.name}</span>
+            <span className="text-sm font-medium">The quick brown fox jumps over the lazy dog</span>
+          </div>
+        ))}
+      </div>
+
+      <SubsectionTitle>Subtle Treatments (a11y audit)</SubsectionTitle>
+      <p className="text-sm text-foreground-muted mb-3">
+        Each row shows a state's <code>bg-X-subtle</code> with <code>text-X</code> applied — the
+        "soft" treatment used by Input error background. Verify text remains readable in both
+        themes.
+      </p>
+      <div className="flex flex-col gap-2">
+        {(
+          [
+            { name: 'destructive', bg: 'bg-destructive-subtle', fg: 'text-destructive' },
+            { name: 'error', bg: 'bg-error-subtle', fg: 'text-error' },
+            { name: 'success', bg: 'bg-success-subtle', fg: 'text-success' },
+            { name: 'warning', bg: 'bg-warning-subtle', fg: 'text-warning' },
+            { name: 'info', bg: 'bg-info-subtle', fg: 'text-info' },
+          ] as const
+        ).map((s) => (
+          <div
+            key={s.name}
+            className={`flex items-center gap-3 rounded-lg border border-border px-4 py-3 ${s.bg} ${s.fg}`}
+          >
+            <span className="font-mono text-xs opacity-70">{s.name}</span>
+            <span className="text-sm font-medium">The quick brown fox jumps over the lazy dog</span>
+          </div>
+        ))}
+      </div>
+
       <SectionTitle>Primitive Palette</SectionTitle>
       <p className="text-sm text-foreground-muted mb-3">
         Core brand colors inspired by Japanese calligraphy. These are fixed values that do not


### PR DESCRIPTION
## Summary

Toast (#45) needs `default / success / error / warning` variants and likely `info` too. Before implementing, this PR fills in the underlying token system so Toast and any future Alert/Banner have a stable, consistent foundation to build on.

## Why this is needed

The state semantics were unevenly defined:

| State | base | hover | foreground | subtle |
|---|:-:|:-:|:-:|:-:|
| `destructive` | ✅ | ✅ | ✅ | ✅ |
| `success` | ✅ | ✅ | ❌ | ❌ |
| `warning` | ✅ | ✅ | ❌ | ❌ |
| `error` | ❌ | ❌ | ❌ | ❌ |
| `info` | ❌ | ❌ | ❌ | ❌ |

Worse, the same `destructive` token was being asked to mean both _destructive action_ (Button delete) and _form error state_ (Input/Field). This PR separates those concerns and rounds out the missing tokens.

## Token model

A 3-layer hierarchy. Components consume only Layer 2.

```
┌─ Layer 1: Primitive (raw color scales — same in light/dark) ─────────┐
│   vermillion-*   green-*   amber-*   blue-*   sumi-*   ...           │
└──────────────┬─────────┬──────────┬─────────┬───────────────────────┘
               │         │          │         │
┌─ Layer 2: Semantic (meaning — light/dark mapping happens here) ──────┐
│                                                                       │
│   destructive ◀── vermillion ──▶ error                                │
│   success     ◀── green                                               │
│   warning     ◀── amber                                               │
│   info        ◀── blue (independent of `primary`)                     │
│                                                                       │
│   each provides: { base, hover, foreground, subtle }                  │
└──────────────┬───────────────────────────────────────────────────────┘
               │
┌─ Layer 3: Components (consume semantic only) ────────────────────────┐
│                                                                       │
│   destructive  → Button(destructive), Badge(destructive)              │
│   error        → Input/Textarea/Select isError, Field error msg + *   │
│   success      → (Toast, Alert — upcoming)                            │
│   warning      → (Toast, Alert — upcoming)                            │
│   info         → (Toast, Alert — upcoming)                            │
└──────────────────────────────────────────────────────────────────────┘
```

### The 4-set token shape

Every state defines four tokens with consistent roles:

| Token | Role | Typical use |
|---|---|---|
| `base` | main color (saturated) | fills, borders, icons, text |
| `hover` | base's interactive sibling | hover/active state of `base` |
| `foreground` | on-`base` text/icon color | readable text atop `base` |
| `subtle` | faint tinted background | soft state surfaces (e.g. error input bg) |

Two natural pairings:
- **`base` ↔ `foreground`** → "filled" treatment (e.g. solid Toast)
- **`subtle` ↔ `base`** → "soft" treatment (e.g. Input error background with `base` border)

### `error` vs `destructive`

They share the **same primitive** (vermillion) so visually identical, but **semantically distinct**:

- `destructive` — destructive _actions_ (Delete, Remove). Used by Button/Badge.
- `error` — _state_ (form validation, error notifications). Used by Input/Textarea/Select/Field/Toast(error).

If we ever want error red ≠ destructive red, only the semantic mapping needs to change.

### `info` independence from `primary`

`info` references `blue-*` directly rather than `primary-*`. This way themes that retune `primary` (e.g. seasonal themes) don't accidentally drift `info`'s meaning.

## Changes

**Token definitions:**
- `src/core/tokens/semantic.css` — add `error-*` and `info-*`; add `foreground` / `subtle` to `success` and `warning`; align all state base shades to `600` (light) / `500` (dark)
- `src/core/tokens/base.css` — register the new tokens in `@theme` so Tailwind utilities (`bg-error-subtle`, etc.) work

**Component remap (form error → `error` token):**
- `Input.tsx`, `Textarea.tsx`, `Select.tsx` — `border-destructive bg-destructive-subtle ring-destructive` → `border-error bg-error-subtle ring-error`
- `Field.tsx` — required `*` and error message: `text-destructive` → `text-error`

**Docs:**
- `Color.stories.tsx` — replace the old "Status" section with a per-state subsection that surfaces all 4 tokens
- `Input/Textarea/Select.stories.tsx` — update `isError` description text

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean
- [x] `pnpm vitest` — 85/85 pass
- [x] `pnpm test:vrt` — **98/98 pass with zero diffs** (vermillion is shared, so form components' error visuals are pixel-identical)
- [ ] Manually verify the new Color story renders the four-token grid for each state in Storybook (light + dark)
- [ ] Confirm `success` / `warning` shade shift (500→600 light, 400→500 dark) is acceptable — no component currently surfaces these visually outside the docs page

## Follow-up

- #45 (Toast) — unblocked by this PR; will consume `success-*`, `error-*`, `warning-*`, optionally `info-*`

🤖 Generated with [Claude Code](https://claude.com/claude-code)