### PR TITLE
chore(lint): strengthen Biome rules on top of recommended (closes #97)

### DIFF
--- a/.changeset/biome-rules-strengthened.md
+++ b/.changeset/biome-rules-strengthened.md
@@ -1,0 +1,32 @@
+---
+'@yasmro/schatten': patch
+---
+
+chore(lint): strengthen Biome rules on top of `recommended`
+
+[biome.json](biome.json) previously enabled only `recommended: true`. That
+left a few classes of bug uncaught — stale `useEffect` deps, unused imports
+left over from refactors, value-imports for type-only symbols, stray
+`console.log` shipped to consumers. None of those are caught by
+`recommended`, but all are mechanical to enforce.
+
+The internal codebase already followed these conventions, so enabling the
+rules produced **zero violations**.
+
+Rules added (see [.claude/rules/lint-rules-guideline.md](.claude/rules/lint-rules-guideline.md)
+for the rationale on each):
+
+- `correctness/useExhaustiveDependencies` — `error`
+- `correctness/noUnusedImports` — `error`
+- `correctness/noUnusedVariables` — `error`
+- `style/useImportType` — `error`
+- `style/useExportType` — `error`
+- `style/noNonNullAssertion` — `warn`
+- `suspicious/noConsole` — `error` with `allow: ["warn", "error"]` (the two
+  variants the library uses to flag developer misuse — e.g. Button's
+  `isLoading + asChild` warning)
+
+Also aligned the `$schema` URL to the installed Biome version (`2.4.14`),
+silencing the schema-mismatch info on every `pnpm lint` run.
+
+No public API change.

--- a/.claude/rules/lint-rules-guideline.md
+++ b/.claude/rules/lint-rules-guideline.md
@@ -1,0 +1,101 @@
+# Lint Rules Guideline
+
+## Overview
+
+[biome.json](../../biome.json) starts from `recommended: true` and adds a small,
+deliberate set of rules on top. This document records **why** each non-default
+rule was selected, so future contributors can judge edge cases and decide
+whether new rules belong here.
+
+Tooling: Biome (single binary handles lint + format + import sort). Run
+`pnpm lint` (CI mode, read-only) or `pnpm lint:fix` (auto-fix where safe).
+
+## Rules added on top of `recommended`
+
+### `correctness/useExhaustiveDependencies` — `error`
+
+Catches missing or stale dependencies on `useEffect` / `useMemo` / `useCallback`.
+
+**Why:** A miscounted dependency array is one of the most common React bugs and
+typically silent — the hook stops re-running but tests still pass. AI-generated
+hooks are especially prone to this when the hook is edited later and a captured
+variable is forgotten. We treat it as `error` rather than `warn` so it must be
+addressed at PR time, not deferred.
+
+**Escape hatch:** If a dependency is genuinely meant to be excluded (e.g. a
+ref or a setter from `useState` that's stable by contract), add an inline
+`// biome-ignore lint/correctness/useExhaustiveDependencies: <reason>` rather
+than silencing the rule globally.
+
+### `correctness/noUnusedImports` — `error`
+
+### `correctness/noUnusedVariables` — `error`
+
+**Why:** Dead imports/variables accumulate fast in a component library where
+prop types, variant tuples, and Radix primitives are constantly being
+re-shuffled. Most are the residue of incomplete refactors. Keeping them is
+strictly downside — bigger bundles, noisier diffs, harder PR reviews.
+
+`noUnusedVariables` also flags unused function parameters. The convention is
+to prefix intentional unused names with `_` (e.g. `_event`) — Biome treats
+that prefix as "intentionally unused" and skips the rule.
+
+### `style/useImportType` — `error`
+
+### `style/useExportType` — `error`
+
+**Why:** TypeScript erases type-only imports at compile time, but only when
+the import is explicitly marked `import type` (or per-symbol `import { type X }`).
+Mixing types into value imports keeps the runtime module reference alive
+unnecessarily, can confuse tree-shaking, and causes subtle issues with
+circular type-only references.
+
+Both Biome rules auto-fix to the canonical `import { type Foo } from '…'` /
+`export type { Foo }` form. Keep using them — manual fixes drift.
+
+### `style/noNonNullAssertion` — `warn`
+
+**Why:** `value!` silences the type system without proof. In a design system
+that consumers depend on, a stray non-null assertion can quietly hide a real
+nullable case and ship the bug to every downstream app.
+
+Set to `warn` (not `error`) because there are a handful of legitimate cases —
+Radix slot refs, well-known DOM globals inside a `typeof window !== 'undefined'`
+branch — where the assertion is the cleanest expression of an invariant the
+type system can't follow. A `warn` keeps these visible in editor hover and PR
+review without blocking CI.
+
+**When you do use `!`:** add a brief comment next to it explaining the
+invariant that makes the assertion safe.
+
+### `suspicious/noConsole` — `error` with `allow: ["warn", "error"]`
+
+**Why:** Stray `console.log` is the most common source of accidental noise
+shipped to consumer apps. A design system should never emit dev-time chatter
+into its users' browsers.
+
+`console.warn` and `console.error` are explicitly allowed because we use them
+to surface *misuses of a component* back to developers — e.g.
+[Button.tsx:102](../../src/components/lv1/Button/Button.tsx#L102) warns when
+`isLoading` is combined with `asChild` (an unsupported combination), and
+[Dialog.tsx:241](../../src/components/lv1/Dialog/Dialog.tsx#L241) warns when
+required props are missing. That's a feature, not noise.
+
+## Rules deliberately **not** added
+
+- **`nursery/useSortedClasses` (Tailwind utility sort)** — under consideration
+  for Phase 2. Not enabled yet because it churns existing files and the
+  ergonomic win is marginal compared to the diff cost.
+- **Custom rule banning primitive color classes (`bg-red-*`, …)** — planned
+  for v0.8.0. The convention is enforced today via [state-token-guideline](state-token-guideline.md)
+  and code review; a Biome custom rule will make it mechanical.
+
+## When adding a new rule
+
+1. Open a draft PR enabling the rule at the desired severity.
+2. Run `pnpm lint` and report the violation count in the PR description.
+3. Justify the rule with a real bug class it would have caught (don't enable
+   rules just because they sound nice).
+4. If the violation count is large, prefer auto-fix; if it requires manual
+   judgment, raise an issue first to land the rule and the fix in separate PRs.
+5. Add a paragraph here recording the **why**.

--- a/.claude/rules/lint-rules-guideline.md
+++ b/.claude/rules/lint-rules-guideline.md
@@ -27,9 +27,7 @@ ref or a setter from `useState` that's stable by contract), add an inline
 `// biome-ignore lint/correctness/useExhaustiveDependencies: <reason>` rather
 than silencing the rule globally.
 
-### `correctness/noUnusedImports` — `error`
-
-### `correctness/noUnusedVariables` — `error`
+### `correctness/noUnusedImports` / `noUnusedVariables` — `error`
 
 **Why:** Dead imports/variables accumulate fast in a component library where
 prop types, variant tuples, and Radix primitives are constantly being
@@ -40,9 +38,7 @@ strictly downside — bigger bundles, noisier diffs, harder PR reviews.
 to prefix intentional unused names with `_` (e.g. `_event`) — Biome treats
 that prefix as "intentionally unused" and skips the rule.
 
-### `style/useImportType` — `error`
-
-### `style/useExportType` — `error`
+### `style/useImportType` / `useExportType` — `error`
 
 **Why:** TypeScript erases type-only imports at compile time, but only when
 the import is explicitly marked `import type` (or per-symbol `import { type X }`).

--- a/.claude/rules/lint-rules-guideline.md
+++ b/.claude/rules/lint-rules-guideline.md
@@ -76,10 +76,11 @@ into its users' browsers.
 
 `console.warn` and `console.error` are explicitly allowed because we use them
 to surface *misuses of a component* back to developers — e.g.
-[Button.tsx:102](../../src/components/lv1/Button/Button.tsx#L102) warns when
-`isLoading` is combined with `asChild` (an unsupported combination), and
-[Dialog.tsx:241](../../src/components/lv1/Dialog/Dialog.tsx#L241) warns when
-required props are missing. That's a feature, not noise.
+[Button](../../src/components/lv1/Button/Button.tsx) warns when `isLoading`
+is combined with `asChild` (an unsupported combination), and
+[Dialog](../../src/components/lv1/Dialog/Dialog.tsx) warns when
+`actionButton.onClick` is undefined (a footgun — clicking the action button
+becomes a silent no-op). That's a feature, not noise.
 
 ## Rules deliberately **not** added
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,6 +38,7 @@ Before adding or modifying components, read the guideline files under [`.claude/
 - [`state-token-guideline.md`](.claude/rules/state-token-guideline.md) — 3-layer token system, state semantic tokens (`error` / `success` / `warning` / `info` / `destructive`) and the 4-token shape (`base` / `hover` / `foreground` / `subtle`).
 - [`field-context-guideline.md`](.claude/rules/field-context-guideline.md) — `FieldContext` integration patterns for form components (Input / Checkbox / Switch / Radio / Select / Textarea).
 - [`vrt-spec-guideline.md`](.claude/rules/vrt-spec-guideline.md) — Playwright VRT spec template, story-id mapping, snapshot naming.
+- [`lint-rules-guideline.md`](.claude/rules/lint-rules-guideline.md) — Biome rules added on top of `recommended` (`useExhaustiveDependencies`, `noUnusedImports/Variables`, `useImportType/ExportType`, `noNonNullAssertion`, `noConsole`) and the rationale for each.
 
 ## Main commands
 
@@ -73,6 +74,7 @@ pnpm changeset         # Create a changeset for user-facing changes
 | [.claude/rules/state-token-guideline.md](.claude/rules/state-token-guideline.md) | 3-layer token system, 4-token shape, `destructive` vs `error`. |
 | [.claude/rules/field-context-guideline.md](.claude/rules/field-context-guideline.md) | `FieldContext` patterns for form components. |
 | [.claude/rules/vrt-spec-guideline.md](.claude/rules/vrt-spec-guideline.md) | Playwright VRT spec template and snapshot naming. |
+| [.claude/rules/lint-rules-guideline.md](.claude/rules/lint-rules-guideline.md) | Biome rules added on top of `recommended` and the rationale for each. |
 
 ## Maintenance
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,3 +32,4 @@ When adding or modifying components, follow shadcn/ui conventions (Radix UI + CV
 - See [.claude/rules/field-context-guideline.md](.claude/rules/field-context-guideline.md) for Field context integration patterns
 - See [.claude/rules/state-token-guideline.md](.claude/rules/state-token-guideline.md) for state semantic tokens (error / success / warning / info / destructive) and the 4-token shape
 - See [.claude/rules/vrt-spec-guideline.md](.claude/rules/vrt-spec-guideline.md) for VRT spec conventions
+- See [.claude/rules/lint-rules-guideline.md](.claude/rules/lint-rules-guideline.md) for the Biome rules added on top of `recommended` and the rationale for each

--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.9/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.4.14/schema.json",
   "assist": {
     "actions": {
       "source": {
@@ -10,7 +10,23 @@
   "linter": {
     "enabled": true,
     "rules": {
-      "recommended": true
+      "recommended": true,
+      "correctness": {
+        "useExhaustiveDependencies": "error",
+        "noUnusedImports": "error",
+        "noUnusedVariables": "error"
+      },
+      "style": {
+        "useImportType": "error",
+        "useExportType": "error",
+        "noNonNullAssertion": "warn"
+      },
+      "suspicious": {
+        "noConsole": {
+          "level": "error",
+          "options": { "allow": ["warn", "error"] }
+        }
+      }
     }
   },
   "formatter": {


### PR DESCRIPTION
## Summary

- Adds a small, deliberate set of Biome rules on top of `recommended` so a few classes of bug (stale hook deps, dead imports/vars, value-imports for types, stray `console.log`) surface at lint time instead of in review.
- Codebase already followed these conventions — enabling the rules yielded **zero violations**.
- Documents the **why** behind each rule (and the ones we deliberately did NOT enable) in [.claude/rules/lint-rules-guideline.md](https://github.com/yasmro/schatten/blob/claude/confident-agnesi-b886b1/.claude/rules/lint-rules-guideline.md) so future contributors can judge edge cases.

Closes [#97](https://github.com/yasmro/schatten/issues/97).

### Rules enabled

| Rule | Severity | Why |
|---|---|---|
| `correctness/useExhaustiveDependencies` | `error` | Most common silent React bug; AI-edited hooks especially prone. |
| `correctness/noUnusedImports` | `error` | Dead refactor residue, bloats bundles and PR diffs. |
| `correctness/noUnusedVariables` | `error` | Same; `_`-prefix escape hatch for intentional cases. |
| `style/useImportType` | `error` | Keep type-only imports erased at compile; cleaner tree-shaking. |
| `style/useExportType` | `error` | Same, on the export side. |
| `style/noNonNullAssertion` | `warn` | `value!` hides nullable cases — `warn` keeps legit Radix/DOM-invariant uses visible without blocking CI. |
| `suspicious/noConsole` | `error` (allow `warn`/`error`) | Stray `console.log` ships to consumers; `warn` / `error` kept for component-misuse signals (e.g. Button's `isLoading + asChild` warning, Dialog's `actionButton.onClick` footgun warning). |

### Side fix

Aligned [biome.json](https://github.com/yasmro/schatten/blob/claude/confident-agnesi-b886b1/biome.json) `$schema` to the installed Biome version (`2.4.14` ← `2.4.9`), silencing the schema-mismatch info that printed on every `pnpm lint` run.

### Index updates

- [CLAUDE.md](https://github.com/yasmro/schatten/blob/claude/confident-agnesi-b886b1/CLAUDE.md) — Guidelines section now points to `lint-rules-guideline.md`.
- [AGENTS.md](https://github.com/yasmro/schatten/blob/claude/confident-agnesi-b886b1/AGENTS.md) — both **Required reading** and **Resource Map** sections.

## Test plan

- [x] `pnpm lint` — clean (131 files, 0 errors)
- [x] `pnpm typecheck` — clean
- [x] `pnpm test` — 146 tests pass across 8 files
- [x] Confirmed rules fire on a synthetic file (`console.log`, unused var, missing exhaustive dep)
- [x] Confirmed `console.warn` / `console.error` still allowed (Button's `isLoading + asChild` warning, Dialog's `actionButton.onClick` footgun warning)
- [x] Changeset added (`patch`)
- [ ] Reviewer: verify CI lint job passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)