### PR TITLE
feat(ci): add changeset status check on PRs (closes #96)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,7 @@ name: CI
 on:
   pull_request:
     branches: [main]
+    types: [opened, synchronize, reopened, labeled, unlabeled]
   push:
     branches: [main]
 
@@ -57,3 +58,26 @@ jobs:
 
       - name: Unit tests
         run: pnpm vitest run
+
+  changeset:
+    runs-on: ubuntu-latest
+    if: |
+      github.event_name == 'pull_request' &&
+      github.event.pull_request.user.login != 'dependabot[bot]' &&
+      !contains(github.event.pull_request.labels.*.name, 'no-changeset')
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - uses: pnpm/action-setup@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Changeset status
+        run: pnpm exec changeset status --since=origin/main

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,7 +61,7 @@ pnpm changeset         # Create a changeset for user-facing changes
 - **Do not** add a new `lv1` / `lv2` component without **Storybook story + Vitest test + VRT spec** alongside it. Follow the Storybook conventions (Playground story first, group by prop) and place the VRT spec at `ComponentName.vrt.spec.ts` next to the component.
 - **Do not** create individual stories for every prop value (`Default`, `Secondary`, `Outline` as separate exports). Group them into render stories (`AllVariants`, `Sizes`, `Disabled`, …). See [storybook-guideline](.claude/rules/storybook-guideline.md).
 - **Do not** write Storybook `description`, `argTypes`, button labels, etc. in Japanese — Storybook surfaces use **English only**.
-- **Do not** ship user-facing changes without a changeset entry. Run `pnpm changeset` and pick the appropriate semver bump.
+- **Do not** ship user-facing changes without a changeset entry. Run `pnpm changeset` and pick the appropriate semver bump. CI enforces this via `changeset status --since=origin/main`. For internal-only PRs (`.github/` workflow changes, docs, test-only additions), apply the `no-changeset` label to skip the check; dependabot PRs are auto-skipped.
 
 ## Resource Map
 

--- a/README.md
+++ b/README.md
@@ -122,6 +122,18 @@ This package uses [Changesets](https://github.com/changesets/changesets). When i
 pnpm changeset
 ```
 
+CI runs `changeset status --since=origin/main` on every PR and fails when source
+changes ship without a changeset. The check is automatically skipped for:
+
+- PRs authored by `dependabot[bot]`
+- PRs labeled **`no-changeset`** — use this for `.github/` workflow changes,
+  docs-only edits, test-only PRs, and other internal work that does not affect
+  the published package
+
+If the check fails and the PR is genuinely user-facing, run `pnpm changeset` and
+commit the generated file. If the PR is internal, apply the `no-changeset`
+label and re-run the job.
+
 ## License
 
 MIT


### PR DESCRIPTION
## Summary

- Adds a `changeset` job to [`.github/workflows/ci.yml`](.github/workflows/ci.yml) that runs `pnpm exec changeset status --since=origin/main` on every PR, failing when source changes ship without a changeset.
- Skip rules implemented via job-level `if:`:
  - PRs from `dependabot[bot]` — dependency bumps don't need a contributor-written release note.
  - PRs labeled **`no-changeset`** — opt-in escape hatch for docs/`.github/`/test-only PRs.
- Adds `labeled` / `unlabeled` to the `pull_request` trigger so the check re-runs when the label is toggled mid-review (other jobs harmlessly re-evaluate too).
- Documents the policy and the `no-changeset` label in [`README.md`](README.md)'s "Release" section and updates the changeset rule in [`AGENTS.md`](AGENTS.md) so AI agents pick the right escape hatch.
- Repo label `no-changeset` (color `#ededed`) was created via `gh label create`.

Closes [yasmro/schatten#96](https://github.com/yasmro/schatten/issues/96).

## DoD coverage (issue #96)

- [x] `.github/workflows/ci.yml` に changeset job 追加
- [x] `no-changeset` ラベル運用ルールを README に明記 (+ AGENTS.md にも反映)
- [x] dependabot PR で自動 skip される設定 — verified that GH API returns `user.login == 'dependabot[bot]'` for [PR #174](https://github.com/yasmro/schatten/pull/174) (an existing dependabot PR), confirming the matcher works
- [x] 動作確認: changeset なしで PR を作って fail することを確認 — locally reproduced (see below); the existing open PR #91 (`.github/` only, no changeset) is the natural post-merge production smoke test
- [x] 動作確認: changeset 追加で pass することを確認 — locally reproduced (see below)

## Local verification

Source change without a changeset → **exit 1** (fail):

```
$ echo "// test" >> src/lib/cn.ts
$ pnpm exec changeset status --since=origin/main
🦋  error Some packages have been changed but no changesets were found.
🦋  error If this change doesn't need a release, run `changeset add --empty`.
exit: 1
```

Source change *with* a matching changeset (both staged so git diff vs `origin/main` sees them) → **exit 0** (pass):

```
$ echo "// test" >> src/lib/cn.ts
$ printf -- '---\n%s\n---\n\ntest: simulate\n' "'@yasmro/schatten': patch" > .changeset/cs-test.md
$ git add src/lib/cn.ts .changeset/cs-test.md
$ pnpm exec changeset status --since=origin/main
🦋  info Packages to be bumped at patch:
🦋  - @yasmro/schatten
exit: 0
```

No source change (this PR's actual state) → **exit 0**.

This PR's own CI run also confirms behavior: the `changeset` job reports `skipping` (0s) because the `no-changeset` label is applied — see [run 25706588450](https://github.com/yasmro/schatten/actions/runs/25706588450).

## Impact on currently open PRs

When this lands on `main`, the new gate will apply to in-flight PRs. Snapshot at PR creation time:

| PR | Affected? | Action |
|---|---|---|
| [#177](https://github.com/yasmro/schatten/pull/177) (Biome rules) | No — changeset included | none |
| [#176](https://github.com/yasmro/schatten/pull/176) (lv1 unit tests) | No — changeset included | none |
| [#174](https://github.com/yasmro/schatten/pull/174) (dependabot vitest) | No — auto-skipped by `user.login` check | none |
| [#91](https://github.com/yasmro/schatten/pull/91) (release workflow) | **Yes** — `.github/` only, no changeset | apply `no-changeset` label before merge |

## This PR's own changeset check

This PR touches only `.github/workflows/ci.yml`, `README.md`, and `AGENTS.md`, so no changeset is required. The `no-changeset` label is applied so the new job is skipped here (chicken-and-egg: the workflow being added is the same one that would gate this PR).

## Test plan

- [x] Local: source change w/o changeset → fail.
- [x] Local: source change w/ changeset → pass.
- [x] CI: `changeset` job skipped on this PR due to label (verified in run 25706588450).
- [ ] After merge, label [#91](https://github.com/yasmro/schatten/pull/91) as `no-changeset` and verify the job skips there.
- [ ] After merge, wait for the next dependabot PR and verify auto-skip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
