### PR TITLE
chore(security): override postcss to >=8.5.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -128,6 +128,11 @@
     "lucide-react": "^1.7.0",
     "tailwind-merge": "^2.6.0"
   },
+  "pnpm": {
+    "overrides": {
+      "postcss@<8.5.10": ">=8.5.10"
+    }
+  },
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  postcss@<8.5.10: '>=8.5.10'
+
 importers:
 
   .:
@@ -113,7 +116,7 @@ importers:
         version: 4.2.2
       tsup:
         specifier: ^8.3.5
-        version: 8.5.1(jiti@2.6.1)(postcss@8.5.8)(typescript@5.8.3)
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.14)(typescript@5.8.3)
       typescript:
         specifier: ^5.8.3
         version: 5.8.3
@@ -2426,7 +2429,7 @@ packages:
     engines: {node: '>= 18'}
     peerDependencies:
       jiti: '>=1.21.0'
-      postcss: '>=8.0.9'
+      postcss: '>=8.5.10'
       tsx: ^4.8.1
       yaml: ^2.4.2
     peerDependenciesMeta:
@@ -2439,8 +2442,8 @@ packages:
       yaml:
         optional: true
 
-  postcss@8.5.8:
-    resolution: {integrity: sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==}
+  postcss@8.5.14:
+    resolution: {integrity: sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==}
     engines: {node: ^10 || ^12 || >=14}
 
   prettier@2.8.8:
@@ -2757,7 +2760,7 @@ packages:
     peerDependencies:
       '@microsoft/api-extractor': ^7.36.0
       '@swc/core': ^1
-      postcss: ^8.4.12
+      postcss: '>=8.5.10'
       typescript: '>=4.5.0'
     peerDependenciesMeta:
       '@microsoft/api-extractor':
@@ -5082,14 +5085,14 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.2
 
-  postcss-load-config@6.0.1(jiti@2.6.1)(postcss@8.5.8):
+  postcss-load-config@6.0.1(jiti@2.6.1)(postcss@8.5.14):
     dependencies:
       lilconfig: 3.1.3
     optionalDependencies:
       jiti: 2.6.1
-      postcss: 8.5.8
+      postcss: 8.5.14
 
-  postcss@8.5.8:
+  postcss@8.5.14:
     dependencies:
       nanoid: 3.3.11
       picocolors: 1.1.1
@@ -5403,7 +5406,7 @@ snapshots:
 
   tslib@2.8.1: {}
 
-  tsup@8.5.1(jiti@2.6.1)(postcss@8.5.8)(typescript@5.8.3):
+  tsup@8.5.1(jiti@2.6.1)(postcss@8.5.14)(typescript@5.8.3):
     dependencies:
       bundle-require: 5.1.0(esbuild@0.27.4)
       cac: 6.7.14
@@ -5414,7 +5417,7 @@ snapshots:
       fix-dts-default-cjs-exports: 1.0.1
       joycon: 3.1.1
       picocolors: 1.1.1
-      postcss-load-config: 6.0.1(jiti@2.6.1)(postcss@8.5.8)
+      postcss-load-config: 6.0.1(jiti@2.6.1)(postcss@8.5.14)
       resolve-from: 5.0.0
       rollup: 4.60.0
       source-map: 0.7.6
@@ -5423,7 +5426,7 @@ snapshots:
       tinyglobby: 0.2.15
       tree-kill: 1.2.2
     optionalDependencies:
-      postcss: 8.5.8
+      postcss: 8.5.14
       typescript: 5.8.3
     transitivePeerDependencies:
       - jiti
@@ -5499,7 +5502,7 @@ snapshots:
   vite@5.4.21(@types/node@25.5.0)(lightningcss@1.32.0):
     dependencies:
       esbuild: 0.21.5
-      postcss: 8.5.8
+      postcss: 8.5.14
       rollup: 4.60.0
     optionalDependencies:
       '@types/node': 25.5.0


### PR DESCRIPTION
## Summary

Force transitive `postcss` to `>=8.5.10` via `pnpm.overrides` to address [GHSA-qx2v-qp2m-jg93](https://github.com/advisories/GHSA-qx2v-qp2m-jg93) (PostCSS XSS via unescaped `</style>` in CSS Stringify Output, moderate severity).

## Why an override?

`postcss` is a **transitive devDependency** — it enters the tree via:
- `tsup` (peer dep, build tool)
- `vite` (peer dep, dev/build)
- `@tailwindcss/vite`, `@storybook/*` (transitive)

Neither `tsup@8.5.1` nor `vite@5.4.21` has released a version constraining `postcss` to `>=8.5.10` yet, and Dependabot can't auto-PR a peer-dep bump. A targeted override is the cleanest fix until upstream catches up.

```json
"pnpm": {
  "overrides": {
    "postcss@<8.5.10": ">=8.5.10"
  }
}
```

The conditional `@<8.5.10` form means the override only applies to vulnerable versions — once upstream packages adopt postcss `>=8.5.10`, this override becomes a no-op and can be safely removed.

## Verification

- `pnpm install` resolved postcss `8.5.8 → 8.5.14` across the tree (verified via `pnpm why postcss`)
- `pnpm typecheck` passes
- `pnpm build` (tsup + lightningcss) succeeds
- No `dist/` impact — postcss is build-time / dev-time only

## Practical risk note

The XSS in question requires postcss to process **untrusted CSS** and emit it into HTML. Schatten only processes its own internal CSS via Lightning CSS bundling, so the practical exploitation surface in this repo is essentially nil. Fixing for **dependency hygiene** rather than active threat.

## Test plan

- [ ] CI green (lint / typecheck / test / VRT)
- [ ] After merge, [Dependabot alert #3](https://github.com/yasmro/schatten/security/dependabot/3) auto-resolves

🤖 Generated with [Claude Code](https://claude.com/claude-code)