### PR TITLE
chore(deps): add finer-grained Dependabot groups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,8 +4,17 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+      day: "monday"
     open-pull-requests-limit: 10
     groups:
+      storybook:
+        patterns: ["@storybook/*", "storybook"]
+      vitest:
+        patterns: ["vitest", "@vitest/*"]
+      types:
+        patterns: ["@types/*"]
+      tailwind:
+        patterns: ["tailwindcss", "@tailwindcss/*"]
       prod-minor-patch:
         dependency-type: "production"
         update-types: ["minor", "patch"]
@@ -22,6 +31,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+      day: "monday"
     groups:
       actions:
         patterns: ["*"]


### PR DESCRIPTION
## Summary

- Add pattern-based groups for Storybook / Vitest / @types/* / Tailwind so related (often interlocking) updates land in a single PR — including major bumps
- Pin the weekly schedule to **Monday** for both `npm` and `github-actions` ecosystems to consolidate review cadence
- Existing `prod-minor-patch` / `dev-minor-patch` catch-all groups remain untouched

## Motivation

Dependabot PRs were accumulating: Storybook major bumps split across `@storybook/addon-docs`, `@storybook/react-vite`, `storybook` etc., and `@types/*` PRs trickling in individually. Pattern groups let each family come through as one PR.

| Group | Patterns | Why |
|---|---|---|
| `storybook` | `@storybook/*`, `storybook` | Major bumps must move together |
| `vitest` | `vitest`, `@vitest/*` | Same |
| `types` | `@types/*` | Reduce trickle of low-risk PRs |
| `tailwind` | `tailwindcss`, `@tailwindcss/*` | Major bumps move together |

Catch-all minor/patch groups still cover everything else. Single-package major bumps (e.g. `tsup`, `class-variance-authority`) continue to come as individual PRs for explicit human review.

## Test plan

- [ ] Wait for next Monday's Dependabot run and confirm groupings work as configured
- [ ] Spot-check via [Dependabot logs in repo Insights](https://github.com/yasmro/schatten/network/updates) after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)