### PR TITLE
chore(types): typecheck stories/tests via tsconfig.test.json (closes #95)

### DIFF
--- a/.changeset/typecheck-stories-tests.md
+++ b/.changeset/typecheck-stories-tests.md
@@ -1,0 +1,30 @@
+---
+'@yasmro/schatten': patch
+---
+
+chore(types): typecheck stories and tests via a dedicated `tsconfig.test.json`
+
+`tsconfig.json` previously excluded `**/*.stories.tsx` and `**/*.test.tsx`,
+which meant `pnpm typecheck` skipped them and let type errors slip past CI.
+The dist build needs that exclude (so generated `.d.ts` files don't pick up
+story/test types), but typecheck does not — and the gap masked real bugs.
+
+This split separates the two concerns:
+
+- `tsconfig.json` — dist build target (still excludes stories/test), unchanged
+  for `tsup`.
+- `tsconfig.test.json` (new) — extends `tsconfig.json` but includes stories,
+  tests, and `vitest.setup.ts` (the latter pulls in
+  `@testing-library/jest-dom/vitest` so matcher type augmentation is visible).
+- `pnpm typecheck` now runs against `tsconfig.test.json`.
+
+Bugs surfaced and fixed while turning typecheck back on:
+
+- `Badge.stories.tsx` used `icon="AlertCircle"`, which is a deprecated
+  lucide-react alias that is **not** present in the `icons` object. The
+  story rendered no icon at runtime. Updated to `"CircleAlert"` and refreshed
+  the matching JSDoc / argTypes examples on `BadgeProps.icon`.
+- `Tooltip.stories.tsx` declared an `argTypes` entry for `hideArrow`, a prop
+  that does not exist on `TooltipContentProps`. Removed the stale entry.
+
+No public API change.

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "lint": "biome ci .",
     "lint:fix": "biome check --write .",
     "format": "biome format --write .",
-    "typecheck": "tsc --noEmit",
+    "typecheck": "tsc --noEmit -p tsconfig.test.json",
     "changeset": "changeset",
     "release": "changeset publish",
     "version": "changeset version",

--- a/src/components/lv1/Badge/Badge.stories.tsx
+++ b/src/components/lv1/Badge/Badge.stories.tsx
@@ -56,7 +56,7 @@ const meta: Meta<typeof Badge> = {
       },
     },
     icon: {
-      description: 'Lucide icon name in PascalCase (e.g. "Check", "AlertCircle").',
+      description: 'Lucide icon name in PascalCase (e.g. "Check", "CircleAlert").',
       control: 'text',
       table: {
         type: { summary: 'IconName' },
@@ -225,7 +225,7 @@ export const Icons: Story = {
       <Badge variant="success" icon="Check">
         Success
       </Badge>
-      <Badge variant="error" icon="AlertCircle">
+      <Badge variant="error" icon="CircleAlert">
         Error
       </Badge>
       <Badge variant="default" treatment="subtle" icon="Clock">

--- a/src/components/lv1/Badge/Badge.tsx
+++ b/src/components/lv1/Badge/Badge.tsx
@@ -25,7 +25,7 @@ export interface BadgeProps extends HTMLAttributes<HTMLDivElement>, BadgeVariant
    * @default 'md'
    */
   size?: BadgeVariants['size']
-  /** Lucide icon name in PascalCase (e.g. `"Check"`, `"AlertCircle"`). */
+  /** Lucide icon name in PascalCase (e.g. `"Check"`, `"CircleAlert"`). */
   icon?: IconName
   /**
    * Position of the icon relative to the label text.

--- a/src/components/lv1/Tooltip/Tooltip.stories.tsx
+++ b/src/components/lv1/Tooltip/Tooltip.stories.tsx
@@ -34,7 +34,6 @@ const meta: Meta<typeof TooltipContent> = {
       },
     },
     container: { table: { disable: true } },
-    hideArrow: { table: { disable: true } },
     asChild: { table: { disable: true } },
   },
 }

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,5 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["src/**/*", "vitest.setup.ts"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Summary

Closes #95.

`tsconfig.json` excluded `**/*.stories.tsx` and `**/*.test.tsx`, so `pnpm typecheck` skipped them entirely and let real bugs through CI. The dist build still needs that exclude (so generated `.d.ts` files don't pick up story/test types), but typecheck doesn't.

Splits the two concerns per Issue #95 **Option B**:

- `tsconfig.json` — dist build target, **unchanged** (still excludes stories/test, so `tsup`'s `dts` output stays clean).
- `tsconfig.test.json` *(new)* — extends the base but `include`s stories, tests, and `vitest.setup.ts`. The setup file already does `import '@testing-library/jest-dom/vitest'`, which is the only file in the project that pulls in the matcher type augmentation, so including it here is what makes `toBeInTheDocument` / `toHaveClass` / etc. visible to `tsc`.
- `pnpm typecheck` now runs against `tsconfig.test.json`.

CI (`.github/workflows/ci.yml`) already invokes `pnpm typecheck`, so no workflow change is needed — the new behavior takes effect automatically.

## Bugs surfaced and fixed while turning typecheck back on

Both of these were real bugs that the loose tsconfig had been hiding:

- **`Badge.stories.tsx` — `icon="AlertCircle"`** is a deprecated lucide-react alias that is **not** present in the `icons` object (verified: ``'AlertCircle' in icons === false``). The story rendered no icon at runtime. Now `"CircleAlert"`. JSDoc and `argTypes` examples on `BadgeProps.icon` updated to match.
- **`Tooltip.stories.tsx` — stale `argTypes.hideArrow` entry** for a prop that does not exist on `TooltipContentProps`. Removed.

## Timing

`pnpm typecheck`: **1.8s → 2.7s** locally (≈ +0.9s for the broader coverage; well within CI budget).

## DoD checklist (from #95)

- [x] `tsconfig.test.json` を新設 (案 B 採用)
- [x] `package.json` の `typecheck` スクリプトを更新
- [x] 検出された型エラーをすべて解消 (Badge.stories の AlertCircle, Tooltip.stories の hideArrow)
- [x] CI (`.github/workflows/ci.yml`) で新しい typecheck コマンドが動作することを確認 (CI は `pnpm typecheck` を呼ぶだけなので workflow 変更は不要 / lefthook の pre-commit でもグリーン)
- [x] `pnpm typecheck` の所要時間を計測 (before 1.8s / after 2.7s)

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm vitest run` — 8 files / 146 tests pass
- [x] `pnpm build:js` succeeds; `dist/` contains no `*.stories.*` / `*.test.*` files
- [x] `pnpm lint` clean
- [x] lefthook `pre-commit` hook (biome + typecheck) green

🤖 Generated with [Claude Code](https://claude.com/claude-code)