### PR TITLE
feat(ai): add TSDoc on lv1 Props for IDE/AI hover support

### DIFF
--- a/.changeset/jsdoc-on-all-lv1-props.md
+++ b/.changeset/jsdoc-on-all-lv1-props.md
@@ -1,0 +1,23 @@
+---
+'@yasmro/schatten': minor
+---
+
+Add TSDoc on `Props` interfaces for every lv1 component, so IDE hover and
+AI coding assistants (Copilot, Cursor, v0, Claude Code, …) surface the same
+descriptions that Storybook's Docs tab does.
+
+Each prop now carries a `/** ... */` comment with a `@default` tag and, for
+enum props (`variant` / `size` / `treatment`), a bullet list of per-option
+purposes. Inherited HTML standard props (`onClick`, `className`, …) are
+intentionally left undocumented.
+
+**Convention** (now codified in `.claude/rules/storybook-guideline.md`):
+TSDoc on the Props interface is the **source of truth** for prop docs.
+`argTypes.description` is a secondary surface that mirrors TSDoc for
+Storybook's Docs tab. When the two disagree, TSDoc wins.
+
+Affected components (all 17 lv1):
+Badge, Button, Callout, Checkbox, Dialog, Field, FieldSet, Input, Radio
+(+ RadioGroup), Select (SelectTrigger / SelectContent), Separator, Spinner,
+Switch, Text, Textarea, Toast (ToastInput / ToastAction) + Toaster, Tooltip
+(TooltipContent).

