### PR TITLE
chore: add manual release workflow with npm provenance

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,51 @@
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to publish (e.g., v0.4.0). Must already exist on origin and match the package.json version on that tag.'
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: npm-publish
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout the tag
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.tag }}
+
+      - uses: pnpm/action-setup@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: pnpm
+          registry-url: 'https://registry.npmjs.org'
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Verify package.json version matches input tag
+        run: |
+          PKG_VERSION="v$(node -p "require('./package.json').version")"
+          if [ "$PKG_VERSION" != "${{ inputs.tag }}" ]; then
+            echo "::error::Version mismatch — package.json says $PKG_VERSION, workflow input is ${{ inputs.tag }}"
+            exit 1
+          fi
+          echo "Version OK: $PKG_VERSION"
+
+      - name: Publish to npm with provenance
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_CONFIG_PROVENANCE: 'true'
+        run: pnpm release


### PR DESCRIPTION
## Summary

Add a `workflow_dispatch`-triggered job (`Release`) that publishes a given tag to npm with **sigstore-based provenance attestation**, replacing only the `pnpm release` step in the manual flow with a CI-driven publish.

All other release steps (`changeset version`, commit, tag, push, GitHub Release creation) stay local for explicit human control.

## Why provenance

`npm publish --provenance` writes a sigstore attestation that cryptographically proves the package was built from a specific commit by a specific GitHub Actions workflow. Consumers can verify with `pnpm install --enforce-package-attestation` (or npm equivalent), turning npm package tampering from "undetectable" into "verifiable."

Provenance only works when publishing from a supported CI environment (GitHub Actions, GitLab CI, etc.) with `id-token: write` permission. It cannot be issued from a local `pnpm publish`.

## What this PR adds

A single workflow file: `.github/workflows/release.yml`

- **Trigger**: `workflow_dispatch` (manual button in Actions tab)
- **Input**: `tag` (e.g., `v0.4.0`) — required
- **Behavior**:
  1. Checks out the specified tag
  2. Verifies `package.json` version matches the input tag (typo guard)
  3. Runs `pnpm release` with `NPM_CONFIG_PROVENANCE=true`
- **No third-party action** beyond the GitHub-maintained `actions/checkout`, `actions/setup-node`, and `pnpm/action-setup` we already use elsewhere in CI

## Operator flow after this lands

```
1. (local)  pnpm changeset version
2. (local)  git commit, git tag vX.Y.Z, git push origin main && git push origin vX.Y.Z
3. (CI)     Trigger this workflow with input "vX.Y.Z"  ← new
4. (verify) Check npmjs.com — published version shows a "Provenance" badge
5. (local)  gh release create vX.Y.Z --notes-file ...
```

## Prerequisite: `NPM_TOKEN` secret

Before merging, add a repo secret named `NPM_TOKEN` set to a **granular npm access token** scoped to:

- **Packages**: `@yasmro/schatten` only (least privilege)
- **Permissions**: read-write
- **2FA bypass**: enabled (required for CI publish under `auth-and-writes` 2FA)
- **Expiration**: 1 year (rotate)

Set it via [Settings → Secrets and variables → Actions](https://github.com/yasmro/schatten/settings/secrets/actions).

## Threat model deltas vs current (local-only) flow

| Aspect | Before (local) | After (this PR) |
|---|---|---|
| Provenance | ❌ none | ✅ sigstore attestation |
| Build reproducibility | local MacBook | clean CI runner |
| `NPM_TOKEN` location | local `~/.npmrc` | GitHub Secrets |
| Compromise vector if `NPM_TOKEN` leaks | needs local TOTP (2FA) | needs only the token (CI bypasses 2FA) |
| Third-party action exposure | none | none — same actions we already trust |

The provenance gain is significant; the only meaningful new risk is the secret living in GitHub. Mitigated by least-privilege scoping and yearly rotation.

## Test plan

- [ ] CI checks pass on this PR
- [ ] Add `NPM_TOKEN` repo secret before merging
- [ ] After merge, do a dry-run release for the next minor (e.g., 0.4.1 if available, or wait for the next planned release) and verify the npm Provenance badge appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)