### PR TITLE
refactor: unify inverse/inv naming to inverted

### DIFF
--- a/.changeset/unify-inverted-naming.md
+++ b/.changeset/unify-inverted-naming.md
@@ -1,0 +1,32 @@
+---
+'@yasmro/schatten': minor
+---
+
+Unify naming of "inverted" color treatment across tokens, primitives, and
+component variants. Previously the codebase had three forms — `inverse`
+(semantic tokens, Spinner variant), `inverted` (Button / Text / Callout /
+Toast variants), and the `-inv` suffix (primitive variables) — for the
+same concept. They are now all `inverted`.
+
+**Token renames** (Tailwind utilities, CSS custom properties):
+
+- `--color-inverse-foreground{,-muted,-subtle}` →
+  `--color-inverted-foreground{,-muted,-subtle}`
+- Tailwind utilities: `bg-inverse-foreground` / `text-inverse-foreground`
+  / `border-inverse-foreground` (and `-muted` / `-subtle` variants) →
+  `bg-inverted-foreground` etc.
+
+**Component variant renames:**
+
+- `Spinner` `variant="inverse"` → `variant="inverted"`
+
+**Primitive renames** (internal — components should not consume these
+directly per the layer rules in `state-token-guideline.md`):
+
+- `--ink-{black,dark,medium,light,subtle}-inv` →
+  `--ink-{...}-inverted`
+- `--paper-{white,warm,cream}-inv` → `--paper-{...}-inverted`
+
+Other component variant names (`Button` `variant="inverted"`, `Text`
+`color="inverted" | "inverted-muted" | "inverted-subtle"`) were already
+on the `inverted` form and are unchanged.

--- a/.claude/rules/state-token-guideline.md
+++ b/.claude/rules/state-token-guideline.md
@@ -71,9 +71,9 @@ Each state shifts shades between modes:
 | Mode | `base` | `hover` | `foreground` | `subtle` |
 |---|---|---|---|---|
 | Light | `*-600` | `*-700` | `paper-white` | `*-50` |
-| Dark | `*-500` | `*-400` | `paper-white-inv` | `*-900` |
+| Dark | `*-500` | `*-400` | `paper-white-inverted` | `*-900` |
 
-The dark-mode `foreground = paper-white-inv` (`#1a1a1a`) is intentional: in dark mode the
+The dark-mode `foreground = paper-white-inverted` (`#1a1a1a`) is intentional: in dark mode the
 state `base` shifts brighter (e.g. `vermillion-500`), and dark text on a bright saturated
 fill achieves higher WCAG contrast than white-on-bright. Verify visually in `Foundation/Color`
 → "Filled Treatments (a11y audit)" before introducing new state-driven UI.

--- a/src/components/lv1/Button/Button.tsx
+++ b/src/components/lv1/Button/Button.tsx
@@ -107,7 +107,7 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
             label="Loading"
             variant={
               variant === 'primary' || variant === 'destructive' || variant === 'inverted'
-                ? 'inverse'
+                ? 'inverted'
                 : 'default'
             }
           />

