### PR TITLE
docs(ai): ルートに AGENTS.md を新設

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,79 @@
+# AGENTS.md
+
+> **What is this file?**
+>
+> Common entry point for AI coding assistants (Codex / Cursor / Aider / OpenHands, etc.). Claude Code reads [CLAUDE.md](CLAUDE.md) instead — that file is Claude Code-specific. Both files share the same source of truth in [`.claude/rules/`](.claude/rules).
+
+## About this repo
+
+**Schatten** is a design system component library based on [shadcn/ui](https://ui.shadcn.com/), customized for the Schatten brand. Components are built on Radix UI primitives, styled with Tailwind CSS v4, and authored with `class-variance-authority` (CVA).
+
+- **Framework**: React 18 / 19 + TypeScript
+- **Styling**: Tailwind CSS v4 + CVA
+- **Primitives**: Radix UI
+- **Build / Test / VRT**: tsup + Lightning CSS / Vitest / Playwright
+- **Lint / Format**: Biome
+- **Release**: Changesets
+- **Package manager**: pnpm
+
+Layout:
+
+```
+src/
+├── components/lv1/   # Primitive components (Button, Input, …)
+├── components/lv2/   # Composite components
+├── contexts/         # React contexts (Field, FieldSet, …)
+├── core/tokens/      # Primitive & semantic CSS tokens (3-layer system)
+├── themes/           # Default and seasonal themes
+├── variants/         # CVA variant definitions
+├── lib/              # Shared utilities (cn, etc.)
+└── docs/             # Storybook docs (Color, Typography, …)
+```
+
+## Required reading
+
+Before adding or modifying components, read the guideline files under [`.claude/rules/`](.claude/rules):
+
+- [`storybook-guideline.md`](.claude/rules/storybook-guideline.md) — Story structure (`Playground` story first, group by prop), `argTypes`, English-only labels.
+- [`state-token-guideline.md`](.claude/rules/state-token-guideline.md) — 3-layer token system, state semantic tokens (`error` / `success` / `warning` / `info` / `destructive`) and the 4-token shape (`base` / `hover` / `foreground` / `subtle`).
+- [`field-context-guideline.md`](.claude/rules/field-context-guideline.md) — `FieldContext` integration patterns for form components (Input / Checkbox / Switch / Radio / Select / Textarea).
+- [`vrt-spec-guideline.md`](.claude/rules/vrt-spec-guideline.md) — Playwright VRT spec template, story-id mapping, snapshot naming.
+
+## Main commands
+
+```sh
+pnpm dev               # Start Storybook on :6006
+pnpm build             # Build JS + CSS into dist/
+pnpm test              # Run Vitest
+pnpm test:vrt          # Run Playwright VRT
+pnpm test:vrt:update   # Update VRT snapshots
+pnpm lint              # Biome CI checks
+pnpm lint:fix          # Biome auto-fix
+pnpm typecheck         # tsc --noEmit
+pnpm changeset         # Create a changeset for user-facing changes
+```
+
+## Things you MUST NOT do
+
+- **Do not** write primitive color classes (`bg-red-500`, `text-blue-700`, `bg-vermillion-600`, …) directly in JSX or CSS. Use **state semantic tokens** (`bg-error`, `text-error-foreground`, `bg-error-subtle`, `bg-destructive`, …) so light/dark and seasonal themes stay correct. See [state-token-guideline](.claude/rules/state-token-guideline.md).
+- **Do not** confuse `destructive` and `error`. They share the same primitive (vermillion) but are semantically distinct — `destructive` is for actions (e.g. `<Button variant="destructive">`), `error` is for form/notification state (e.g. `<Input isError>`). See [state-token-guideline](.claude/rules/state-token-guideline.md#destructive-vs-error).
+- **Do not** build new components with ad-hoc styles outside the design system. Compose existing `lv1` primitives, or extend the variant definitions in `src/variants/`.
+- **Do not** add a new `lv1` / `lv2` component without **Storybook story + Vitest test + VRT spec** alongside it. Follow the Storybook conventions (Playground story first, group by prop) and place the VRT spec at `ComponentName.vrt.spec.ts` next to the component.
+- **Do not** create individual stories for every prop value (`Default`, `Secondary`, `Outline` as separate exports). Group them into render stories (`AllVariants`, `Sizes`, `Disabled`, …). See [storybook-guideline](.claude/rules/storybook-guideline.md).
+- **Do not** write Storybook `description`, `argTypes`, button labels, etc. in Japanese — Storybook surfaces use **English only**.
+- **Do not** ship user-facing changes without a changeset entry. Run `pnpm changeset` and pick the appropriate semver bump.
+
+## Resource Map
+
+| File | One-liner |
+|---|---|
+| [CLAUDE.md](CLAUDE.md) | Claude Code-specific tech stack and rule index. |
+| [README.md](README.md) | Public-facing overview, installation, and usage. |
+| [.claude/rules/storybook-guideline.md](.claude/rules/storybook-guideline.md) | Storybook conventions — Playground story, `argTypes`, grouping. |
+| [.claude/rules/state-token-guideline.md](.claude/rules/state-token-guideline.md) | 3-layer token system, 4-token shape, `destructive` vs `error`. |
+| [.claude/rules/field-context-guideline.md](.claude/rules/field-context-guideline.md) | `FieldContext` patterns for form components. |
+| [.claude/rules/vrt-spec-guideline.md](.claude/rules/vrt-spec-guideline.md) | Playwright VRT spec template and snapshot naming. |
+
+## Maintenance
+
+When you add or remove a file under [`.claude/rules/`](.claude/rules), update **Required reading** and **Resource Map** above so AI agents pick it up automatically. CLAUDE.md's `Guidelines` section also lists the same files — keep both indexes in sync.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,7 +3,7 @@
 Design system component library based on [shadcn/ui](https://ui.shadcn.com/), customized for the Schatten brand.
 When adding or modifying components, follow shadcn/ui conventions (Radix UI + CVA + cn utility) as the baseline.
 
-> Non-Claude-Code AI tools (Codex / Cursor / Aider / OpenHands, etc.) should read [AGENTS.md](AGENTS.md) — a tool-agnostic mirror of this file that also covers main commands, NG patterns, and a resource map.
+> Non-Claude-Code AI tools (Codex / Cursor / Aider / OpenHands, etc.) should read [AGENTS.md](AGENTS.md) — a tool-agnostic mirror of this file that also covers main commands, anti-patterns, and a resource map.
 
 ## Tech Stack
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,6 +3,8 @@
 Design system component library based on [shadcn/ui](https://ui.shadcn.com/), customized for the Schatten brand.
 When adding or modifying components, follow shadcn/ui conventions (Radix UI + CVA + cn utility) as the baseline.
 
+> Non-Claude-Code AI tools (Codex / Cursor / Aider / OpenHands, etc.) should read [AGENTS.md](AGENTS.md) — a tool-agnostic mirror of this file that also covers main commands, NG patterns, and a resource map.
+
 ## Tech Stack
 
 - **Base**: shadcn/ui


### PR DESCRIPTION
Closes #94

## 概要

リポジトリルートに `AGENTS.md` を新設し、Claude Code 以外の AI コーディング支援 (Codex / Cursor / Aider / OpenHands 等) が読みに来る共通エントリポイントを提供します。CLAUDE.md と `AGENTS.md` は `.claude/rules/` を共通の真実源として参照し、お互いに被リンクを貼って双方向で辿れるようにしています。

## 変更内容

### 新規: `AGENTS.md` (79 行)

- 冒頭で **CLAUDE.md との役割分担** を明記 (Claude Code は CLAUDE.md / それ以外の AI は AGENTS.md)
- **About this repo** — Schatten の技術スタックと `src/` 配下のレイアウト
- **Required reading** — 既存 4 つの rules ファイルを必読として列挙
- **Main commands** — `pnpm dev` / `test` / `test:vrt` / `lint` / `typecheck` / `changeset` 等
- **Things you MUST NOT do** — primitive 色クラス禁止、\`destructive\` と \`error\` の混同禁止、story+test+VRT 必須、Storybook の英語ルール等
- **Resource Map** — 各 rules ファイルへのリンクと一行説明 (テーブル形式)
- **Maintenance** — rules 追加・削除時に AGENTS.md と CLAUDE.md の両方を同期する運用ルール

### 更新: `CLAUDE.md`

- 冒頭に AGENTS.md への被リンクを追加 (\`Non-Claude-Code AI tools should read AGENTS.md\`)

## 判断ポイント

### 言語: 英語のみ

issue 本文では「日本語+英語の併記を推奨」とありましたが、ユーザー指示により **全文英語** にしました。AGENTS.md の業界規約は英語が主流である点、AI ツールの parse しやすさを優先しています。

### 参照する rules

issue 例には v0.6.0 で新設予定の以下 3 ファイルが含まれていましたが、現状未存在のためリンクから除外しました。v0.6.0 着手時に Resource Map と Required reading の両方に追記する運用とします。

- \`.claude/rules/component-api-conventions.md\`
- \`.claude/rules/component-architecture.md\`
- \`.claude/rules/spacing-conventions.md\`

現時点で参照しているのは既存の 4 ファイル:

- \`storybook-guideline.md\`
- \`state-token-guideline.md\`
- \`field-context-guideline.md\`
- \`vrt-spec-guideline.md\`

### Changeset 不要

docs-only の変更で npm パッケージ \`@yasmro/schatten\` の配信物には影響しないため、changeset は追加していません (README 追加時 #67 と同じ運用)。

## DoD チェック

- [x] ルート \`AGENTS.md\` 作成
- [x] 150 行以内 (79 行)
- [x] CLAUDE.md からの被リンクを追加 (お互い参照)
- [x] 既存 rules / 主要コマンド / NG パターン / 参照 Resource Map を網羅
- [ ] Cursor 等で読み込めることを確認 (動作確認は手動)

## Test plan

- [ ] GitHub 上で AGENTS.md をプレビューしてリンクと表組みが崩れていないことを確認
- [ ] CLAUDE.md → AGENTS.md および AGENTS.md → CLAUDE.md のリンクが双方向で機能することを確認
- [ ] AGENTS.md 内の rules ファイル 4 本へのリンクが全て生きていることを確認
- [ ] (手動) Cursor 等で本リポジトリを開き、AGENTS.md が AI コンテキストとして読まれることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)