--- a/.claude/rules/storybook-guideline.md
+++ b/.claude/rules/storybook-guideline.md
@@ -34,6 +34,76 @@ argTypes: {
 }
 ```
 
+## TSDoc on Props (source of truth)
+
+Every public prop on a lv1 component's `Props` interface MUST carry a TSDoc
+comment (`/** ... */`). This is the **source of truth** for prop documentation —
+Storybook's `argTypes.description` is a secondary surface that mirrors TSDoc
+for the Docs tab. When TSDoc and `argTypes.description` disagree, **TSDoc wins**.
+
+Why TSDoc is the master:
+
+- IDE hover (VS Code, etc.) reads TSDoc.
+- AI coding assistants (Copilot, Cursor, v0, Claude Code) consume TSDoc through
+  the TypeScript language server.
+- Storybook addon-docs *also* reads TSDoc via `react-docgen-typescript` when
+  `argTypes.description` is absent.
+
+### Rules
+
+- Add TSDoc to every prop the component defines, including props redeclared
+  from CVA `VariantProps` (so `@default` and per-option descriptions are
+  visible on hover).
+- For `variant` / `size` and other enum props, list each option's purpose
+  with a bullet list inside the TSDoc.
+- Add a `@default` tag matching the CVA `defaultVariants` value.
+- **Do NOT** add TSDoc to inherited HTML standard props (`onClick`, `className`,
+  `disabled`, etc.). Redeclaring them adds noise without adding value, since
+  React's built-in types already document them.
+- For Radix-derived props (e.g. `orientation` on Separator, `side` on
+  Tooltip), redeclare with TSDoc when the description is non-obvious. Skip
+  redeclaration when the Radix type's own comment is sufficient.
+
+### Example
+
+```tsx
+export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement>, ButtonVariants {
+  /**
+   * Visual style of the button.
+   * - `primary` — solid fill, main CTA
+   * - `secondary` — outlined, secondary actions
+   * - `destructive` — for delete/remove actions (red)
+   * @default 'primary'
+   */
+  variant?: ButtonVariants['variant']
+  /**
+   * Size of the button.
+   * @default 'md'
+   */
+  size?: ButtonVariants['size']
+  // ...
+}
+```
+
+Then in the story:
+
+```ts
+argTypes: {
+  variant: {
+    description: 'Visual style of the button.',  // mirrors TSDoc, may be shorter
+    control: 'select',
+    options: ['primary', 'secondary', 'destructive'],
+    table: {
+      type: { summary: '"primary" | "secondary" | "destructive"' },
+      defaultValue: { summary: 'primary' },
+    },
+  },
+}
+```
+
+When you change a prop's description, **update TSDoc first**, then sync
+`argTypes.description` if the Storybook wording needs the same change.
+
 ## Language
 
 - All `description` text and Storybook labels should be written in **English**.

--- a/src/components/lv1/Badge/Badge.tsx
+++ b/src/components/lv1/Badge/Badge.tsx
@@ -6,7 +6,31 @@ import { type BadgeVariants, badgeVariants } from '../../../variants/badge'
 export type IconName = keyof typeof icons
 
 export interface BadgeProps extends HTMLAttributes<HTMLDivElement>, BadgeVariants {
+  /**
+   * Semantic state of the badge. Shares the state semantic tokens with `Toast` and `Callout`.
+   * Use `error` for "failed/invalid" tags. For destructive *actions*, use `<Button variant="destructive">`.
+   * @default 'default'
+   */
+  variant?: BadgeVariants['variant']
+  /**
+   * Visual treatment.
+   * - `subtle` — soft tinted background, suited for ambient list rows and status tags
+   * - `solid` — filled emphasis
+   * - `outline` — lightest, border-only style
+   * @default 'subtle'
+   */
+  treatment?: BadgeVariants['treatment']
+  /**
+   * Size of the badge.
+   * @default 'md'
+   */
+  size?: BadgeVariants['size']
+  /** Lucide icon name in PascalCase (e.g. `"Check"`, `"AlertCircle"`). */
   icon?: IconName
+  /**
+   * Position of the icon relative to the label text.
+   * @default 'start'
+   */
   iconPosition?: 'start' | 'end'
 }
 

--- a/src/components/lv1/Button/Button.tsx
+++ b/src/components/lv1/Button/Button.tsx
@@ -8,11 +8,40 @@ import { Spinner } from '../Spinner'
 export type IconName = keyof typeof icons
 
 export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement>, ButtonVariants {
-  /** Render as child element using Radix Slot. Note: `isLoading` is ignored when `asChild` is true. */
+  /**
+   * Visual style of the button.
+   * - `primary` — solid fill, main CTA
+   * - `secondary` — outlined, secondary actions
+   * - `tertiary` — text only, low-priority actions
+   * - `inverted` — ghost button intended for saturated surfaces (e.g. on top of a solid Toast or banner)
+   * - `destructive` — for delete/remove actions (red)
+   * - `link` — inline text link with button semantics
+   * @default 'primary'
+   */
+  variant?: ButtonVariants['variant']
+  /**
+   * Size of the button.
+   * @default 'md'
+   */
+  size?: ButtonVariants['size']
+  /**
+   * Delegates props to the child element via Radix Slot.
+   * Note: `isLoading` is ignored when `asChild` is true.
+   * @default false
+   */
   asChild?: boolean
+  /** Lucide icon name in PascalCase (e.g. `"Search"`, `"ArrowRight"`). */
   icon?: IconName
+  /**
+   * Position of the icon relative to the label text.
+   * @default 'start'
+   */
   iconPosition?: 'start' | 'end'
-  /** Shows a loading spinner and disables the button. Ignored when `asChild` is true. */
+  /**
+   * Shows a loading spinner and disables the button.
+   * Ignored when `asChild` is true.
+   * @default false
+   */
   isLoading?: boolean
 }
 

--- a/src/components/lv1/Callout/Callout.tsx
+++ b/src/components/lv1/Callout/Callout.tsx
@@ -18,6 +18,17 @@ const iconByVariant: Record<CalloutVariant, LucideIcon> = {
 export interface CalloutProps
   extends Omit<HTMLAttributes<HTMLDivElement>, 'title'>,
     CalloutVariants {
+  /**
+   * State variant. Drives the icon, color treatment, and accent.
+   * Shares the state semantic tokens with `Toast` and `Badge`.
+   * @default 'default'
+   */
+  variant?: CalloutVariants['variant']
+  /**
+   * Visual treatment — `subtle` for soft tinted background, `solid` for filled.
+   * @default 'subtle'
+   */
+  treatment?: CalloutVariants['treatment']
   /** Optional heading rendered in bold above the body content. */
   title?: ReactNode
   /**

--- a/src/components/lv1/Checkbox/Checkbox.tsx
+++ b/src/components/lv1/Checkbox/Checkbox.tsx
@@ -13,9 +13,18 @@ import { type CheckboxVariants, checkboxVariants } from '../../../variants/check
 export interface CheckboxProps
   extends Omit<ComponentPropsWithoutRef<typeof CheckboxPrimitive.Root>, 'size'>,
     CheckboxVariants {
-  /** Displays the checkbox in an error state with error border and ring. */
+  /**
+   * Size of the checkbox.
+   * @default 'md'
+   */
+  size?: CheckboxVariants['size']
+  /**
+   * Displays the checkbox in an error state with error border and ring.
+   * When used inside a `<Field>`, the field's error state takes precedence.
+   * @default false
+   */
   isError?: boolean
-  /** Label text displayed next to the checkbox. Automatically associates via id. */
+  /** Label text displayed next to the checkbox. Automatically associates via `htmlFor`. */
   label?: ReactNode
 }
 

--- a/src/components/lv1/Dialog/Dialog.tsx
+++ b/src/components/lv1/Dialog/Dialog.tsx
@@ -41,9 +41,14 @@ export interface DialogProps {
   isOpen: boolean
   /** Called when the open state changes (close ✕, ESC, overlay click, cancel button). */
   onOpenChange: (isOpen: boolean) => void
+  /** Dialog heading. Rendered as the accessible name via Radix `aria-labelledby`. */
   title: string
+  /** Optional supporting text rendered below the title. */
   description?: string
-  /** Default: true. */
+  /**
+   * Whether the close (✕) button in the top-right is rendered.
+   * @default true
+   */
   isCloseButtonVisible?: boolean
   /**
    * Required primary action. Set `isLoading: true` on the slot to show

--- a/src/components/lv1/Field/Field.tsx
+++ b/src/components/lv1/Field/Field.tsx
@@ -6,29 +6,38 @@ import { cn } from '../../../lib/utils'
 import { Tooltip, TooltipContent, TooltipTrigger } from '../Tooltip/Tooltip'
 
 export interface FieldProps {
-  /** Label text for the field */
+  /** Label text for the field. Associated with the input via `htmlFor`. */
   label?: ReactNode
-  /** Description text displayed above the input */
+  /** Description text displayed above the input. Linked via `aria-describedby`. */
   description?: ReactNode
-  /** Tooltip content displayed on hover of info icon next to label */
+  /** Tooltip content displayed on hover of an info icon next to the label. */
   tooltip?: ReactNode
-  /** Error message to display */
+  /** Error message displayed below the input. Setting this also implies `isError`. */
   error?: string
-  /** Explicitly set error state. If not provided, derived from error prop */
+  /**
+   * Explicitly set error state.
+   * If not provided, derived from `error` prop presence (or inherited from a parent `FieldSet`).
+   */
   isError?: boolean
-  /** Show required indicator (*) */
+  /**
+   * Show required indicator (`*`) next to the label.
+   * @default false
+   */
   required?: boolean
-  /** Disable the field */
+  /**
+   * Disable the field. Propagates to child components via context.
+   * @default false
+   */
   disabled?: boolean
-  /** Flex grow factor for layout within FieldSet */
+  /** Flex grow factor for layout within a `FieldSet`. */
   flexGrow?: 0 | 1
-  /** Flex shrink factor for layout within FieldSet */
+  /** Flex shrink factor for layout within a `FieldSet`. */
   flexShrink?: 0 | 1
-  /** Flex basis for layout within FieldSet (CSS value) */
+  /** Flex basis for layout within a `FieldSet` (CSS value, e.g. `"12rem"`). */
   flexBasis?: string
-  /** Field content (input element) */
+  /** Field content — typically a single input element (Input / Select / Textarea / Switch / RadioGroup). */
   children: ReactNode
-  /** Additional CSS classes */
+  /** Additional CSS classes applied to the outer wrapper. */
   className?: string
 }
 

--- a/src/components/lv1/FieldSet/FieldSet.tsx
+++ b/src/components/lv1/FieldSet/FieldSet.tsx
@@ -5,21 +5,31 @@ import { cn } from '../../../lib/utils'
 export interface FieldSetProps {
   /** Legend text for the fieldset. Omit for layout-only grouping. */
   legend?: ReactNode
-  /** Description text displayed below the legend */
+  /** Description text displayed below the legend. */
   description?: ReactNode
-  /** Error message to display (group-level) */
+  /** Group-level error message displayed below the children. Setting this also implies `isError`. */
   error?: string
-  /** Explicitly set error state. If not provided, derived from error prop */
+  /** Explicitly set error state. If not provided, derived from `error` prop presence. */
   isError?: boolean
-  /** Disable all child fields */
+  /**
+   * Disable all child fields. Uses native `<fieldset disabled>` behavior, so all descendant
+   * form controls are disabled.
+   * @default false
+   */
   disabled?: boolean
-  /** Flex direction for children layout */
+  /**
+   * Flex direction for children layout.
+   * @default 'column'
+   */
   direction?: 'row' | 'column'
-  /** Enable flex wrap for children */
+  /**
+   * Enable flex wrap for children. Useful with `direction="row"` for responsive layouts.
+   * @default false
+   */
   wrap?: boolean
-  /** FieldSet content (Field elements) */
+  /** FieldSet content — typically `Field` elements (or nested `FieldSet`s). */
   children: ReactNode
-  /** Additional CSS classes */
+  /** Additional CSS classes applied to the outer `<fieldset>`. */
   className?: string
 }
 

--- a/src/components/lv1/Input/Input.tsx
+++ b/src/components/lv1/Input/Input.tsx
@@ -10,10 +10,24 @@ export type IconName = keyof typeof icons
 export interface InputProps
   extends Omit<InputHTMLAttributes<HTMLInputElement>, 'size'>,
     InputVariants {
+  /**
+   * Size of the input.
+   * @default 'md'
+   */
+  size?: InputVariants['size']
+  /**
+   * Displays the input in an error state with error border and ring.
+   * When used inside a `<Field>`, the field's error state takes precedence.
+   * @default false
+   */
   isError?: boolean
+  /** Text displayed before the input. Takes priority over `iconLeft`. */
   textLeft?: string
+  /** Text displayed after the input. Takes priority over `iconRight`. */
   textRight?: string
+  /** Lucide icon name rendered before the input. Ignored when `textLeft` is set. */
   iconLeft?: IconName
+  /** Lucide icon name rendered after the input. Ignored when `textRight` is set. */
   iconRight?: IconName
 }
 

--- a/src/components/lv1/Radio/Radio.tsx
+++ b/src/components/lv1/Radio/Radio.tsx
@@ -28,9 +28,16 @@ const RadioGroupContext = createContext<RadioGroupContextValue>({
 /* ----- RadioGroup ----- */
 
 export interface RadioGroupProps extends ComponentPropsWithoutRef<typeof RadioGroupPrimitive.Root> {
-  /** Displays all radio items in an error state. Propagated via context. */
+  /**
+   * Displays all radio items in an error state. Propagated to children via context.
+   * When used inside a `<Field>`, the field's error state takes precedence.
+   * @default false
+   */
   isError?: boolean
-  /** Size applied to all radio items. Can be overridden per item. */
+  /**
+   * Size applied to all radio items. Can be overridden per item.
+   * @default 'md'
+   */
   size?: RadioVariants['size']
 }
 
@@ -77,9 +84,17 @@ RadioGroup.displayName = 'RadioGroup'
 export interface RadioProps
   extends Omit<ComponentPropsWithoutRef<typeof RadioGroupPrimitive.Item>, 'size'>,
     RadioVariants {
-  /** Displays the radio in an error state. Inherited from RadioGroup if not set. */
+  /**
+   * Size of the radio button. Inherited from the parent `RadioGroup` if not set.
+   * @default 'md'
+   */
+  size?: RadioVariants['size']
+  /**
+   * Displays the radio in an error state. Inherited from the parent `RadioGroup` if not set.
+   * @default false
+   */
   isError?: boolean
-  /** Label text displayed next to the radio. Automatically associates via id. */
+  /** Label text displayed next to the radio. Automatically associates via `htmlFor`. */
   label?: ReactNode
 }
 

--- a/src/components/lv1/Select/Select.tsx
+++ b/src/components/lv1/Select/Select.tsx
@@ -22,6 +22,16 @@ const SelectValue = SelectPrimitive.Value
 export interface SelectTriggerProps
   extends Omit<ComponentPropsWithoutRef<typeof SelectPrimitive.Trigger>, 'size'>,
     SelectTriggerVariants {
+  /**
+   * Size of the select trigger.
+   * @default 'md'
+   */
+  size?: SelectTriggerVariants['size']
+  /**
+   * Displays the select trigger in an error state with error border and ring.
+   * When used inside a `<Field>`, the field's error state takes precedence.
+   * @default false
+   */
   isError?: boolean
 }
 
@@ -111,6 +121,10 @@ SelectScrollDownButton.displayName = SelectPrimitive.ScrollDownButton.displayNam
 
 export interface SelectContentProps
   extends ComponentPropsWithoutRef<typeof SelectPrimitive.Content> {
+  /**
+   * Custom container element for the portal. Useful for rendering inside
+   * a Dialog or Drawer.
+   */
   container?: ComponentPropsWithoutRef<typeof SelectPrimitive.Portal>['container']
 }
 

--- a/src/components/lv1/Separator/Separator.tsx
+++ b/src/components/lv1/Separator/Separator.tsx
@@ -2,7 +2,19 @@ import * as SeparatorPrimitive from '@radix-ui/react-separator'
 import { type ComponentPropsWithoutRef, type ComponentRef, forwardRef } from 'react'
 import { cn } from '../../../lib/utils'
 
-export interface SeparatorProps extends ComponentPropsWithoutRef<typeof SeparatorPrimitive.Root> {}
+export interface SeparatorProps extends ComponentPropsWithoutRef<typeof SeparatorPrimitive.Root> {
+  /**
+   * Orientation of the separator.
+   * @default 'horizontal'
+   */
+  orientation?: ComponentPropsWithoutRef<typeof SeparatorPrimitive.Root>['orientation']
+  /**
+   * When true, the separator is purely visual and hidden from assistive technologies.
+   * When false, it is exposed as a semantic divider with `role="separator"`.
+   * @default true
+   */
+  decorative?: boolean
+}
 
 export const Separator = forwardRef<ComponentRef<typeof SeparatorPrimitive.Root>, SeparatorProps>(
   ({ className, orientation = 'horizontal', decorative = true, ...props }, ref) => (

--- a/src/components/lv1/Spinner/Spinner.tsx
+++ b/src/components/lv1/Spinner/Spinner.tsx
@@ -4,9 +4,27 @@ import { type SpinnerVariants, spinnerVariants } from '../../../variants/spinner
 import './Spinner.css'
 
 export interface SpinnerProps extends HTMLAttributes<HTMLDivElement>, SpinnerVariants {
-  /** Accessible label for screen readers. */
+  /**
+   * Color variant. Use `inverted` when placing the spinner on top of a saturated surface.
+   * @default 'default'
+   */
+  variant?: SpinnerVariants['variant']
+  /**
+   * Size of the spinner.
+   * @default 'md'
+   */
+  size?: SpinnerVariants['size']
+  /**
+   * Accessible label for screen readers (rendered via a visually-hidden span).
+   * @default 'Loading'
+   */
   label?: string
-  /** Spinner animation type. */
+  /**
+   * Spinner animation type.
+   * - `default` — circular spinner that rotates
+   * - `ripple` — concentric pulsing rings
+   * @default 'default'
+   */
   type?: 'default' | 'ripple'
 }
 

--- a/src/components/lv1/Switch/Switch.tsx
+++ b/src/components/lv1/Switch/Switch.tsx
@@ -13,9 +13,18 @@ import { type SwitchVariants, switchThumbVariants, switchVariants } from '../../
 export interface SwitchProps
   extends Omit<ComponentPropsWithoutRef<typeof SwitchPrimitive.Root>, 'size'>,
     SwitchVariants {
-  /** Displays the switch in an error state with error border and ring. */
+  /**
+   * Size of the switch.
+   * @default 'md'
+   */
+  size?: SwitchVariants['size']
+  /**
+   * Displays the switch in an error state with error border and ring.
+   * When used inside a `<Field>`, the field's error state takes precedence.
+   * @default false
+   */
   isError?: boolean
-  /** Label text displayed next to the switch. Automatically associates via id. */
+  /** Label text displayed next to the switch. Automatically associates via `htmlFor`. */
   label?: ReactNode
 }
 

--- a/src/components/lv1/Text/Text.tsx
+++ b/src/components/lv1/Text/Text.tsx
@@ -6,7 +6,44 @@ import { type TextVariants, textVariants } from '../../../variants/text'
 type TextElement = 'p' | 'span' | 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6'
 
 export interface TextProps extends Omit<HTMLAttributes<HTMLElement>, 'color'>, TextVariants {
+  /**
+   * Semantic role of the text.
+   * - `body` — paragraph copy
+   * - `label` — form labels and inline metadata
+   * - `heading` — headings (use `as` to pick `h1`–`h6`)
+   * @default 'body'
+   */
+  variant?: TextVariants['variant']
+  /**
+   * Size of the text. Available sizes depend on the variant.
+   * @default 'md'
+   */
+  size?: TextVariants['size']
+  /**
+   * Color of the text. Three parallel hierarchies plus state colors:
+   * - Foreground: `default` / `muted` / `subtle` (most → least prominent)
+   * - State: `error` / `success` / `warning` / `info` (inline status text)
+   * - Inverted: `inverted` / `inverted-muted` / `inverted-subtle` (for saturated surfaces)
+   * - Plus: `accent` (one-off emphasis), `inherit` (delegates to the parent)
+   * @default 'default'
+   */
+  color?: TextVariants['color']
+  /** Text alignment. */
+  align?: TextVariants['align']
+  /**
+   * Truncate text with ellipsis on overflow.
+   * @default false
+   */
+  truncate?: TextVariants['truncate']
+  /**
+   * HTML element to render.
+   * Defaults to `<p>` for `body` and `heading`, and `<label>` for `label`.
+   */
   as?: TextElement
+  /**
+   * Delegates props to the child element via Radix Slot.
+   * @default false
+   */
   asChild?: boolean
 }
 

--- a/src/components/lv1/Textarea/Textarea.tsx
+++ b/src/components/lv1/Textarea/Textarea.tsx
@@ -6,6 +6,16 @@ import { type TextareaVariants, textareaVariants } from '../../../variants/texta
 export interface TextareaProps
   extends Omit<TextareaHTMLAttributes<HTMLTextAreaElement>, 'size'>,
     TextareaVariants {
+  /**
+   * Size of the textarea.
+   * @default 'md'
+   */
+  size?: TextareaVariants['size']
+  /**
+   * Displays the textarea in an error state with error border and ring.
+   * When used inside a `<Field>`, the field's error state takes precedence.
+   * @default false
+   */
   isError?: boolean
 }
 

--- a/src/components/lv1/Toast/Toaster.tsx
+++ b/src/components/lv1/Toast/Toaster.tsx
@@ -6,17 +6,17 @@ import { useToast } from './use-toast'
 
 export interface ToasterProps {
   /**
-   * Where the toast viewport sits on screen. Defaults to `bottom-center`.
+   * Where the toast viewport sits on screen.
+   * @default 'bottom-center'
    */
   position?: ToastPosition
   /**
    * Default auto-dismiss duration in ms applied when a toast does not
-   * specify its own. Per-toast `duration` always wins. Default 5000.
+   * specify its own. Per-toast `duration` always wins.
+   * @default 5000
    */
   duration?: number
-  /**
-   * Optional class applied to the viewport container.
-   */
+  /** Optional class applied to the viewport container. */
   className?: string
 }
 

--- a/src/components/lv1/Toast/use-toast.ts
+++ b/src/components/lv1/Toast/use-toast.ts
@@ -4,19 +4,39 @@ export type ToastVariant = 'default' | 'success' | 'error' | 'warning' | 'info'
 export type ToastTreatment = 'subtle' | 'solid'
 
 export interface ToastAction {
+  /** Action button label. */
   label: ReactNode
+  /** Invoked when the action button is clicked. The toast is also dismissed automatically. */
   onClick: () => void
   /** Screen reader text. Required when `label` is not a string. */
   altText?: string
 }
 
 export interface ToastInput {
+  /** Optional bold heading shown at the top of the toast. */
   title?: ReactNode
+  /** Body text rendered below the title. */
   description?: ReactNode
+  /**
+   * State variant. Drives the icon, color treatment, and accent.
+   * Shares the state semantic tokens with `Callout` and `Badge`.
+   * @default 'default'
+   */
   variant?: ToastVariant
+  /**
+   * Visual treatment — `subtle` for soft tinted background, `solid` for filled.
+   * @default 'subtle'
+   */
   treatment?: ToastTreatment
-  /** Auto-dismiss after this many ms. Default 5000. */
+  /**
+   * Auto-dismiss after this many milliseconds.
+   * @default 5000
+   */
   duration?: number
+  /**
+   * Optional action button rendered on the right. When present, the close (✕) button is suppressed
+   * — clicking the action also dismisses the toast.
+   */
   action?: ToastAction
 }
 

--- a/src/components/lv1/Tooltip/Tooltip.tsx
+++ b/src/components/lv1/Tooltip/Tooltip.tsx
@@ -38,7 +38,12 @@ export interface TooltipContentProps
     ComponentPropsWithoutRef<typeof TooltipPrimitive.Content>,
     'sideOffset' | 'alignOffset' | 'align'
   > {
-  /** Portal container element */
+  /**
+   * The preferred side of the trigger to render the tooltip.
+   * @default 'top'
+   */
+  side?: ComponentPropsWithoutRef<typeof TooltipPrimitive.Content>['side']
+  /** Custom container element for the portal. Useful for rendering inside a Dialog. */
   container?: ComponentPropsWithoutRef<typeof TooltipPrimitive.Portal>['container']
 }
 


### PR DESCRIPTION
Closes #92.

## Summary

- TSDoc on every public prop of all 17 lv1 components (= 18 incl. Toaster). IDE hover (VS Code, …) and AI coding assistants (Copilot, Cursor, v0, Claude Code) read TSDoc via the TS language server; Storybook's \`argTypes.description\` is invisible to both, so prop docs were effectively unavailable outside the Storybook UI.
- CVA-derived \`variant\` / \`size\` / \`treatment\` are redeclared on each Props interface so TSDoc is hover-visible (otherwise hidden behind the \`VariantProps<…>\` intersection). Inherited HTML standard props (\`onClick\`, \`className\`, …) are left undocumented per the issue's rule.
- \`.claude/rules/storybook-guideline.md\` — new "TSDoc on Props (source of truth)" section: TSDoc is the master, \`argTypes.description\` mirrors it.

## DoD checklist

- [x] 全 18 コンポーネントの Props 型に TSDoc 付与完了
- [x] \`pnpm typecheck\` がパス
- [x] hover で各 prop の説明が表示されることを確認 (\`dist/components/lv1/index.d.ts\` に TSDoc が出力されていることを検証 — IDE は同じ d.ts を読むため hover でも表示される)
- [x] \`.claude/rules/storybook-guideline.md\` に「TSDoc と argTypes.description の関係 (TSDoc が master)」を追記
- [x] Button / Input / Select を先行サンプルとして実装 (この PR では同時に全コンポを反映済み)

## Self-review notes

- Reviewed and corrected \`isError\` wording across Input / Select / Checkbox / Switch / Textarea / RadioGroup. The earlier draft said "When inside a \`Field\` with \`isError\`, this prop is overridden" — misleading because \`field.isError\` is always defined as a boolean (defaults to \`false\`), so the Field *always* overrides the prop inside a Field, not only "when isError is set." Final wording: "When used inside a \`<Field>\`, the field's error state takes precedence."
- Removed "Inherited from \`@radix-ui/react-tooltip\`" implementation noise from Tooltip's \`side\` TSDoc.
- Skipped TSDoc on inherited HTML standard props (\`onClick\`, \`className\`, \`disabled\`, …) per the issue's rule. \`disabled\` propagation from Field context is intentionally undocumented since the override behavior is symmetric with \`isError\` and consumers rarely pass \`disabled\` inside a Field anyway.
- Spot-checked that TSDoc reaches \`dist/components/lv1/index.d.ts\` via \`pnpm build\` — IDE hover reads the same d.ts, so this confirms the user-visible outcome.

## Test plan

- [x] \`pnpm typecheck\` ✓
- [x] \`pnpm test\` ✓ (146/146 pass)
- [x] \`pnpm lint\` ✓
- [x] \`pnpm build\` ✓ — \`dist/components/lv1/index.d.ts\` contains the TSDoc

🤖 Generated with [Claude Code](https://claude.com/claude-code)