### PR TITLE
chore(deps): ignore TypeScript major bumps in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -31,6 +31,8 @@ updates:
         update-types: ["version-update:semver-major"]
       - dependency-name: "react-dom"
         update-types: ["version-update:semver-major"]
+      - dependency-name: "typescript"
+        update-types: ["version-update:semver-major"]
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
## Summary

Add `typescript` to the major-version ignore list in `dependabot.yml`, mirroring the existing `react` / `react-dom` rules.

```yaml
ignore:
  - dependency-name: "react"
    update-types: ["version-update:semver-major"]
  - dependency-name: "react-dom"
    update-types: ["version-update:semver-major"]
  - dependency-name: "typescript"
    update-types: ["version-update:semver-major"]
```

## Why

TypeScript major bumps touch:
- **Type inference and emit behavior** across the entire codebase
- **The `.d.ts` output we ship** to consumers (i.e., consumer impact even though `typescript` is a devDep)
- **Toolchain compatibility** (tsup, Storybook, Vitest, Biome) — these need to confirm TS major support before we can move

Letting Dependabot re-file this each cycle creates noise without value. We'll bump deliberately when it's the right time.

Same rationale as the React major ignore — frameworks/compilers in the "high blast radius" tier deserve human-driven upgrade timing.

Closes the loop on #74 (closed manually with this follow-up planned).

## Test plan

- [ ] CI passes (typecheck verifies the YAML doesn't break tooling)
- [ ] Confirm the ignore takes effect at the next Dependabot scheduler run

🤖 Generated with [Claude Code](https://claude.com/claude-code)