### PR TITLE
test: add unit tests for 8 lv1 components (closes #98)

### DIFF
--- a/.changeset/unit-tests-for-lv1-components.md
+++ b/.changeset/unit-tests-for-lv1-components.md
@@ -1,0 +1,20 @@
+---
+'@yasmro/schatten': patch
+---
+
+test: add unit tests for 8 lv1 components
+
+Add `*.test.tsx` for the 8 lv1 components that previously only had VRT coverage:
+Badge, Checkbox, Radio (+ RadioGroup), Select, Spinner, Switch, Text, Textarea.
+VRT keeps the look in check; unit tests now cover the logic that VRT cannot
+catch — props handling, `aria-*` attributes, keyboard / click events, controlled
+vs. uncontrolled state, and `<Field>` / `<RadioGroup>` context propagation.
+
+For Radix-backed components (Checkbox / Radio / Select / Switch), tests focus
+on the Schatten wrapping layer (variant classes, `isError`, `disabled`, context
+inheritance) rather than re-testing Radix internals.
+
+Adds a `scrollIntoView` polyfill to `vitest.setup.ts` so jsdom can run Radix
+Select tests that open the dropdown.
+
+No public API change.

--- a/src/components/lv1/Badge/Badge.test.tsx
+++ b/src/components/lv1/Badge/Badge.test.tsx
@@ -1,0 +1,132 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import { Badge } from './Badge'
+
+describe('Badge', () => {
+  it('renders children', () => {
+    render(<Badge>New</Badge>)
+    expect(screen.getByText('New')).toBeInTheDocument()
+  })
+
+  it('forwards className to the root element', () => {
+    const { container } = render(<Badge className="custom-class">Tag</Badge>)
+    const root = container.firstChild as HTMLElement
+    expect(root).toHaveClass('custom-class')
+  })
+
+  it('forwards data-* and other HTML attributes', () => {
+    const { container } = render(
+      <Badge data-testid="my-badge" role="status">
+        Tag
+      </Badge>,
+    )
+    const root = container.firstChild as HTMLElement
+    expect(root.getAttribute('data-testid')).toBe('my-badge')
+    expect(root.getAttribute('role')).toBe('status')
+  })
+
+  describe('variants × treatment', () => {
+    it('applies subtle treatment classes for error variant', () => {
+      const { container } = render(
+        <Badge variant="error" treatment="subtle">
+          Error
+        </Badge>,
+      )
+      const root = container.firstChild as HTMLElement
+      expect(root.className).toContain('bg-error-subtle')
+      expect(root.className).toContain('text-error')
+      expect(root.className).toContain('border-error')
+    })
+
+    it('applies solid treatment classes for success variant', () => {
+      const { container } = render(
+        <Badge variant="success" treatment="solid">
+          Saved
+        </Badge>,
+      )
+      const root = container.firstChild as HTMLElement
+      expect(root.className).toContain('bg-success')
+      expect(root.className).toContain('text-success-foreground')
+      expect(root.className).toContain('border-transparent')
+    })
+
+    it('applies outline treatment classes for info variant', () => {
+      const { container } = render(
+        <Badge variant="info" treatment="outline">
+          Info
+        </Badge>,
+      )
+      const root = container.firstChild as HTMLElement
+      expect(root.className).toContain('text-info')
+      expect(root.className).toContain('border-info')
+    })
+
+    it('applies default variant + subtle treatment by default', () => {
+      const { container } = render(<Badge>Default</Badge>)
+      const root = container.firstChild as HTMLElement
+      // subtle compound for default variant
+      expect(root.className).toContain('bg-surface-hover')
+      expect(root.className).toContain('border-border-strong')
+    })
+  })
+
+  describe('sizes', () => {
+    it('applies size classes', () => {
+      const { container, rerender } = render(<Badge size="sm">Small</Badge>)
+      const getRoot = () => container.firstChild as HTMLElement
+      expect(getRoot().className).toContain('text-[10px]')
+
+      rerender(<Badge size="lg">Large</Badge>)
+      expect(getRoot().className).toContain('text-sm')
+    })
+  })
+
+  describe('icon', () => {
+    it('renders icon at start position by default', () => {
+      const { container } = render(<Badge icon="Check">Done</Badge>)
+      const root = container.firstChild as HTMLElement
+      const svg = root.querySelector('svg')
+      expect(svg).toBeInTheDocument()
+      expect(svg?.getAttribute('aria-hidden')).toBe('true')
+      expect(root.firstChild).toBe(svg)
+    })
+
+    it('renders icon at end position when iconPosition="end"', () => {
+      const { container } = render(
+        <Badge icon="ArrowRight" iconPosition="end">
+          Next
+        </Badge>,
+      )
+      const root = container.firstChild as HTMLElement
+      const svg = root.querySelector('svg')
+      expect(svg).toBeInTheDocument()
+      expect(root.lastChild).toBe(svg)
+    })
+
+    it('renders without icon when icon prop is not provided', () => {
+      const { container } = render(<Badge>No icon</Badge>)
+      const root = container.firstChild as HTMLElement
+      expect(root.querySelector('svg')).not.toBeInTheDocument()
+    })
+
+    it('applies icon-only square layout when icon is set without children', () => {
+      const { container } = render(<Badge icon="Check" aria-label="Done" />)
+      const root = container.firstChild as HTMLElement
+      expect(root.className).toContain('aspect-square')
+      expect(root.className).toContain('p-1')
+      expect(root.querySelector('svg')).toBeInTheDocument()
+    })
+
+    it('does not apply icon-only layout when both icon and children are present', () => {
+      const { container } = render(<Badge icon="Check">Done</Badge>)
+      const root = container.firstChild as HTMLElement
+      expect(root.className).not.toContain('aspect-square')
+    })
+  })
+
+  it('forwards ref to the root div', () => {
+    const ref = { current: null as HTMLDivElement | null }
+    render(<Badge ref={ref}>Tag</Badge>)
+    expect(ref.current).toBeInstanceOf(HTMLDivElement)
+  })
+})

--- a/src/components/lv1/Checkbox/Checkbox.test.tsx
+++ b/src/components/lv1/Checkbox/Checkbox.test.tsx
@@ -1,0 +1,159 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it, vi } from 'vitest'
+import { Field } from '../Field/Field'
+import { Checkbox } from './Checkbox'
+
+describe('Checkbox', () => {
+  it('renders an unchecked checkbox by default', () => {
+    render(<Checkbox aria-label="Accept" />)
+    const checkbox = screen.getByRole('checkbox', { name: 'Accept' })
+    expect(checkbox).toBeInTheDocument()
+    expect(checkbox).toHaveAttribute('data-state', 'unchecked')
+  })
+
+  it('renders label and associates it via htmlFor', () => {
+    render(<Checkbox label="Subscribe" />)
+    const checkbox = screen.getByRole('checkbox')
+    const label = screen.getByText('Subscribe')
+    expect(label).toHaveAttribute('for', checkbox.id)
+  })
+
+  describe('sizes', () => {
+    it('applies size classes', () => {
+      const { rerender } = render(<Checkbox aria-label="cb" size="sm" />)
+      expect(screen.getByRole('checkbox')).toHaveClass('size-4')
+
+      rerender(<Checkbox aria-label="cb" size="lg" />)
+      expect(screen.getByRole('checkbox')).toHaveClass('size-6')
+    })
+
+    it('defaults to md size', () => {
+      render(<Checkbox aria-label="cb" />)
+      expect(screen.getByRole('checkbox')).toHaveClass('size-5')
+    })
+  })
+
+  describe('error state', () => {
+    it('applies error classes and aria-invalid when isError is true', () => {
+      render(<Checkbox aria-label="cb" isError />)
+      const checkbox = screen.getByRole('checkbox')
+      expect(checkbox.className).toContain('border-error')
+      expect(checkbox).toHaveAttribute('aria-invalid', 'true')
+    })
+
+    it('does not set aria-invalid when isError is false', () => {
+      render(<Checkbox aria-label="cb" />)
+      expect(screen.getByRole('checkbox')).not.toHaveAttribute('aria-invalid')
+    })
+  })
+
+  describe('disabled', () => {
+    it('disables the checkbox', () => {
+      render(<Checkbox aria-label="cb" disabled />)
+      expect(screen.getByRole('checkbox')).toBeDisabled()
+    })
+
+    it('does not fire onCheckedChange when disabled', async () => {
+      const onCheckedChange = vi.fn()
+      const user = userEvent.setup()
+      render(<Checkbox aria-label="cb" disabled onCheckedChange={onCheckedChange} />)
+      await user.click(screen.getByRole('checkbox'))
+      expect(onCheckedChange).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('controlled / uncontrolled', () => {
+    it('respects defaultChecked (uncontrolled)', () => {
+      render(<Checkbox aria-label="cb" defaultChecked />)
+      expect(screen.getByRole('checkbox')).toHaveAttribute('data-state', 'checked')
+    })
+
+    it('reflects controlled checked={true}', () => {
+      render(<Checkbox aria-label="cb" checked onCheckedChange={() => {}} />)
+      expect(screen.getByRole('checkbox')).toHaveAttribute('data-state', 'checked')
+    })
+
+    it('reflects controlled checked="indeterminate"', () => {
+      render(<Checkbox aria-label="cb" checked="indeterminate" onCheckedChange={() => {}} />)
+      expect(screen.getByRole('checkbox')).toHaveAttribute('data-state', 'indeterminate')
+    })
+
+    it('toggles state and fires onCheckedChange on click', async () => {
+      const onCheckedChange = vi.fn()
+      const user = userEvent.setup()
+      render(<Checkbox aria-label="cb" onCheckedChange={onCheckedChange} />)
+      const checkbox = screen.getByRole('checkbox')
+      await user.click(checkbox)
+      expect(onCheckedChange).toHaveBeenCalledWith(true)
+      expect(checkbox).toHaveAttribute('data-state', 'checked')
+    })
+  })
+
+  describe('label click', () => {
+    it('focuses/toggles when label is clicked', async () => {
+      const onCheckedChange = vi.fn()
+      const user = userEvent.setup()
+      render(<Checkbox label="Subscribe" onCheckedChange={onCheckedChange} />)
+      await user.click(screen.getByText('Subscribe'))
+      expect(onCheckedChange).toHaveBeenCalledWith(true)
+    })
+  })
+
+  describe('Field context integration', () => {
+    it('inherits isError from Field', () => {
+      render(
+        <Field label="Terms" error="Required">
+          <Checkbox aria-label="cb" />
+        </Field>,
+      )
+      const checkbox = screen.getByRole('checkbox')
+      expect(checkbox.className).toContain('border-error')
+      expect(checkbox).toHaveAttribute('aria-invalid', 'true')
+    })
+
+    it('inherits disabled from Field', () => {
+      render(
+        <Field label="Terms" disabled>
+          <Checkbox aria-label="cb" />
+        </Field>,
+      )
+      expect(screen.getByRole('checkbox')).toBeDisabled()
+    })
+
+    it('inherits aria-describedby from Field', () => {
+      render(
+        <Field label="Terms" description="Help text">
+          <Checkbox aria-label="cb" />
+        </Field>,
+      )
+      const describedBy = screen.getByRole('checkbox').getAttribute('aria-describedby')
+      expect(describedBy).toContain('-description')
+    })
+
+    it('does NOT inherit id from Field (Checkbox has its own label)', () => {
+      // Field provides its own id; Checkbox should keep its own unique id so
+      // label htmlFor works for the internal label.
+      render(
+        <Field label="Terms">
+          <Checkbox label="Accept" />
+        </Field>,
+      )
+      const checkbox = screen.getByRole('checkbox')
+      const internalLabel = screen.getByText('Accept')
+      // Internal label points to checkbox's id, not Field's outer label
+      expect(internalLabel).toHaveAttribute('for', checkbox.id)
+    })
+
+    it('prop isError overrides false Field context when used standalone', () => {
+      render(<Checkbox aria-label="cb" isError />)
+      expect(screen.getByRole('checkbox')).toHaveAttribute('aria-invalid', 'true')
+    })
+  })
+
+  it('forwards className to the root element', () => {
+    const { container } = render(<Checkbox aria-label="cb" className="custom-class" />)
+    const wrapper = container.firstChild as HTMLElement
+    expect(wrapper).toHaveClass('custom-class')
+  })
+})

--- a/src/components/lv1/Radio/Radio.test.tsx
+++ b/src/components/lv1/Radio/Radio.test.tsx
@@ -1,0 +1,185 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it, vi } from 'vitest'
+import { Field } from '../Field/Field'
+import { Radio, RadioGroup } from './Radio'
+
+describe('RadioGroup', () => {
+  it('renders all child radios', () => {
+    render(
+      <RadioGroup>
+        <Radio value="a" label="A" />
+        <Radio value="b" label="B" />
+        <Radio value="c" label="C" />
+      </RadioGroup>,
+    )
+    expect(screen.getAllByRole('radio')).toHaveLength(3)
+  })
+
+  it('selects a single radio at a time (controlled)', async () => {
+    const user = userEvent.setup()
+    const onValueChange = vi.fn()
+    render(
+      <RadioGroup value="a" onValueChange={onValueChange}>
+        <Radio value="a" label="A" />
+        <Radio value="b" label="B" />
+      </RadioGroup>,
+    )
+    const [a, b] = screen.getAllByRole('radio')
+    expect(a).toHaveAttribute('data-state', 'checked')
+    expect(b).toHaveAttribute('data-state', 'unchecked')
+
+    await user.click(b)
+    expect(onValueChange).toHaveBeenCalledWith('b')
+  })
+
+  it('respects defaultValue (uncontrolled)', () => {
+    render(
+      <RadioGroup defaultValue="b">
+        <Radio value="a" label="A" />
+        <Radio value="b" label="B" />
+      </RadioGroup>,
+    )
+    const [a, b] = screen.getAllByRole('radio')
+    expect(a).toHaveAttribute('data-state', 'unchecked')
+    expect(b).toHaveAttribute('data-state', 'checked')
+  })
+
+  it('propagates disabled to all radios', () => {
+    render(
+      <RadioGroup disabled>
+        <Radio value="a" label="A" />
+        <Radio value="b" label="B" />
+      </RadioGroup>,
+    )
+    for (const r of screen.getAllByRole('radio')) {
+      expect(r).toBeDisabled()
+    }
+  })
+
+  it('propagates isError to all radios', () => {
+    render(
+      <RadioGroup isError>
+        <Radio value="a" label="A" />
+        <Radio value="b" label="B" />
+      </RadioGroup>,
+    )
+    for (const r of screen.getAllByRole('radio')) {
+      expect(r).toHaveAttribute('aria-invalid', 'true')
+      expect(r.className).toContain('border-error')
+    }
+  })
+
+  it('propagates size to child radios', () => {
+    render(
+      <RadioGroup size="lg">
+        <Radio value="a" label="A" />
+      </RadioGroup>,
+    )
+    expect(screen.getByRole('radio')).toHaveClass('size-6')
+  })
+
+  it('sets aria-invalid on the group itself when isError', () => {
+    const { container } = render(
+      <RadioGroup isError>
+        <Radio value="a" label="A" />
+      </RadioGroup>,
+    )
+    const group = container.querySelector('[role="radiogroup"]')
+    expect(group).toHaveAttribute('aria-invalid', 'true')
+  })
+})
+
+describe('Radio', () => {
+  it('renders label and associates it via htmlFor', () => {
+    render(
+      <RadioGroup>
+        <Radio value="a" label="Option A" />
+      </RadioGroup>,
+    )
+    const radio = screen.getByRole('radio')
+    const label = screen.getByText('Option A')
+    expect(label).toHaveAttribute('for', radio.id)
+  })
+
+  it('per-item size overrides group size', () => {
+    render(
+      <RadioGroup size="lg">
+        <Radio value="a" label="A" size="sm" />
+        <Radio value="b" label="B" />
+      </RadioGroup>,
+    )
+    const [a, b] = screen.getAllByRole('radio')
+    expect(a).toHaveClass('size-4')
+    expect(b).toHaveClass('size-6')
+  })
+
+  it('per-item disabled does not affect siblings', () => {
+    render(
+      <RadioGroup>
+        <Radio value="a" label="A" disabled />
+        <Radio value="b" label="B" />
+      </RadioGroup>,
+    )
+    const [a, b] = screen.getAllByRole('radio')
+    expect(a).toBeDisabled()
+    expect(b).not.toBeDisabled()
+  })
+
+  it('per-item isError overrides group when explicitly set', () => {
+    render(
+      <RadioGroup>
+        <Radio value="a" label="A" isError />
+        <Radio value="b" label="B" />
+      </RadioGroup>,
+    )
+    const [a, b] = screen.getAllByRole('radio')
+    expect(a).toHaveAttribute('aria-invalid', 'true')
+    expect(b).not.toHaveAttribute('aria-invalid')
+  })
+
+  describe('Field context integration', () => {
+    it('RadioGroup inherits isError from Field', () => {
+      render(
+        <Field label="Pick one" error="Required">
+          <RadioGroup>
+            <Radio value="a" label="A" />
+          </RadioGroup>
+        </Field>,
+      )
+      expect(screen.getByRole('radio')).toHaveAttribute('aria-invalid', 'true')
+    })
+
+    it('RadioGroup inherits disabled from Field', () => {
+      render(
+        <Field label="Pick one" disabled>
+          <RadioGroup>
+            <Radio value="a" label="A" />
+          </RadioGroup>
+        </Field>,
+      )
+      expect(screen.getByRole('radio')).toBeDisabled()
+    })
+
+    it('RadioGroup inherits aria-describedby from Field', () => {
+      const { container } = render(
+        <Field label="Pick one" description="Help text">
+          <RadioGroup>
+            <Radio value="a" label="A" />
+          </RadioGroup>
+        </Field>,
+      )
+      const group = container.querySelector('[role="radiogroup"]')
+      expect(group?.getAttribute('aria-describedby')).toContain('-description')
+    })
+  })
+
+  it('forwards className on wrapping div', () => {
+    const { container } = render(
+      <RadioGroup>
+        <Radio value="a" label="A" className="custom-wrap" />
+      </RadioGroup>,
+    )
+    expect(container.querySelector('.custom-wrap')).toBeInTheDocument()
+  })
+})

--- a/src/components/lv1/Select/Select.test.tsx
+++ b/src/components/lv1/Select/Select.test.tsx
@@ -1,0 +1,159 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it, vi } from 'vitest'
+import { Field } from '../Field/Field'
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from './Select'
+
+function BasicSelect(props: {
+  defaultValue?: string
+  value?: string
+  onValueChange?: (v: string) => void
+  isError?: boolean
+  disabled?: boolean
+  size?: 'sm' | 'md' | 'lg'
+}) {
+  return (
+    <Select
+      defaultValue={props.defaultValue}
+      value={props.value}
+      onValueChange={props.onValueChange}
+    >
+      <SelectTrigger isError={props.isError} disabled={props.disabled} size={props.size}>
+        <SelectValue placeholder="Pick a fruit" />
+      </SelectTrigger>
+      <SelectContent>
+        <SelectItem value="apple">Apple</SelectItem>
+        <SelectItem value="banana">Banana</SelectItem>
+        <SelectItem value="cherry" disabled>
+          Cherry
+        </SelectItem>
+      </SelectContent>
+    </Select>
+  )
+}
+
+describe('Select', () => {
+  it('renders trigger with placeholder when no value is selected', () => {
+    render(<BasicSelect />)
+    const trigger = screen.getByRole('combobox')
+    expect(trigger).toBeInTheDocument()
+    expect(trigger).toHaveTextContent('Pick a fruit')
+  })
+
+  it('shows the selected value text when defaultValue is set', () => {
+    render(<BasicSelect defaultValue="apple" />)
+    expect(screen.getByRole('combobox')).toHaveTextContent('Apple')
+  })
+
+  describe('sizes', () => {
+    it('applies size classes to the trigger', () => {
+      const { rerender } = render(<BasicSelect size="sm" />)
+      expect(screen.getByRole('combobox')).toHaveClass('h-8')
+
+      rerender(<BasicSelect size="lg" />)
+      expect(screen.getByRole('combobox')).toHaveClass('h-12')
+    })
+
+    it('defaults to md size', () => {
+      render(<BasicSelect />)
+      expect(screen.getByRole('combobox')).toHaveClass('h-10')
+    })
+  })
+
+  describe('error state', () => {
+    it('applies error classes and aria-invalid when isError', () => {
+      render(<BasicSelect isError />)
+      const trigger = screen.getByRole('combobox')
+      expect(trigger.className).toContain('border-error')
+      expect(trigger).toHaveAttribute('aria-invalid', 'true')
+    })
+
+    it('does not set aria-invalid when isError is false', () => {
+      render(<BasicSelect />)
+      expect(screen.getByRole('combobox')).not.toHaveAttribute('aria-invalid')
+    })
+  })
+
+  describe('disabled', () => {
+    it('disables the trigger', () => {
+      render(<BasicSelect disabled />)
+      expect(screen.getByRole('combobox')).toBeDisabled()
+    })
+  })
+
+  describe('open / close / select', () => {
+    it('opens content on trigger click and shows items', async () => {
+      const user = userEvent.setup()
+      render(<BasicSelect />)
+      await user.click(screen.getByRole('combobox'))
+      // Radix renders items in a portal once open.
+      expect(await screen.findByRole('option', { name: 'Apple' })).toBeInTheDocument()
+      expect(screen.getByRole('option', { name: 'Banana' })).toBeInTheDocument()
+    })
+
+    it('selecting an item fires onValueChange', async () => {
+      const onValueChange = vi.fn()
+      const user = userEvent.setup()
+      render(<BasicSelect onValueChange={onValueChange} />)
+      await user.click(screen.getByRole('combobox'))
+      const banana = await screen.findByRole('option', { name: 'Banana' })
+      await user.click(banana)
+      expect(onValueChange).toHaveBeenCalledWith('banana')
+    })
+
+    it('marks disabled items with data-disabled and skips them on selection', async () => {
+      const onValueChange = vi.fn()
+      const user = userEvent.setup()
+      render(<BasicSelect onValueChange={onValueChange} />)
+      await user.click(screen.getByRole('combobox'))
+      const cherry = await screen.findByRole('option', { name: 'Cherry' })
+      expect(cherry).toHaveAttribute('data-disabled')
+      await user.click(cherry)
+      // Radix swallows the click on disabled items.
+      expect(onValueChange).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('Field context integration', () => {
+    it('uses Field id on the trigger', () => {
+      render(
+        <Field label="Fruit">
+          <BasicSelect />
+        </Field>,
+      )
+      const trigger = screen.getByRole('combobox')
+      const label = screen.getByText('Fruit')
+      expect(label).toHaveAttribute('for', trigger.id)
+    })
+
+    it('inherits isError from Field', () => {
+      render(
+        <Field label="Fruit" error="Required">
+          <BasicSelect />
+        </Field>,
+      )
+      const trigger = screen.getByRole('combobox')
+      expect(trigger.className).toContain('border-error')
+      expect(trigger).toHaveAttribute('aria-invalid', 'true')
+    })
+
+    it('inherits disabled from Field', () => {
+      render(
+        <Field label="Fruit" disabled>
+          <BasicSelect />
+        </Field>,
+      )
+      expect(screen.getByRole('combobox')).toBeDisabled()
+    })
+
+    it('inherits aria-describedby from Field', () => {
+      render(
+        <Field label="Fruit" description="Help text">
+          <BasicSelect />
+        </Field>,
+      )
+      const describedBy = screen.getByRole('combobox').getAttribute('aria-describedby')
+      expect(describedBy).toContain('-description')
+    })
+  })
+})

--- a/src/components/lv1/Spinner/Spinner.test.tsx
+++ b/src/components/lv1/Spinner/Spinner.test.tsx
@@ -24,7 +24,6 @@ describe('Spinner', () => {
   describe('type', () => {
     it('renders the default (spinning circle) SVG by default', () => {
       const { container } = render(<Spinner data-testid="s" />)
-      // The default spinner uses `animate-spin` on its <svg>.
       const svg = container.querySelector('svg')
       expect(svg).toBeInTheDocument()
       expect(svg?.classList.contains('animate-spin')).toBe(true)

--- a/src/components/lv1/Spinner/Spinner.test.tsx
+++ b/src/components/lv1/Spinner/Spinner.test.tsx
@@ -1,0 +1,91 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import { Spinner } from './Spinner'
+
+describe('Spinner', () => {
+  it('renders with role="status"', () => {
+    render(<Spinner />)
+    expect(screen.getByRole('status')).toBeInTheDocument()
+  })
+
+  it('renders a visually-hidden default label "Loading"', () => {
+    render(<Spinner />)
+    const labelEl = screen.getByText('Loading')
+    expect(labelEl).toBeInTheDocument()
+    expect(labelEl).toHaveClass('sr-only')
+  })
+
+  it('renders a custom label', () => {
+    render(<Spinner label="Fetching data" />)
+    expect(screen.getByText('Fetching data')).toBeInTheDocument()
+    expect(screen.queryByText('Loading')).not.toBeInTheDocument()
+  })
+
+  describe('type', () => {
+    it('renders the default (spinning circle) SVG by default', () => {
+      const { container } = render(<Spinner data-testid="s" />)
+      // The default spinner uses `animate-spin` on its <svg>.
+      const svg = container.querySelector('svg')
+      expect(svg).toBeInTheDocument()
+      expect(svg?.classList.contains('animate-spin')).toBe(true)
+    })
+
+    it('renders the ripple variant when type="ripple"', () => {
+      const { container } = render(<Spinner type="ripple" />)
+      // The ripple variant has dot + 2 concentric ripples; check for the
+      // unique class names rather than counting SVG children, which can
+      // change with future tweaks.
+      expect(container.querySelector('.schatten-spinner-dot')).toBeInTheDocument()
+      expect(container.querySelectorAll('.schatten-spinner-ripple')).toHaveLength(2)
+    })
+  })
+
+  describe('sizes', () => {
+    it('applies size classes', () => {
+      const { rerender, container } = render(<Spinner size="sm" />)
+      const getRoot = () => container.firstChild as HTMLElement
+      expect(getRoot()).toHaveClass('size-4')
+
+      rerender(<Spinner size="lg" />)
+      expect(getRoot()).toHaveClass('size-8')
+    })
+
+    it('defaults to md size', () => {
+      const { container } = render(<Spinner />)
+      expect(container.firstChild as HTMLElement).toHaveClass('size-6')
+    })
+  })
+
+  describe('variants', () => {
+    it('uses text-foreground for default variant', () => {
+      const { container } = render(<Spinner />)
+      expect(container.firstChild as HTMLElement).toHaveClass('text-foreground')
+    })
+
+    it('uses text-inverted-foreground for inverted variant', () => {
+      const { container } = render(<Spinner variant="inverted" />)
+      expect(container.firstChild as HTMLElement).toHaveClass('text-inverted-foreground')
+    })
+  })
+
+  it('marks the inner SVG as aria-hidden', () => {
+    const { container } = render(<Spinner />)
+    expect(container.querySelector('svg')).toHaveAttribute('aria-hidden', 'true')
+  })
+
+  it('forwards className', () => {
+    const { container } = render(<Spinner className="custom-class" />)
+    expect(container.firstChild as HTMLElement).toHaveClass('custom-class')
+  })
+
+  it('forwards arbitrary props like data-* to the root', () => {
+    render(<Spinner data-testid="my-spinner" />)
+    expect(screen.getByTestId('my-spinner')).toBeInTheDocument()
+  })
+
+  it('forwards ref to the root div', () => {
+    const ref = { current: null as HTMLDivElement | null }
+    render(<Spinner ref={ref} />)
+    expect(ref.current).toBeInstanceOf(HTMLDivElement)
+  })
+})

--- a/src/components/lv1/Switch/Switch.test.tsx
+++ b/src/components/lv1/Switch/Switch.test.tsx
@@ -1,0 +1,143 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it, vi } from 'vitest'
+import { Field } from '../Field/Field'
+import { Switch } from './Switch'
+
+describe('Switch', () => {
+  it('renders an unchecked switch by default', () => {
+    render(<Switch aria-label="Notifications" />)
+    const sw = screen.getByRole('switch', { name: 'Notifications' })
+    expect(sw).toBeInTheDocument()
+    expect(sw).toHaveAttribute('data-state', 'unchecked')
+  })
+
+  it('renders label and associates it via htmlFor', () => {
+    render(<Switch label="Notifications" />)
+    const sw = screen.getByRole('switch')
+    const label = screen.getByText('Notifications')
+    expect(label).toHaveAttribute('for', sw.id)
+  })
+
+  describe('sizes', () => {
+    it('applies size classes', () => {
+      const { rerender } = render(<Switch aria-label="sw" size="sm" />)
+      expect(screen.getByRole('switch')).toHaveClass('h-4')
+
+      rerender(<Switch aria-label="sw" size="lg" />)
+      expect(screen.getByRole('switch')).toHaveClass('h-6')
+    })
+
+    it('defaults to md size', () => {
+      render(<Switch aria-label="sw" />)
+      expect(screen.getByRole('switch')).toHaveClass('h-5')
+    })
+  })
+
+  describe('error state', () => {
+    it('applies error classes and aria-invalid when isError is true', () => {
+      render(<Switch aria-label="sw" isError />)
+      const sw = screen.getByRole('switch')
+      expect(sw.className).toContain('border-error')
+      expect(sw).toHaveAttribute('aria-invalid', 'true')
+    })
+
+    it('does not set aria-invalid when isError is false', () => {
+      render(<Switch aria-label="sw" />)
+      expect(screen.getByRole('switch')).not.toHaveAttribute('aria-invalid')
+    })
+  })
+
+  describe('disabled', () => {
+    it('disables the switch', () => {
+      render(<Switch aria-label="sw" disabled />)
+      expect(screen.getByRole('switch')).toBeDisabled()
+    })
+
+    it('does not fire onCheckedChange when disabled', async () => {
+      const onCheckedChange = vi.fn()
+      const user = userEvent.setup()
+      render(<Switch aria-label="sw" disabled onCheckedChange={onCheckedChange} />)
+      await user.click(screen.getByRole('switch'))
+      expect(onCheckedChange).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('controlled / uncontrolled', () => {
+    it('respects defaultChecked (uncontrolled)', () => {
+      render(<Switch aria-label="sw" defaultChecked />)
+      expect(screen.getByRole('switch')).toHaveAttribute('data-state', 'checked')
+    })
+
+    it('reflects controlled checked', () => {
+      render(<Switch aria-label="sw" checked onCheckedChange={() => {}} />)
+      expect(screen.getByRole('switch')).toHaveAttribute('data-state', 'checked')
+    })
+
+    it('toggles state and fires onCheckedChange on click', async () => {
+      const onCheckedChange = vi.fn()
+      const user = userEvent.setup()
+      render(<Switch aria-label="sw" onCheckedChange={onCheckedChange} />)
+      const sw = screen.getByRole('switch')
+      await user.click(sw)
+      expect(onCheckedChange).toHaveBeenCalledWith(true)
+      expect(sw).toHaveAttribute('data-state', 'checked')
+    })
+
+    it('toggles via label click', async () => {
+      const onCheckedChange = vi.fn()
+      const user = userEvent.setup()
+      render(<Switch label="Notifications" onCheckedChange={onCheckedChange} />)
+      await user.click(screen.getByText('Notifications'))
+      expect(onCheckedChange).toHaveBeenCalledWith(true)
+    })
+  })
+
+  describe('Field context integration', () => {
+    it('inherits isError from Field', () => {
+      render(
+        <Field label="Notifications" error="Required">
+          <Switch aria-label="sw" />
+        </Field>,
+      )
+      const sw = screen.getByRole('switch')
+      expect(sw.className).toContain('border-error')
+      expect(sw).toHaveAttribute('aria-invalid', 'true')
+    })
+
+    it('inherits disabled from Field', () => {
+      render(
+        <Field label="Notifications" disabled>
+          <Switch aria-label="sw" />
+        </Field>,
+      )
+      expect(screen.getByRole('switch')).toBeDisabled()
+    })
+
+    it('inherits aria-describedby from Field', () => {
+      render(
+        <Field label="Notifications" description="Help text">
+          <Switch aria-label="sw" />
+        </Field>,
+      )
+      const describedBy = screen.getByRole('switch').getAttribute('aria-describedby')
+      expect(describedBy).toContain('-description')
+    })
+
+    it('does NOT inherit id from Field (Switch has its own label)', () => {
+      render(
+        <Field label="Notifications">
+          <Switch label="Toggle" />
+        </Field>,
+      )
+      const sw = screen.getByRole('switch')
+      const internalLabel = screen.getByText('Toggle')
+      expect(internalLabel).toHaveAttribute('for', sw.id)
+    })
+  })
+
+  it('forwards className to the wrapper', () => {
+    const { container } = render(<Switch aria-label="sw" className="custom-class" />)
+    expect(container.firstChild as HTMLElement).toHaveClass('custom-class')
+  })
+})

--- a/src/components/lv1/Text/Text.test.tsx
+++ b/src/components/lv1/Text/Text.test.tsx
@@ -1,0 +1,126 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import { Text } from './Text'
+
+describe('Text', () => {
+  it('renders children as text', () => {
+    render(<Text>Hello</Text>)
+    expect(screen.getByText('Hello')).toBeInTheDocument()
+  })
+
+  describe('default element', () => {
+    it('renders <p> for variant="body" by default', () => {
+      const { container } = render(<Text>Body</Text>)
+      expect(container.firstElementChild?.tagName.toLowerCase()).toBe('p')
+    })
+
+    it('renders <p> for variant="heading" by default (caller must pass `as`)', () => {
+      const { container } = render(<Text variant="heading">Title</Text>)
+      expect(container.firstElementChild?.tagName.toLowerCase()).toBe('p')
+    })
+
+    it('renders <label> for variant="label" by default', () => {
+      const { container } = render(<Text variant="label">Field</Text>)
+      expect(container.firstElementChild?.tagName.toLowerCase()).toBe('label')
+    })
+  })
+
+  describe('as prop', () => {
+    it.each([
+      'h1',
+      'h2',
+      'h3',
+      'h4',
+      'h5',
+      'h6',
+      'span',
+      'p',
+    ] as const)('renders an <%s> element when as="%s"', (tag) => {
+      const { container } = render(
+        <Text variant="heading" as={tag}>
+          Heading
+        </Text>,
+      )
+      expect(container.firstElementChild?.tagName.toLowerCase()).toBe(tag)
+    })
+  })
+
+  describe('asChild', () => {
+    it('delegates rendering to child via Slot when asChild is true', () => {
+      render(
+        <Text asChild>
+          <a href="/foo">Link</a>
+        </Text>,
+      )
+      const link = screen.getByRole('link', { name: 'Link' })
+      expect(link.tagName.toLowerCase()).toBe('a')
+      expect(link).toHaveAttribute('href', '/foo')
+    })
+
+    it('merges Text classes onto the child element', () => {
+      render(
+        <Text asChild color="error">
+          <a href="/foo">Link</a>
+        </Text>,
+      )
+      const link = screen.getByRole('link')
+      expect(link).toHaveClass('text-error')
+    })
+  })
+
+  describe('color', () => {
+    it('applies semantic color classes', () => {
+      const { container, rerender } = render(<Text color="error">x</Text>)
+      const getEl = () => container.firstElementChild as HTMLElement
+      expect(getEl()).toHaveClass('text-error')
+
+      rerender(<Text color="success">x</Text>)
+      expect(getEl()).toHaveClass('text-success')
+
+      rerender(<Text color="muted">x</Text>)
+      expect(getEl()).toHaveClass('text-foreground-muted')
+
+      rerender(<Text color="inherit">x</Text>)
+      expect(getEl()).toHaveClass('text-inherit')
+    })
+  })
+
+  describe('align', () => {
+    it('applies alignment classes', () => {
+      const { container, rerender } = render(<Text align="center">x</Text>)
+      const getEl = () => container.firstElementChild as HTMLElement
+      expect(getEl()).toHaveClass('text-center')
+
+      rerender(<Text align="right">x</Text>)
+      expect(getEl()).toHaveClass('text-right')
+    })
+  })
+
+  describe('truncate', () => {
+    it('applies truncate class when truncate is true', () => {
+      const { container } = render(<Text truncate>long</Text>)
+      expect(container.firstElementChild).toHaveClass('truncate')
+    })
+
+    it('does not apply truncate class by default', () => {
+      const { container } = render(<Text>short</Text>)
+      expect(container.firstElementChild).not.toHaveClass('truncate')
+    })
+  })
+
+  it('forwards className', () => {
+    const { container } = render(<Text className="custom-class">x</Text>)
+    expect(container.firstElementChild).toHaveClass('custom-class')
+  })
+
+  it('forwards arbitrary HTML attributes', () => {
+    const { container } = render(
+      <Text data-testid="t" id="my-id">
+        x
+      </Text>,
+    )
+    const el = container.firstElementChild as HTMLElement
+    expect(el.getAttribute('data-testid')).toBe('t')
+    expect(el.id).toBe('my-id')
+  })
+})

--- a/src/components/lv1/Textarea/Textarea.test.tsx
+++ b/src/components/lv1/Textarea/Textarea.test.tsx
@@ -1,0 +1,127 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it, vi } from 'vitest'
+import { Field } from '../Field/Field'
+import { Textarea } from './Textarea'
+
+describe('Textarea', () => {
+  it('renders a <textarea> element', () => {
+    render(<Textarea aria-label="bio" />)
+    const ta = screen.getByRole('textbox', { name: 'bio' })
+    expect(ta.tagName.toLowerCase()).toBe('textarea')
+  })
+
+  it('renders the placeholder', () => {
+    render(<Textarea aria-label="bio" placeholder="Tell us about yourself" />)
+    expect(screen.getByPlaceholderText('Tell us about yourself')).toBeInTheDocument()
+  })
+
+  it('respects the rows attribute', () => {
+    render(<Textarea aria-label="bio" rows={6} />)
+    expect(screen.getByRole('textbox')).toHaveAttribute('rows', '6')
+  })
+
+  describe('sizes', () => {
+    it('applies size classes', () => {
+      const { rerender } = render(<Textarea aria-label="bio" size="sm" />)
+      expect(screen.getByRole('textbox')).toHaveClass('text-xs')
+
+      rerender(<Textarea aria-label="bio" size="lg" />)
+      expect(screen.getByRole('textbox')).toHaveClass('text-base')
+    })
+
+    it('defaults to md size', () => {
+      render(<Textarea aria-label="bio" />)
+      expect(screen.getByRole('textbox')).toHaveClass('text-sm')
+    })
+  })
+
+  describe('error state', () => {
+    it('applies error classes and aria-invalid when isError is true', () => {
+      render(<Textarea aria-label="bio" isError />)
+      const ta = screen.getByRole('textbox')
+      expect(ta.className).toContain('border-error')
+      expect(ta.className).toContain('bg-error-subtle')
+      expect(ta).toHaveAttribute('aria-invalid', 'true')
+    })
+
+    it('uses border-border-strong (no error) when isError is false', () => {
+      render(<Textarea aria-label="bio" />)
+      const ta = screen.getByRole('textbox')
+      expect(ta.className).toContain('border-border-strong')
+      expect(ta).not.toHaveAttribute('aria-invalid')
+    })
+  })
+
+  describe('disabled', () => {
+    it('disables the textarea', () => {
+      render(<Textarea aria-label="bio" disabled />)
+      expect(screen.getByRole('textbox')).toBeDisabled()
+    })
+  })
+
+  describe('change handling', () => {
+    it('fires onChange while typing', async () => {
+      const onChange = vi.fn()
+      const user = userEvent.setup()
+      render(<Textarea aria-label="bio" onChange={onChange} />)
+      await user.type(screen.getByRole('textbox'), 'hi')
+      expect(onChange).toHaveBeenCalled()
+      expect(screen.getByRole('textbox')).toHaveValue('hi')
+    })
+  })
+
+  describe('Field context integration', () => {
+    it('uses Field id', () => {
+      render(
+        <Field label="Bio">
+          <Textarea />
+        </Field>,
+      )
+      const ta = screen.getByRole('textbox')
+      const label = screen.getByText('Bio')
+      expect(label).toHaveAttribute('for', ta.id)
+    })
+
+    it('inherits isError from Field', () => {
+      render(
+        <Field label="Bio" error="Required">
+          <Textarea />
+        </Field>,
+      )
+      const ta = screen.getByRole('textbox')
+      expect(ta.className).toContain('border-error')
+      expect(ta).toHaveAttribute('aria-invalid', 'true')
+    })
+
+    it('inherits disabled from Field', () => {
+      render(
+        <Field label="Bio" disabled>
+          <Textarea />
+        </Field>,
+      )
+      expect(screen.getByRole('textbox')).toBeDisabled()
+    })
+
+    it('inherits aria-describedby from Field', () => {
+      render(
+        <Field label="Bio" description="Help text">
+          <Textarea />
+        </Field>,
+      )
+      const describedBy = screen.getByRole('textbox').getAttribute('aria-describedby')
+      expect(describedBy).toContain('-description')
+    })
+  })
+
+  it('forwards className', () => {
+    render(<Textarea aria-label="bio" className="custom-class" />)
+    expect(screen.getByRole('textbox')).toHaveClass('custom-class')
+  })
+
+  it('forwards ref to the textarea element', () => {
+    const ref = { current: null as HTMLTextAreaElement | null }
+    render(<Textarea aria-label="bio" ref={ref} />)
+    expect(ref.current).toBeInstanceOf(HTMLTextAreaElement)
+  })
+})

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -18,4 +18,8 @@ if (typeof Element !== 'undefined') {
   if (!Element.prototype.releasePointerCapture) {
     Element.prototype.releasePointerCapture = () => {}
   }
+  // Radix Select calls scrollIntoView on the active item when opening.
+  if (!Element.prototype.scrollIntoView) {
+    Element.prototype.scrollIntoView = () => {}
+  }
 }


### PR DESCRIPTION
## Summary

Add `*.test.tsx` for the 8 lv1 components that previously had VRT-only coverage:
**Badge, Checkbox, Radio (+ RadioGroup), Select, Spinner, Switch, Text, Textarea**.

VRT keeps the look in check; unit tests cover the logic VRT cannot catch — props
handling, `aria-*` attributes, keyboard/click events, controlled vs. uncontrolled
state, and `<Field>` / `<RadioGroup>` context propagation.

### Test scope per component

| Component | Highlights |
|---|---|
| Badge | variant × treatment compound classes, icon position, icon-only square layout |
| Checkbox | controlled/uncontrolled + indeterminate, click & label toggle, Field context |
| Radio + RadioGroup | single-select, group→item propagation, per-item override |
| Select | open/close, item select, **disabled-item skip**, Field id wiring |
| Spinner | role=status, sr-only label, `default` vs `ripple` rendering |
| Switch | controlled state, label click toggle, Field context |
| Text | default/ as / asChild element mapping, color/align/truncate |
| Textarea | rows, error styling, Field id + describedBy wiring |

For Radix-backed components (Checkbox / Radio / Select / Switch) the tests
focus on the **Schatten wrapping layer** (variant classes, `isError`, `disabled`,
context inheritance) rather than re-testing Radix internals — per the issue
guidance.

### Infra

- Added a `scrollIntoView` polyfill to [vitest.setup.ts](https://github.com/yasmro/schatten/blob/main/vitest.setup.ts) so jsdom can run Radix Select tests that open the dropdown.

### Numbers

- **273 tests passing across 16 files** (up from 146 in 8 files — +127 tests / +8 files).
- `pnpm typecheck` ✅
- `pnpm lint` ✅

## Self-review notes

- Running just the 8 new files in isolation: **127/127 pass with no `act()` warnings**. The `act()` warning visible in the full-suite output originates from pre-existing tests (Toast / Dialog), not from this PR.
- Comments in new tests were kept to *why* only (e.g. why `findByRole` rather than `getByRole` after opening Radix Select). One stray *what* comment in `Spinner.test.tsx` was caught and removed in a follow-up commit.

### Out of scope (potential follow-ups)

- **Spinner `prefers-reduced-motion`**: the issue listed this as a consideration, but `src/components/lv1/Spinner/Spinner.css` does not yet have any `@media (prefers-reduced-motion: reduce)` rules (Tooltip / Toast / Dialog do). The feature itself is unimplemented, so this PR does not test it. Worth a separate issue if the team wants Spinner to honor the user preference.

## Test plan

- [x] `pnpm test` — all 273 pass
- [x] `pnpm test` against the 8 new files only — 127 pass, no `act()` warnings
- [x] `pnpm typecheck` — no errors
- [x] `pnpm lint` — no errors
- [x] CI will re-run the same checks

Closes #98

🤖 Generated with [Claude Code](https://claude.com/claude-code)