### PR TITLE
feat(tokens): export TS-typed design tokens via @yasmro/schatten/tokens

### DIFF
--- a/.changeset/typed-design-tokens.md
+++ b/.changeset/typed-design-tokens.md
@@ -1,0 +1,15 @@
+---
+'@yasmro/schatten': minor
+---
+
+feat(tokens): export TS-typed design tokens via `@yasmro/schatten/tokens`
+
+Adds `src/tokens.ts` that re-exports all semantic CSS custom properties as a hierarchical `as const` object, plus `*Token` literal-union types per category (color, spacing, radius, shadow, transition, zIndex, font, fontSize, lineHeight, fontWeight, letterSpacing). CSS remains the single source of truth — this is a thin pointer layer so AI / IDE completion can surface the available tokens.
+
+Prefer Tailwind utilities for everyday styling; reach for `tokens` only for inline style or CSS-in-JS.
+
+```ts
+import { tokens } from '@yasmro/schatten/tokens'
+
+<div style={{ background: tokens.color.errorSubtle, color: tokens.color.error }} />
+```

--- a/README.md
+++ b/README.md
@@ -58,6 +58,22 @@ import '@yasmro/schatten/themes/default'
 import '@yasmro/schatten/themes/seasonal/themes.css'
 ```
 
+### Typed token references
+
+Prefer Tailwind utilities (`bg-error`, `text-foreground-muted`, …) for everyday styling. When you need a CSS variable reference in inline style or CSS-in-JS, the `tokens` export provides typed pointers:
+
+```tsx
+import { tokens, type ColorToken } from '@yasmro/schatten/tokens'
+
+function Banner({ tone }: { tone: ColorToken }) {
+  return <div style={{ background: tokens.color[tone] }}>...</div>
+}
+
+<div style={{ background: tokens.color.errorSubtle, color: tokens.color.error }}>
+  Something went wrong
+</div>
+```
+
 ## Components
 
 Primitive components live under `src/components/lv1/`:

--- a/package.json
+++ b/package.json
@@ -37,6 +37,11 @@
       "import": "./dist/variants/index.js",
       "require": "./dist/variants/index.cjs"
     },
+    "./tokens": {
+      "types": "./dist/tokens/index.d.ts",
+      "import": "./dist/tokens/index.js",
+      "require": "./dist/tokens/index.cjs"
+    },
     "./components": {
       "types": "./dist/components/index.d.ts",
       "import": "./dist/components/index.js",

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -1,0 +1,203 @@
+/**
+ * Schatten Design Tokens — TypeScript export of CSS custom properties.
+ *
+ * CSS is the single source of truth (see `src/core/tokens/*.css`); this file
+ * is a thin, typed pointer layer so AI / IDE completion can surface the set
+ * of design tokens available in the system.
+ *
+ * Prefer Tailwind utilities (`bg-error`, `text-foreground-muted`, …) for
+ * everyday styling. Reach for `tokens` only when you need a CSS variable
+ * reference in inline style, CSS-in-JS, or other non-class contexts.
+ */
+
+export const tokens = {
+  color: {
+    // Surfaces
+    background: 'var(--color-background)',
+    surface: 'var(--color-surface)',
+    surfaceHover: 'var(--color-surface-hover)',
+
+    // Foreground tiers (most → least prominent)
+    foreground: 'var(--color-foreground)',
+    foregroundMuted: 'var(--color-foreground-muted)',
+    foregroundSubtle: 'var(--color-foreground-subtle)',
+
+    // Solid (filled component backgrounds)
+    solid: 'var(--color-solid)',
+    solidHover: 'var(--color-solid-hover)',
+    solidForeground: 'var(--color-solid-foreground)',
+    solidForegroundHover: 'var(--color-solid-foreground-hover)',
+
+    // Destructive (action color — shares vermillion with `error`)
+    destructive: 'var(--color-destructive)',
+    destructiveHover: 'var(--color-destructive-hover)',
+    destructiveForeground: 'var(--color-destructive-foreground)',
+    destructiveSubtle: 'var(--color-destructive-subtle)',
+
+    // Accent
+    accent: 'var(--color-accent)',
+    accentForeground: 'var(--color-accent-foreground)',
+
+    // Borders
+    border: 'var(--color-border)',
+    borderStrong: 'var(--color-border-strong)',
+
+    // Focus ring
+    ring: 'var(--color-ring)',
+    ringOffset: 'var(--color-ring-offset)',
+
+    // Inverted foreground tiers (text on saturated / dark fills)
+    invertedForeground: 'var(--color-inverted-foreground)',
+    invertedForegroundMuted: 'var(--color-inverted-foreground-muted)',
+    invertedForegroundSubtle: 'var(--color-inverted-foreground-subtle)',
+
+    // Primary scale (overridable per theme)
+    primary50: 'var(--color-primary-50)',
+    primary100: 'var(--color-primary-100)',
+    primary200: 'var(--color-primary-200)',
+    primary300: 'var(--color-primary-300)',
+    primary400: 'var(--color-primary-400)',
+    primary500: 'var(--color-primary-500)',
+    primary600: 'var(--color-primary-600)',
+    primary700: 'var(--color-primary-700)',
+    primary800: 'var(--color-primary-800)',
+    primary900: 'var(--color-primary-900)',
+    primary950: 'var(--color-primary-950)',
+
+    // State — error
+    error: 'var(--color-error)',
+    errorHover: 'var(--color-error-hover)',
+    errorForeground: 'var(--color-error-foreground)',
+    errorSubtle: 'var(--color-error-subtle)',
+
+    // State — success
+    success: 'var(--color-success)',
+    successHover: 'var(--color-success-hover)',
+    successForeground: 'var(--color-success-foreground)',
+    successSubtle: 'var(--color-success-subtle)',
+
+    // State — warning
+    warning: 'var(--color-warning)',
+    warningHover: 'var(--color-warning-hover)',
+    warningForeground: 'var(--color-warning-foreground)',
+    warningSubtle: 'var(--color-warning-subtle)',
+
+    // State — info (pinned to blue, independent of `primary`)
+    info: 'var(--color-info)',
+    infoHover: 'var(--color-info-hover)',
+    infoForeground: 'var(--color-info-foreground)',
+    infoSubtle: 'var(--color-info-subtle)',
+  },
+
+  spacing: {
+    0: 'var(--spacing-0)',
+    px: 'var(--spacing-px)',
+    '0.5': 'var(--spacing-0-5)',
+    1: 'var(--spacing-1)',
+    '1.5': 'var(--spacing-1-5)',
+    2: 'var(--spacing-2)',
+    '2.5': 'var(--spacing-2-5)',
+    3: 'var(--spacing-3)',
+    '3.5': 'var(--spacing-3-5)',
+    4: 'var(--spacing-4)',
+    5: 'var(--spacing-5)',
+    6: 'var(--spacing-6)',
+    7: 'var(--spacing-7)',
+    8: 'var(--spacing-8)',
+    9: 'var(--spacing-9)',
+    10: 'var(--spacing-10)',
+    12: 'var(--spacing-12)',
+    14: 'var(--spacing-14)',
+    16: 'var(--spacing-16)',
+    20: 'var(--spacing-20)',
+    24: 'var(--spacing-24)',
+  },
+
+  radius: {
+    none: 'var(--radius-none)',
+    sm: 'var(--radius-sm)',
+    md: 'var(--radius-md)',
+    lg: 'var(--radius-lg)',
+    xl: 'var(--radius-xl)',
+    '2xl': 'var(--radius-2xl)',
+    full: 'var(--radius-full)',
+  },
+
+  shadow: {
+    sm: 'var(--shadow-sm)',
+    md: 'var(--shadow-md)',
+    lg: 'var(--shadow-lg)',
+    xl: 'var(--shadow-xl)',
+  },
+
+  transition: {
+    fast: 'var(--transition-fast)',
+    normal: 'var(--transition-normal)',
+    slow: 'var(--transition-slow)',
+  },
+
+  zIndex: {
+    base: 'var(--z-base)',
+    dropdown: 'var(--z-dropdown)',
+    sticky: 'var(--z-sticky)',
+    fixed: 'var(--z-fixed)',
+    modalBackdrop: 'var(--z-modal-backdrop)',
+    modal: 'var(--z-modal)',
+    popover: 'var(--z-popover)',
+    tooltip: 'var(--z-tooltip)',
+    toast: 'var(--z-toast)',
+  },
+
+  font: {
+    sans: 'var(--font-sans)',
+    serif: 'var(--font-serif)',
+    mono: 'var(--font-mono)',
+  },
+
+  fontSize: {
+    xs: 'var(--text-xs)',
+    sm: 'var(--text-sm)',
+    base: 'var(--text-base)',
+    lg: 'var(--text-lg)',
+    xl: 'var(--text-xl)',
+    '2xl': 'var(--text-2xl)',
+    '3xl': 'var(--text-3xl)',
+    '4xl': 'var(--text-4xl)',
+  },
+
+  lineHeight: {
+    none: 'var(--leading-none)',
+    tight: 'var(--leading-tight)',
+    snug: 'var(--leading-snug)',
+    normal: 'var(--leading-normal)',
+    relaxed: 'var(--leading-relaxed)',
+    loose: 'var(--leading-loose)',
+  },
+
+  fontWeight: {
+    normal: 'var(--font-normal)',
+    medium: 'var(--font-medium)',
+    semibold: 'var(--font-semibold)',
+    bold: 'var(--font-bold)',
+  },
+
+  letterSpacing: {
+    tighter: 'var(--tracking-tighter)',
+    tight: 'var(--tracking-tight)',
+    normal: 'var(--tracking-normal)',
+    wide: 'var(--tracking-wide)',
+    wider: 'var(--tracking-wider)',
+  },
+} as const
+
+export type ColorToken = keyof typeof tokens.color
+export type SpacingToken = keyof typeof tokens.spacing
+export type RadiusToken = keyof typeof tokens.radius
+export type ShadowToken = keyof typeof tokens.shadow
+export type TransitionToken = keyof typeof tokens.transition
+export type ZIndexToken = keyof typeof tokens.zIndex
+export type FontToken = keyof typeof tokens.font
+export type FontSizeToken = keyof typeof tokens.fontSize
+export type LineHeightToken = keyof typeof tokens.lineHeight
+export type FontWeightToken = keyof typeof tokens.fontWeight
+export type LetterSpacingToken = keyof typeof tokens.letterSpacing

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -14,10 +14,11 @@ function copyCssAssets() {
 }
 
 export default defineConfig([
-  // Variants (CSS-only, for Astro)
+  // Variants & tokens (no React, for Astro / non-React consumers)
   {
     entry: {
       'variants/index': 'src/variants/index.ts',
+      'tokens/index': 'src/tokens.ts',
     },
     format: ['esm', 'cjs'],
     dts: true,


### PR DESCRIPTION
Closes #93

## Summary

- Add `src/tokens.ts` re-exporting all current semantic CSS custom properties as an `as const` hierarchy (`color`, `spacing`, `radius`, `shadow`, `transition`, `zIndex`, `font`, `fontSize`, `lineHeight`, `fontWeight`, `letterSpacing`) plus `*Token` literal-union types per category
- Wire the new entry into `tsup.config.ts` (no-React bundle, alongside `variants/index`) and `package.json` `exports` (`./tokens` → `./dist/tokens/index.{js,cjs,d.ts}`)
- Document the new import in README, framing it as a supplement to Tailwind utilities

## Why

CSS is the single source of truth, but AI / IDE completion can't surface the design-token vocabulary from `.css` files. This makes it too easy to slip `bg-red-500` or `text-gray-700` into JSX. `import { tokens } from '@yasmro/schatten/tokens'` exposes the same set as a typed object — useful for inline style and CSS-in-JS, and discoverable in editors.

## Self-review notes

- Compared `tokens.color` against every variable in `src/core/tokens/semantic.css` — all 49 semantic colors covered (surfaces, foreground tiers, solid, destructive, accent, border, ring, inverted-foreground, primary scale, error/success/warning/info × 4)
- Composite typography tokens (`text-body-md-*`, `text-label-*`, `text-heading-*`) intentionally deferred — they're consumed by the Text component variants internally; adding them would 3× the surface (size/leading/weight per role × 13 roles) without a clear inline-style use case
- `dist/tokens/index.d.ts` preserves each value as a string literal type (e.g. `readonly error: "var(--color-error)"`) — verified `as const` propagates through tsup's `dts` output
- README example uses `ColorToken` in a `Banner` component prop to show the type is actually load-bearing, not decorative

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm build` — generates `dist/tokens/index.{js,cjs,d.ts}` (5.14 KB ESM, 6.12 KB CJS, 7.60 KB types)
- [x] `pnpm lint`
- [x] `pnpm vitest run` — 146 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)