### PR TITLE
chore(deps): add Dependabot cooldown for supply-chain hygiene

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,11 @@ updates:
       interval: "weekly"
       day: "monday"
     open-pull-requests-limit: 10
+    cooldown:
+      default-days: 7
+      semver-major-days: 14
+      semver-minor-days: 5
+      semver-patch-days: 3
     groups:
       storybook:
         patterns: ["@storybook/*", "storybook"]


### PR DESCRIPTION
## Summary

Add `cooldown` to the npm Dependabot config so version updates aren't PR'd until releases have matured.

```yaml
cooldown:
  default-days: 7
  semver-major-days: 14
  semver-minor-days: 5
  semver-patch-days: 3
```

## Why

Compromised npm releases (the recent vector for several supply-chain attacks: `event-stream`, `xz`, `chalk`-related typosquats, etc.) are typically **detected and unpublished within 24–72 hours** by the community / npm security team. Adopting a release immediately means racing that detection window.

A short cooldown:
- Lets the community surface malicious versions before they land here
- Doesn't block **security updates** — Dependabot files those immediately, exempt from cooldown
- Doesn't block **CVE-driven backports** since those flow as security alerts, not regular updates

The 14-day window for majors reflects that majors tend to ship with more bugs caught in the first 1–2 weeks, on top of the supply-chain rationale.

## Trade-offs

| Pro | Con |
|---|---|
| Reduced supply-chain attack surface | Patches/minors arrive ~3–5 days later than upstream |
| Automatic — no per-PR ceremony | First-week ecosystem fixes (e.g., a Storybook patch fixing yesterday's release) delayed |
| Security updates unaffected | — |

The Schatten project releases independently and isn't on a tight upstream-tracking cadence, so this trade-off is favourable.

## Verification

- This is a config-only change; no runtime / build impact
- Effect kicks in from the next Dependabot scheduler run (Mondays per the `weekly` schedule)

## Test plan

- [ ] CI passes (lint / typecheck / test)
- [ ] Confirm next Monday's Dependabot run respects cooldown by checking [Dependabot logs](https://github.com/yasmro/schatten/network/updates)

🤖 Generated with [Claude Code](https://claude.com/claude-code)