--- a/src/components/lv1/Callout/Callout.test.tsx
+++ b/src/components/lv1/Callout/Callout.test.tsx
@@ -112,10 +112,10 @@ describe('Callout', () => {
       <Callout variant="error" treatment="solid" onClose={() => {}} title="Failed" />,
     )
     const closeBtn = container.querySelector('button[aria-label="Close"]')
-    // The inverted Button variant adds `text-inverse-foreground`; the
+    // The inverted Button variant adds `text-inverted-foreground`; the
     // tertiary variant uses `text-foreground`. Asserting against the
     // inverted token is enough to discriminate.
-    expect(closeBtn?.className).toContain('text-inverse-foreground')
+    expect(closeBtn?.className).toContain('text-inverted-foreground')
   })
 
   it('uses the tertiary Button variant for the close button on subtle treatment', () => {
@@ -124,7 +124,7 @@ describe('Callout', () => {
     )
     const closeBtn = container.querySelector('button[aria-label="Close"]')
     expect(closeBtn?.className).toContain('text-foreground')
-    expect(closeBtn?.className).not.toContain('text-inverse-foreground')
+    expect(closeBtn?.className).not.toContain('text-inverted-foreground')
   })
 
   it('passes through arbitrary HTML attributes (role, data-*)', () => {

--- a/src/components/lv1/Spinner/Spinner.stories.tsx
+++ b/src/components/lv1/Spinner/Spinner.stories.tsx
@@ -12,9 +12,9 @@ const meta: Meta<typeof Spinner> = {
     variant: {
       description: 'Color variant of the spinner.',
       control: 'select',
-      options: ['default', 'inverse'],
+      options: ['default', 'inverted'],
       table: {
-        type: { summary: '"default" | "inverse"' },
+        type: { summary: '"default" | "inverted"' },
         defaultValue: { summary: 'default' },
       },
     },
@@ -84,8 +84,8 @@ export const OnDarkBackground: Story = {
   name: 'On Dark Background',
   render: () => (
     <div className="flex items-center gap-8 rounded-lg bg-solid p-8">
-      <Spinner variant="inverse" type="default" />
-      <Spinner variant="inverse" type="ripple" />
+      <Spinner variant="inverted" type="default" />
+      <Spinner variant="inverted" type="ripple" />
     </div>
   ),
 }

--- a/src/components/lv1/Toast/Toast.tsx
+++ b/src/components/lv1/Toast/Toast.tsx
@@ -38,7 +38,7 @@ export function ToastItem({ toast }: ToastItemProps) {
   }
 
   // Solid toasts have a saturated fill, so the action/close button needs an
-  // inverse foreground to stay legible against the bg.
+  // inverted foreground to stay legible against the bg.
   const buttonVariant = toast.treatment === 'solid' ? 'inverted' : 'tertiary'
 
   const Icon = iconByVariant[toast.variant ?? 'default']

--- a/src/core/tokens/base.css
+++ b/src/core/tokens/base.css
@@ -57,10 +57,10 @@
   --color-ring: var(--color-ring);
   --color-ring-offset: var(--color-ring-offset);
 
-  /* Inverse */
-  --color-inverse-foreground: var(--color-inverse-foreground);
-  --color-inverse-foreground-muted: var(--color-inverse-foreground-muted);
-  --color-inverse-foreground-subtle: var(--color-inverse-foreground-subtle);
+  /* Inverted */
+  --color-inverted-foreground: var(--color-inverted-foreground);
+  --color-inverted-foreground-muted: var(--color-inverted-foreground-muted);
+  --color-inverted-foreground-subtle: var(--color-inverted-foreground-subtle);
 
   /* States — each provides { base, hover, foreground, subtle } */
   --color-error: var(--color-error);

--- a/src/core/tokens/primitives.css
+++ b/src/core/tokens/primitives.css
@@ -44,16 +44,16 @@
   --paper-cream: #f0ede8;
 
   /* Ink inverted (for dark mode semantic mapping) */
-  --ink-black-inv: var(--alabaster-200);
-  --ink-dark-inv: var(--alabaster-300);
-  --ink-medium-inv: var(--alabaster-400);
-  --ink-light-inv: var(--alabaster-500);
-  --ink-subtle-inv: var(--alabaster-600);
+  --ink-black-inverted: var(--alabaster-200);
+  --ink-dark-inverted: var(--alabaster-300);
+  --ink-medium-inverted: var(--alabaster-400);
+  --ink-light-inverted: var(--alabaster-500);
+  --ink-subtle-inverted: var(--alabaster-600);
 
   /* Paper inverted (for dark mode semantic mapping) */
-  --paper-white-inv: #1a1a1a;
-  --paper-warm-inv: #1e1e1c;
-  --paper-cream-inv: #44403a;
+  --paper-white-inverted: #1a1a1a;
+  --paper-warm-inverted: #1e1e1c;
+  --paper-cream-inverted: #44403a;
 
   /* Accent: Vermillion (Japanese traditional, brand anchor: 600 ≈ #c53d43) */
   --vermillion-50: oklch(0.98 0.02 22);

--- a/src/core/tokens/semantic.css
+++ b/src/core/tokens/semantic.css
@@ -60,15 +60,15 @@
   --color-ring-offset: var(--paper-warm);
 
   /*
-   * Inverse foreground tiers — for text on saturated / dark-background
+   * Inverted foreground tiers — for text on saturated / dark-background
    * containers (solid Toast / Callout, primary-colored fills, …).
    * Each tier becomes progressively less prominent against the
    * saturated background, mirroring the foreground / -muted / -subtle
    * hierarchy.
    */
-  --color-inverse-foreground: var(--paper-white);
-  --color-inverse-foreground-muted: var(--alabaster-300);
-  --color-inverse-foreground-subtle: var(--alabaster-400);
+  --color-inverted-foreground: var(--paper-white);
+  --color-inverted-foreground-muted: var(--alabaster-300);
+  --color-inverted-foreground-subtle: var(--alabaster-400);
 
   /*
    * State tokens — each provides { base, hover, foreground, subtle }.
@@ -106,13 +106,13 @@
 /* Dark mode - System preference fallback */
 @media (prefers-color-scheme: dark) {
   :root:not(.light) {
-    --color-background: var(--paper-warm-inv);
-    --color-surface: var(--paper-white-inv);
-    --color-surface-hover: var(--paper-cream-inv);
+    --color-background: var(--paper-warm-inverted);
+    --color-surface: var(--paper-white-inverted);
+    --color-surface-hover: var(--paper-cream-inverted);
 
-    --color-foreground: var(--ink-black-inv);
-    --color-foreground-muted: var(--ink-light-inv);
-    --color-foreground-subtle: var(--ink-subtle-inv);
+    --color-foreground: var(--ink-black-inverted);
+    --color-foreground-muted: var(--ink-light-inverted);
+    --color-foreground-subtle: var(--ink-subtle-inverted);
 
     --color-solid: var(--alabaster-300);
     --color-solid-hover: var(--alabaster-100);
@@ -121,55 +121,55 @@
 
     --color-destructive: var(--vermillion-500);
     --color-destructive-hover: var(--vermillion-400);
-    --color-destructive-foreground: var(--paper-white-inv);
+    --color-destructive-foreground: var(--paper-white-inverted);
     --color-destructive-subtle: var(--vermillion-900);
 
     --color-accent: var(--vermillion-400);
     --color-accent-foreground: var(--gray-950);
 
     --color-border: var(--gray-700);
-    --color-border-strong: var(--ink-black-inv);
+    --color-border-strong: var(--ink-black-inverted);
 
-    --color-ring: var(--ink-black-inv);
-    --color-ring-offset: var(--paper-warm-inv);
+    --color-ring: var(--ink-black-inverted);
+    --color-ring-offset: var(--paper-warm-inverted);
 
-    --color-inverse-foreground: var(--paper-white-inv);
-    --color-inverse-foreground-muted: var(--alabaster-700);
-    --color-inverse-foreground-subtle: var(--alabaster-600);
+    --color-inverted-foreground: var(--paper-white-inverted);
+    --color-inverted-foreground-muted: var(--alabaster-700);
+    --color-inverted-foreground-subtle: var(--alabaster-600);
 
     /* State tokens — dark mode mappings */
 
     --color-error: var(--vermillion-500);
     --color-error-hover: var(--vermillion-400);
-    --color-error-foreground: var(--paper-white-inv);
+    --color-error-foreground: var(--paper-white-inverted);
     --color-error-subtle: var(--vermillion-900);
 
     --color-success: var(--green-500);
     --color-success-hover: var(--green-400);
-    --color-success-foreground: var(--paper-white-inv);
+    --color-success-foreground: var(--paper-white-inverted);
     --color-success-subtle: var(--green-900);
 
     --color-warning: var(--amber-500);
     --color-warning-hover: var(--amber-400);
-    --color-warning-foreground: var(--paper-white-inv);
+    --color-warning-foreground: var(--paper-white-inverted);
     --color-warning-subtle: var(--amber-900);
 
     --color-info: var(--blue-500);
     --color-info-hover: var(--blue-400);
-    --color-info-foreground: var(--paper-white-inv);
+    --color-info-foreground: var(--paper-white-inverted);
     --color-info-subtle: var(--blue-900);
   }
 }
 
 /* Dark mode - Explicit class */
 .dark {
-  --color-background: var(--paper-warm-inv);
-  --color-surface: var(--paper-white-inv);
-  --color-surface-hover: var(--paper-cream-inv);
+  --color-background: var(--paper-warm-inverted);
+  --color-surface: var(--paper-white-inverted);
+  --color-surface-hover: var(--paper-cream-inverted);
 
-  --color-foreground: var(--ink-black-inv);
-  --color-foreground-muted: var(--ink-light-inv);
-  --color-foreground-subtle: var(--ink-subtle-inv);
+  --color-foreground: var(--ink-black-inverted);
+  --color-foreground-muted: var(--ink-light-inverted);
+  --color-foreground-subtle: var(--ink-subtle-inverted);
 
   --color-solid: var(--alabaster-300);
   --color-solid-hover: var(--alabaster-100);
@@ -178,41 +178,41 @@
 
   --color-destructive: var(--vermillion-500);
   --color-destructive-hover: var(--vermillion-400);
-  --color-destructive-foreground: var(--paper-white-inv);
+  --color-destructive-foreground: var(--paper-white-inverted);
   --color-destructive-subtle: var(--vermillion-900);
 
   --color-accent: var(--vermillion-400);
   --color-accent-foreground: var(--gray-950);
 
   --color-border: var(--gray-700);
-  --color-border-strong: var(--ink-black-inv);
+  --color-border-strong: var(--ink-black-inverted);
 
-  --color-ring: var(--ink-black-inv);
-  --color-ring-offset: var(--paper-warm-inv);
+  --color-ring: var(--ink-black-inverted);
+  --color-ring-offset: var(--paper-warm-inverted);
 
-  --color-inverse-foreground: var(--paper-white-inv);
-  --color-inverse-foreground-muted: var(--alabaster-700);
-  --color-inverse-foreground-subtle: var(--alabaster-600);
+  --color-inverted-foreground: var(--paper-white-inverted);
+  --color-inverted-foreground-muted: var(--alabaster-700);
+  --color-inverted-foreground-subtle: var(--alabaster-600);
 
   /* State tokens — dark mode mappings */
 
   --color-error: var(--vermillion-500);
   --color-error-hover: var(--vermillion-400);
-  --color-error-foreground: var(--paper-white-inv);
+  --color-error-foreground: var(--paper-white-inverted);
   --color-error-subtle: var(--vermillion-900);
 
   --color-success: var(--green-500);
   --color-success-hover: var(--green-400);
-  --color-success-foreground: var(--paper-white-inv);
+  --color-success-foreground: var(--paper-white-inverted);
   --color-success-subtle: var(--green-900);
 
   --color-warning: var(--amber-500);
   --color-warning-hover: var(--amber-400);
-  --color-warning-foreground: var(--paper-white-inv);
+  --color-warning-foreground: var(--paper-white-inverted);
   --color-warning-subtle: var(--amber-900);
 
   --color-info: var(--blue-500);
   --color-info-hover: var(--blue-400);
-  --color-info-foreground: var(--paper-white-inv);
+  --color-info-foreground: var(--paper-white-inverted);
   --color-info-subtle: var(--blue-900);
 }

--- a/src/docs/Color.stories.tsx
+++ b/src/docs/Color.stories.tsx
@@ -99,26 +99,26 @@ export const Colors: Story = {
         />
       </div>
 
-      <SubsectionTitle>Inverse Foreground</SubsectionTitle>
+      <SubsectionTitle>Inverted Foreground</SubsectionTitle>
       <p className="text-sm text-foreground-muted mb-3">
         For text placed on saturated / dark-background containers (solid Toast or Callout, primary
         fills, …). Mirrors the foreground hierarchy.
       </p>
       <div className="border border-border rounded-xl px-5">
         <ColorRow
-          name="inverse-foreground"
+          name="inverted-foreground"
           description="Primary text on saturated surface"
-          className="bg-inverse-foreground border border-border"
+          className="bg-inverted-foreground border border-border"
         />
         <ColorRow
-          name="inverse-foreground-muted"
+          name="inverted-foreground-muted"
           description="Secondary / helper text on saturated surface"
-          className="bg-inverse-foreground-muted border border-border"
+          className="bg-inverted-foreground-muted border border-border"
         />
         <ColorRow
-          name="inverse-foreground-subtle"
+          name="inverted-foreground-subtle"
           description="Tertiary text on saturated surface"
-          className="bg-inverse-foreground-subtle border border-border"
+          className="bg-inverted-foreground-subtle border border-border"
         />
       </div>
 

--- a/src/variants/button.ts
+++ b/src/variants/button.ts
@@ -13,10 +13,10 @@ export const buttonVariants = cva(
         /**
          * Borderless ghost button intended for use *on top of* a saturated
          * surface (e.g. solid Toast, primary-colored banner). Inherits the
-         * inverse foreground color and hover-tints with a translucent
+         * inverted foreground color and hover-tints with a translucent
          * overlay so it stays legible regardless of the surrounding fill.
          */
-        inverted: 'text-inverse-foreground not-disabled:hover:bg-current/10',
+        inverted: 'text-inverted-foreground not-disabled:hover:bg-current/10',
         destructive:
           'bg-destructive text-destructive-foreground not-disabled:hover:bg-destructive-hover',
         link: '',

--- a/src/variants/spinner.ts
+++ b/src/variants/spinner.ts
@@ -4,7 +4,7 @@ export const spinnerVariants = cva('inline-flex items-center justify-center', {
   variants: {
     variant: {
       default: 'text-foreground',
-      inverse: 'text-inverse-foreground',
+      inverted: 'text-inverted-foreground',
     },
     size: {
       sm: 'size-4',

--- a/src/variants/text.ts
+++ b/src/variants/text.ts
@@ -24,9 +24,9 @@ export const textVariants = cva('text-foreground antialiased', {
       success: 'text-success',
       warning: 'text-warning',
       info: 'text-info',
-      inverted: 'text-inverse-foreground',
-      'inverted-muted': 'text-inverse-foreground-muted',
-      'inverted-subtle': 'text-inverse-foreground-subtle',
+      inverted: 'text-inverted-foreground',
+      'inverted-muted': 'text-inverted-foreground-muted',
+      'inverted-subtle': 'text-inverted-foreground-subtle',
       inherit: 'text-inherit',
     },
     align: {


### PR DESCRIPTION
## Summary

Three forms (`inverse` / `inverted` / `-inv`) were used for the same concept across tokens, primitives, and component variants. Consolidate to **`inverted`** everywhere.

- **Semantic tokens**: `--color-inverse-foreground{,-muted,-subtle}` → `--color-inverted-foreground{,-muted,-subtle}` (Tailwind utilities `text-inverted-foreground` / `bg-inverted-foreground` follow)
- **Spinner variant**: `variant="inverse"` → `variant="inverted"` (Spinner was the lone outlier — Button, Text, Callout, Toast were already on `inverted`)
- **Primitives**: `--ink-*-inv` / `--paper-*-inv` → `--ink-*-inverted` / `--paper-*-inverted` (internal-only per the layer rules in `state-token-guideline.md`)
- **Docs + comments**: `state-token-guideline.md`, `Toast.tsx`

Why `inverted`: it reads naturally as both an adjective (`<Button variant="inverted">`, `<Text color="inverted">`) and a CSS class (`text-inverted-foreground`), matches the dominant existing variant API, and aligns with the primitive-layer comments which already used "inverted".

These tokens have no external consumers yet, so this is a clean unification before public consumption begins. Bumped as `minor` (0.x semver).

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm test` — 123/123 passing
- [x] `pnpm lint` (biome ci) clean
- [x] grep sweep: no `inverse` / `-inv\b` references remain in `src/` or `.claude/`
- [ ] VRT snapshots unchanged (token rename is a no-op visually — if any drift, regen baselines)

🤖 Generated with [Claude Code](https://claude.com/claude-code)