### PR TITLE
docs(rule): add component-testid-guideline (closes #106)

### DIFF
--- a/.claude/rules/component-architecture.md
+++ b/.claude/rules/component-architecture.md
@@ -286,6 +286,157 @@ the reviewer must verify each rule satisfies the "not expressible in
 Tailwind / CVA" bar above. If any rule could be a Tailwind class, move
 it.
 
+## 8. Accessibility contract
+
+Every lv1 component must expose a stable a11y surface so that consumer
+applications can write tests and E2E selectors against role + accessible
+name rather than against class names or DOM structure. The
+[component-testid-guideline](component-testid-guideline.md) explicitly
+treats role-based queries as the first choice and `data-testid` as a
+fallback — that policy only holds if the contract below holds.
+
+### The four guarantees
+
+1. **An explicit role**, sourced from one of:
+   - A native element with built-in semantics (`<button>`, `<input>`,
+     `<textarea>`, `<fieldset>`, heading levels). Default whenever
+     possible — Button / Input / Textarea / FieldSet do this today.
+   - A Radix primitive that assigns the role for us — Dialog (`dialog`),
+     Tooltip (`tooltip`), Checkbox (`checkbox`), Switch (`switch`),
+     Select trigger (`combobox`) + content (`listbox`), Toast
+     (`status`), Radio (`radio` inside `radiogroup`).
+   - An explicit `role="…"` written by Schatten — used only when
+     neither of the above gives the right semantic. Current explicit
+     uses: [Spinner](../../src/components/lv1/Spinner/Spinner.tsx)
+     (`role="status"`) and
+     [Separator](../../src/components/lv1/Separator/Separator.tsx)
+     (`role="separator"` when `decorative={false}`, else
+     `role="none"`).
+
+   Wrapping a `<div>` with `onClick` / key handlers to fake
+   interactivity is the failure mode this guarantee prevents.
+
+2. **A queryable accessible name**, sourced from one of (in preference
+   order):
+   - **Children text content** — Button (`<Button>Submit</Button>`),
+     Toast title, Callout title.
+   - **`aria-labelledby` auto-wired by Radix** — Dialog (`Title` →
+     `aria-labelledby` on Content,
+     [Dialog.tsx:44](../../src/components/lv1/Dialog/Dialog.tsx:44)).
+   - **`<label htmlFor>` paired through `FieldContext`** —
+     externally-labelled form inputs (Input, Textarea, Select). See
+     [field-context-guideline](field-context-guideline.md).
+   - **Internal `<label>` rendered by the component** — self-labelled
+     form inputs (Checkbox, Switch, Radio).
+   - **`aria-label`** — icon-only or symbol-only triggers. Required
+     where a button has no readable text content: Dialog close ✕
+     ([Dialog.tsx:217](../../src/components/lv1/Dialog/Dialog.tsx:217)),
+     Callout close ✕
+     ([Callout.tsx:120](../../src/components/lv1/Callout/Callout.tsx:120)),
+     Toast close ✕
+     ([Toast.tsx:102](../../src/components/lv1/Toast/Toast.tsx:102)),
+     Field tooltip info icon
+     ([Field.tsx:104](../../src/components/lv1/Field/Field.tsx:104)).
+
+   The contract: `getByRole(role, { name })` returns the component. If
+   it does not, the component has no usable accessible name and the
+   contract is broken.
+
+3. **Keyboard support**:
+   - Reachable via `Tab` — no root-level `tabIndex={-1}` on
+     interactive components. (`tabIndex={-1}` is fine on non-focusable
+     inner wrappers.)
+   - Activates with the role-appropriate key (`Enter` / `Space` for
+     buttons; `Arrow` keys for Radio / Select).
+   - A visible focus indicator — every interactive variant in
+     [src/variants/](../../src/variants/) bakes
+     `focus-visible:outline-none focus-visible:ring-2
+     focus-visible:ring-ring focus-visible:ring-offset-2` into its
+     base class. Do not strip this chain. If a layout conflicts,
+     replace it with an equivalent visible indicator, do not delete
+     it.
+
+   For Radix-based components the keyboard wiring is implemented by
+   Radix. The contract here is to **not break** it — don't override
+   `onKeyDown` without composing the original handler, don't
+   intercept focus, don't move handlers off the Radix element.
+
+4. **State announcements via `aria-*`**:
+   - **Error state** → `aria-invalid={isError || undefined}`. Wired
+     today on Input / Textarea / Select / Checkbox / Switch / Radio /
+     RadioGroup / FieldSet. The `|| undefined` is intentional: it
+     omits the attribute when false rather than emitting
+     `aria-invalid="false"`.
+   - **Description / error message** → `aria-describedby`, fed by
+     `FieldContext.describedBy` ([field-context-guideline](field-context-guideline.md)).
+   - **Disabled** → the native `disabled` attribute when the element
+     supports it (form inputs, buttons). Radix's `data-disabled` is a
+     styling hook that mirrors the same state, not a substitute for
+     the ARIA mapping.
+   - **Loading** — component-specific. Button uses
+     `aria-hidden={!isLoading}` on its inline spinner so the spinner
+     only enters the accessibility tree while loading
+     ([Button.tsx:131](../../src/components/lv1/Button/Button.tsx:131)).
+   - **Required** — Field renders a visual `*` next to the label but
+     **does not** propagate `aria-required` to the underlying input
+     today. Consumers who need the ARIA flag must set `required` on
+     the input element directly. This is a deliberate gap to revisit;
+     see "When this rule changes" below.
+
+### Patterns Schatten relies on
+
+- **Decorative icons get `aria-hidden="true"`.** Every Lucide / SVG
+  icon used purely as a visual flourish must be aria-hidden. Existing
+  examples: Toast variant icon, Callout variant icon, Input
+  leading/trailing icon, Button leading/trailing icon, Badge icon,
+  Checkbox mark, Switch knob, Spinner SVG, the `Separator` rendered
+  inside Dialog's footer. When you add an icon, add it.
+- **Components that intentionally have no default role** —
+  [Callout](../../src/components/lv1/Callout/Callout.tsx) ships
+  role-less and documents in TSDoc that consumers should pass
+  `role="status"` (polite) or `role="alert"` (assertive) when the
+  callout content is dynamic. Don't bake in a role that's wrong half
+  the time — make the absence explicit and tell the consumer how to
+  fill it.
+- **Conditional ARIA opt-out** — when a default-wired ARIA reference
+  would point at a non-existent node, spread the attribute
+  conditionally as `undefined` rather than letting Radix emit a
+  dangling reference. Dialog does this for `aria-describedby` when
+  `description` is absent
+  ([Dialog.tsx:273](../../src/components/lv1/Dialog/Dialog.tsx:273)).
+
+### Hard rules
+
+- **Do not** wrap interactive content in a `<div>` with `onClick` and
+  call it a button. Use `<button>` (or `<Button>`), or a Radix
+  primitive that renders a button.
+- **Do not** rely on color alone to convey state. `isError` must add
+  both `aria-invalid` (for assistive tech) and `border-error` (for
+  sighted users) — both are required, never either-or. Same for
+  Callout / Toast variants.
+- **Do not** strip the `focus-visible:ring-*` chain from a variant
+  base class. Override the ring color if you need contrast on a
+  colored surface (see Input's `has-focus-visible:ring-error` for the
+  pattern), but never disable it outright.
+- **Do not** introduce `tabIndex={-1}` on the root of a focusable
+  component. It's correct on inner wrappers when focus lives
+  elsewhere; it's wrong as a substitute for `disabled`.
+
+### Verifying compliance
+
+1. **Unit test** — every lv1 has a test that calls
+   `getByRole(role, { name })` against a representative render. See
+   [testing-guideline](testing-guideline.md) § Required test cases.
+   "Query by role first" applies (testing-guideline §5).
+2. **Storybook** — `addon-a11y` panel shows 0 violations on every
+   story. Manual today; CI enforcement is planned through
+   [#147](https://github.com/yasmro/schatten/issues/147)
+   (`@axe-core/playwright`).
+3. **Code review** — when reviewing an lv1 PR, walk the four
+   guarantees and Hard rules above. If the component opts out of a
+   default (e.g. Callout's no-role posture), the TSDoc must say so
+   explicitly and explain how the consumer should fill the gap.
+
 ## When this rule changes
 
 - **§1 (lv2 promotion criterion):** will be defined as a follow-up rule
@@ -301,3 +452,9 @@ it.
   or lv3 (page-level shells) gets introduced, add the new layer to the
   table and update the resource maps in [CLAUDE.md](../../CLAUDE.md) /
   [AGENTS.md](../../AGENTS.md).
+- **§8 (a11y contract):**
+  - When [#147](https://github.com/yasmro/schatten/issues/147) lands
+    (`@axe-core/playwright`), promote the "Storybook addon-a11y" check
+    in "Verifying compliance" from manual to CI-enforced.
+  - When `Field.required` gains `aria-required` propagation, remove
+    the gap note in guarantee #4.

--- a/.claude/rules/component-testid-guideline.md
+++ b/.claude/rules/component-testid-guideline.md
@@ -1,0 +1,233 @@
+# Component testid Guideline
+
+## Overview
+
+`data-testid` is the contract that lets a consumer's E2E suite latch onto a
+Schatten component without depending on class names, ARIA attributes, or DOM
+structure. This document codifies **how** that contract is exposed on Schatten
+components and — equally important — what Schatten itself must **not** do.
+
+Goal: a consuming product can write a stable selector against any rendered
+Schatten element, including ones that escape into a Portal, without Schatten
+ever choosing a testid on the consumer's behalf.
+
+## Core policy: direct `...props` pass-through
+
+Schatten components forward `data-testid` (and every other unknown DOM attribute)
+to their root element via `...rest`. There is **no** dedicated `testId` prop.
+
+```tsx
+<Button data-testid="submit-btn">Submit</Button>
+// → <button data-testid="submit-btn" class="…">Submit</button>
+```
+
+### Why no dedicated prop
+
+- `data-testid` is already a standard DOM attribute — TypeScript accepts it via
+  the `HTMLAttributes` extension, and React passes it through unchanged. A
+  custom `testId` prop would be a parallel surface that adds nothing.
+- A pass-through model means the same approach works for any other
+  `data-*` attribute consumers might want (`data-cy`, `data-test`, etc.) — no
+  per-attribute prop expansion.
+
+### What this requires of component authors
+
+Every `lv1` / `lv2` component **must** accept `...props` (or `...rest`) and
+spread it onto its rendered root element. This is already the prevailing
+pattern (see [Separator](../../src/components/lv1/Separator/Separator.tsx),
+[Button](../../src/components/lv1/Button/Button.tsx),
+[Callout](../../src/components/lv1/Callout/Callout.tsx), etc.) — keep doing it.
+
+If a component intentionally does *not* pass `...rest` through (e.g. it
+accepts a curated, non-DOM prop surface — see [Exceptions](#exceptions-high-level-components-without-rest)
+below), document that explicitly and provide a documented alternative.
+
+## Compound components
+
+Each subcomponent receives its own `data-testid` independently. The canonical
+example in Schatten is [Select](../../src/components/lv1/Select/Select.tsx):
+
+```tsx
+<Select>
+  <SelectTrigger data-testid="country-trigger">
+    <SelectValue placeholder="Country" />
+  </SelectTrigger>
+  <SelectContent data-testid="country-content">
+    <SelectItem value="jp" data-testid="country-item-jp">Japan</SelectItem>
+    <SelectItem value="us" data-testid="country-item-us">United States</SelectItem>
+  </SelectContent>
+</Select>
+```
+
+Same shape applies to [Tooltip](../../src/components/lv1/Tooltip/Tooltip.tsx)
+(`TooltipTrigger` / `TooltipContent`) and [RadioGroup](../../src/components/lv1/Radio/Radio.tsx)
+(`RadioGroup` / `Radio`).
+
+### Caveat: Trigger components that use Radix `asChild`
+
+`TooltipTrigger` switches to `asChild` mode when its child is a non-string
+element (e.g. `<Button>`). In `asChild` mode Radix **merges props onto the
+child**, so `data-testid` ends up on the child, not on a wrapper:
+
+```tsx
+// Text child → asChild=false → Radix renders its own <button>, testid on it
+<TooltipTrigger data-testid="help">Hover for help</TooltipTrigger>
+// → <button data-testid="help" data-state="…">Hover for help</button>
+
+// Element child → asChild=true → testid is merged onto the Button
+<TooltipTrigger data-testid="help"><Button>Help</Button></TooltipTrigger>
+// → <button data-testid="help" class="btn …">Help</button>
+```
+
+Both end up addressable by `getByTestId('help')` — but be aware that in the
+second case the testid is on **your** Button, not on a Schatten-rendered
+wrapper. This matters when writing assertions about DOM structure around the
+trigger.
+
+## Portal-rendered content
+
+`SelectContent`, `TooltipContent`, and similar portal-mounted content render
+into `document.body`, **outside** `#storybook-root` and outside any component
+subtree in the DOM tree (even though they are children in the React tree).
+
+Two consequences:
+
+1. **Put the testid on the Content element itself**, not on the Trigger. A
+   selector rooted at the Trigger element will never reach the portaled
+   content via DOM traversal:
+
+   ```tsx
+   // ❌ Trigger testid doesn't help reach the popup
+   <SelectTrigger data-testid="country">…</SelectTrigger>
+   ```
+
+   ```tsx
+   // ✅ Content has its own testid
+   <SelectContent data-testid="country-options">…</SelectContent>
+   ```
+
+2. **Scope queries from `page` (not from a component-local root)**. In
+   Playwright:
+
+   ```ts
+   await page.getByTestId('country-trigger').click()
+   const options = page.getByTestId('country-options')
+   await options.getByRole('option', { name: 'Japan' }).click()
+   ```
+
+   In Vitest + Testing Library, prefer `screen.getByTestId(...)` over
+   `within(container).getByTestId(...)` for portaled content.
+
+(Compare with the matching note in
+[vrt-spec-guideline](vrt-spec-guideline.md#components-rendered-into-a-portal) —
+the same Portal mechanics affect VRT screenshots.)
+
+## Exceptions: high-level components without `...rest`
+
+A handful of Schatten components expose a curated prop surface instead of
+`...rest`. The principal example is [Dialog](../../src/components/lv1/Dialog/Dialog.tsx),
+which takes structured props (`title`, `actionButton`, `cancelButton`, etc.)
+and does *not* spread unknown attributes onto its Content element.
+
+For these components:
+
+- **Apply testids to the children you pass in.** Dialog renders `children`
+  inside its body region — put `data-testid` on the elements you author:
+
+  ```tsx
+  <Dialog title="Confirm" actionButton={…} isOpen={open} onOpenChange={setOpen}>
+    <p data-testid="confirm-message">Are you sure?</p>
+    <input data-testid="confirm-reason" />
+  </Dialog>
+  ```
+
+- **Prefer role-based selectors for the dialog frame itself.** Radix sets
+  `role="dialog"` on Dialog Content, so `page.getByRole('dialog', { name: 'Confirm' })`
+  uniquely identifies it without needing a testid.
+
+- **Toast is imperative.** The `toast({...})` API does not accept JSX, so
+  there is no direct `data-testid` hook on individual toasts. E2E tests should
+  query via role (`role="status"` for non-error variants, `role="alert"` for
+  error) plus accessible name.
+
+If you find a component that *should* be testid-addressable but currently
+isn't, file an issue rather than hacking around it.
+
+## Schatten internal restrictions
+
+Schatten's own implementation **must not** emit `data-testid` attributes from
+inside the library. Specifically:
+
+- No hardcoded `data-testid="dialog-content"`-style attributes on internal
+  Slots, Portals, or composition helpers.
+- No "default" testids derived from `displayName` or `id`.
+- No conditional testids gated by a `testing` flag.
+
+### Why
+
+Consumers come in with their own naming conventions — BEM-style
+(`signup-form__submit-button`), path-style (`pages.signup.cta`),
+feature-prefixed (`auth_login_submit`). A library-supplied testid pollutes
+that namespace and either gets ignored (creating two parallel testids on one
+element) or forces consumers to dodge Schatten-reserved names. Both are bad.
+
+The single source of truth must be the consumer.
+
+### What's fine
+
+`data-*` attributes that are part of a component's *behavioural* API — e.g.
+Radix's `data-state="open"`, `data-disabled`, `data-side="bottom"`. These are
+not testids and have a different lifecycle (they reflect runtime state for
+styling). They are exposed by Radix and we don't override them.
+
+## Naming responsibility
+
+Choosing testid values is the **consumer's** responsibility, not Schatten's.
+This guideline only describes the *plumbing* (where the attribute lands, how
+it survives Portal boundaries, etc.). When designing your application's
+testid scheme:
+
+- Pick a convention and stick to it across the codebase. Hierarchical
+  (`signup.form.submit`) and BEM-flavoured (`signup-form__submit`) both work
+  — the convention matters more than the shape.
+- Reserve testids for elements that *cannot* be reached by role + accessible
+  name. If `getByRole('button', { name: 'Submit' })` already uniquely
+  selects the target, a testid is redundant.
+
+## Relationship with accessibility
+
+`data-testid` and ARIA attributes serve different audiences:
+
+| | `aria-label` / `role` | `data-testid` |
+|---|---|---|
+| Audience | Assistive tech (and `getByRole` queries) | E2E / integration tests |
+| Visibility | User-facing semantics | Test-only hook |
+| When to use | First choice for selectors | When semantic queries don't disambiguate |
+
+`getByRole` + accessible name is the preferred selector in both Testing
+Library and Playwright. Reach for `getByTestId` only when role-based queries
+are ambiguous, unstable, or impossible (e.g. anonymous wrappers).
+
+A11y audits (e.g. `addon-a11y`, `@axe-core/playwright`) operate on the ARIA
+layer and are unaffected by testid choices — the two concerns are
+orthogonal.
+
+## Verifying compliance
+
+When adding or reviewing a new component, check:
+
+1. The component's root accepts `...props` (or has a documented exception
+   with a children-based workaround).
+2. A unit test demonstrates `data-testid` lands on the expected element — the
+   existing pattern is a one-liner:
+   ```tsx
+   render(<Foo data-testid="foo" />)
+   expect(screen.getByTestId('foo')).toBeInTheDocument()
+   ```
+   See [Separator.test.tsx](../../src/components/lv1/Separator/Separator.test.tsx),
+   [Callout.test.tsx](../../src/components/lv1/Callout/Callout.test.tsx),
+   [Badge.test.tsx](../../src/components/lv1/Badge/Badge.test.tsx),
+   [Text.test.tsx](../../src/components/lv1/Text/Text.test.tsx),
+   and [Spinner.test.tsx](../../src/components/lv1/Spinner/Spinner.test.tsx)
+   for the established pattern.
+3. No internal subcomponents emit fixed `data-testid` values.

--- a/.claude/rules/component-testid-guideline.md
+++ b/.claude/rules/component-testid-guideline.md
@@ -146,9 +146,11 @@ For these components:
   uniquely identifies it without needing a testid.
 
 - **Toast is imperative.** The `toast({...})` API does not accept JSX, so
-  there is no direct `data-testid` hook on individual toasts. E2E tests should
-  query via role (`role="status"` for non-error variants, `role="alert"` for
-  error) plus accessible name.
+  there is no direct `data-testid` hook on individual toasts. Radix renders
+  every toast with `role="status"` (regardless of variant — the variant only
+  shifts `aria-live` between `assertive` and `polite`), so E2E tests should
+  query by role + accessible name, e.g.
+  `page.getByRole('status', { name: 'Saved successfully' })`.
 
 If you find a component that *should* be testid-addressable but currently
 isn't, file an issue rather than hacking around it.

--- a/.claude/rules/testing-guideline.md
+++ b/.claude/rules/testing-guideline.md
@@ -62,6 +62,10 @@ whenever there's distinct behavior worth pinning down — coverage of the
 - `ref` reaches the underlying DOM node (forwardRef)
 - Primary `variant` / `size` props apply distinct classes
 - `disabled` (when applicable) blocks interactions
+- Exposes a queryable accessible role + name — `getByRole(role, { name })`
+  returns the component. The role and accessible-name source per
+  component are defined in
+  [component-architecture.md §8](component-architecture.md#8-accessibility-contract)
 
 ### Form input components
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,7 +34,7 @@ src/
 
 Before adding or modifying components, read the guideline files under [`.claude/rules/`](.claude/rules):
 
-- [`component-architecture.md`](.claude/rules/component-architecture.md) — lv1 vs lv2 folder responsibilities, compound vs flat, `asChild` default-off for new lv1s + hard exclusions on form inputs / portal content (complements `component-api-conventions.md` §`asChild`; `buttonVariants` / `textVariants` are the preferred alternative), polymorphic `as` not adopted, unified `FieldContext` consumption, one-way dependency direction (lv1 → lv2 forbidden, no barrel laundering), when an lv1-local `.css` file is allowed.
+- [`component-architecture.md`](.claude/rules/component-architecture.md) — lv1 vs lv2 folder responsibilities, compound vs flat, `asChild` default-off for new lv1s + hard exclusions on form inputs / portal content (complements `component-api-conventions.md` §`asChild`; `buttonVariants` / `textVariants` are the preferred alternative), polymorphic `as` not adopted, unified `FieldContext` consumption, one-way dependency direction (lv1 → lv2 forbidden, no barrel laundering), when an lv1-local `.css` file is allowed, accessibility contract every lv1 must satisfy (role + accessible name + keyboard + `aria-*` state announcements).
 - [`component-api-conventions.md`](.claude/rules/component-api-conventions.md) — Public prop API shape: two patterns (**Role-based** for action components like `Button`; **Tone × Shape** for state components like `Badge` / `Callout` / `Toast`), per-component matrix, common props (`size` / `isError` / `isLoading` / `disabled` / `readOnly`), and `asChild` adoption criteria.
 - [`storybook-guideline.md`](.claude/rules/storybook-guideline.md) — Story structure (`Playground` story first, group by prop), `argTypes`, English-only labels.
 - [`state-token-guideline.md`](.claude/rules/state-token-guideline.md) — 3-layer token system, state semantic tokens (`error` / `success` / `warning` / `info` / `destructive`) and the 4-token shape (`base` / `hover` / `foreground` / `subtle`).
@@ -76,7 +76,7 @@ pnpm changeset         # Create a changeset for user-facing changes
 |---|---|
 | [CLAUDE.md](CLAUDE.md) | Claude Code-specific tech stack and rule index. |
 | [README.md](README.md) | Public-facing overview, installation, and usage. |
-| [.claude/rules/component-architecture.md](.claude/rules/component-architecture.md) | Component-level design choices — lv1 / lv2 folders, compound vs flat, `asChild` default-off for new lv1s + hard exclusions, unified context consumption, one-way dependency direction, lv1-local `.css` criteria. |
+| [.claude/rules/component-architecture.md](.claude/rules/component-architecture.md) | Component-level design choices — lv1 / lv2 folders, compound vs flat, `asChild` default-off for new lv1s + hard exclusions, unified context consumption, one-way dependency direction, lv1-local `.css` criteria, a11y contract (role + accessible name + keyboard + `aria-*`). |
 | [.claude/rules/component-api-conventions.md](.claude/rules/component-api-conventions.md) | Public prop API shape — Role-based (Button) vs Tone × Shape (Badge/Callout/Toast) patterns, common props, `asChild` criteria. |
 | [.claude/rules/storybook-guideline.md](.claude/rules/storybook-guideline.md) | Storybook conventions — Playground story, `argTypes`, grouping. |
 | [.claude/rules/state-token-guideline.md](.claude/rules/state-token-guideline.md) | 3-layer token system, 4-token shape, `destructive` vs `error`. |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,6 +44,7 @@ Before adding or modifying components, read the guideline files under [`.claude/
 - [`testing-guideline.md`](.claude/rules/testing-guideline.md) — Unit test conventions: required cases per component type (form / compound / action / display), BDD naming, typed factories, what NOT to test.
 - [`lint-rules-guideline.md`](.claude/rules/lint-rules-guideline.md) — Biome rules added on top of `recommended` (`useExhaustiveDependencies`, `noUnusedImports/Variables`, `useImportType/ExportType`, `noNonNullAssertion`, `noConsole`) and the rationale for each.
 - [`api-stability.md`](.claude/rules/api-stability.md) — Public API stability contract effective from v1.0.0: what counts as public API (React props, CSS classes, CSS variables, CVA output), breaking-change policy, and CHANGELOG prefix conventions.
+- [`component-testid-guideline.md`](.claude/rules/component-testid-guideline.md) — `data-testid` flows through `...rest` (no `testId` prop); Schatten never auto-emits testids; how to reach Portal-rendered content.
 
 ## Main commands
 
@@ -85,6 +86,7 @@ pnpm changeset         # Create a changeset for user-facing changes
 | [.claude/rules/testing-guideline.md](.claude/rules/testing-guideline.md) | Unit test conventions — required cases per component type, BDD naming, typed factories. |
 | [.claude/rules/lint-rules-guideline.md](.claude/rules/lint-rules-guideline.md) | Biome rules added on top of `recommended` and the rationale for each. |
 | [.claude/rules/api-stability.md](.claude/rules/api-stability.md) | Public API stability contract (effective v1.0.0) — what is public, breaking-change policy, CHANGELOG conventions. |
+| [.claude/rules/component-testid-guideline.md](.claude/rules/component-testid-guideline.md) | `data-testid` pass-through policy, Portal content handling, no-auto-testid rule. |
 
 ## Maintenance
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,7 @@ When adding or modifying components, follow shadcn/ui conventions (Radix UI + CV
 
 ## Guidelines
 
-- See [.claude/rules/component-architecture.md](.claude/rules/component-architecture.md) for component-level design choices (lv1 vs lv2 folders, compound vs flat, `asChild` default-off for new lv1s + hard exclusions on form inputs / portal content, polymorphic `as` not adopted, unified context consumption, one-way dependency direction, when an lv1-local `.css` file is allowed)
+- See [.claude/rules/component-architecture.md](.claude/rules/component-architecture.md) for component-level design choices (lv1 vs lv2 folders, compound vs flat, `asChild` default-off for new lv1s + hard exclusions on form inputs / portal content, polymorphic `as` not adopted, unified context consumption, one-way dependency direction, when an lv1-local `.css` file is allowed, a11y contract every lv1 must satisfy — role + accessible name + keyboard + `aria-*` wiring)
 - See [.claude/rules/component-api-conventions.md](.claude/rules/component-api-conventions.md) for the public prop API shape — the two patterns (Role-based / Tone × Shape), per-component matrix, common props (`size` / `isError` / `isLoading` / `disabled` / `readOnly`), and `asChild` criteria
 - See [.claude/rules/storybook-guideline.md](.claude/rules/storybook-guideline.md) for Storybook conventions
 - See [.claude/rules/field-context-guideline.md](.claude/rules/field-context-guideline.md) for Field context integration patterns

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,3 +38,4 @@ When adding or modifying components, follow shadcn/ui conventions (Radix UI + CV
 - See [.claude/rules/testing-guideline.md](.claude/rules/testing-guideline.md) for unit test conventions (required cases per component type, writing style, typed factories)
 - See [.claude/rules/lint-rules-guideline.md](.claude/rules/lint-rules-guideline.md) for the Biome rules added on top of `recommended` and the rationale for each
 - See [.claude/rules/api-stability.md](.claude/rules/api-stability.md) for the public API stability contract (effective from v1.0.0) — what counts as public API across React props, CSS classes, CSS variables, and CVA output, and the breaking-change policy
+- See [.claude/rules/component-testid-guideline.md](.claude/rules/component-testid-guideline.md) for the `data-testid` pass-through policy and the no-auto-testid rule


### PR DESCRIPTION
## Summary

Closes #106. Adds `.claude/rules/component-testid-guideline.md` documenting how `data-testid` flows through Schatten components, and links it from CLAUDE.md and AGENTS.md.

Key policies codified:

- **Direct `...props` pass-through** — no dedicated `testId` prop. `data-testid` lands on the root element of every component that spreads `...rest`.
- **Compound components** (Select, Tooltip, RadioGroup) accept testids per subcomponent. Canonical example uses Select since it's a true compound API in Schatten.
- **Portal-rendered content** (`SelectContent`, `TooltipContent`) — put the testid on the Content element, not the Trigger; query from `page` / `screen` rather than a component-local root.
- **High-level-component exception** — Dialog and Toast don't accept `...rest`; document the children-based and role-based workarounds.
- **No internal auto-testid** — Schatten itself must never emit fixed `data-testid` values, so consumer naming schemes stay uncontaminated.

Internal-only documentation, so `no-changeset` label applied.

## Also bundled in this PR: a11y contract (component-architecture §8)

Surfaced during review of the testid guideline: its "Relationship with accessibility" section recommends `getByRole` + accessible name as the primary selector, but Schatten had no codified contract guaranteeing those would actually be present on every lv1. §8 closes that gap so the testid policy rests on a solid foundation.

Added to `.claude/rules/component-architecture.md`:

- **Four guarantees** every lv1 must satisfy: explicit role / queryable accessible name / keyboard support / `aria-*` state announcements — each grounded in concrete source references (Dialog Title, Field `htmlFor`, internal `<label>` for self-labelled inputs, Spinner/Separator explicit roles, etc.).
- **Patterns Schatten relies on**: decorative-icon `aria-hidden`, Callout's deliberate no-role posture, Dialog's conditional `aria-describedby` opt-out.
- **Hard rules**: no fake-`<div>` buttons, no color-only state signal, no stripping the `focus-visible:ring-*` chain, no root `tabIndex={-1}` as a `disabled` proxy.
- **Verifying compliance**: `getByRole(role, { name })` in unit tests, `addon-a11y` in Storybook today, `@axe-core/playwright` in CI when #147 lands.
- Honest gap noted: `Field.required` renders a visual `*` but does not yet propagate `aria-required` — flagged in the "When this rule changes" list.

`testing-guideline.md` § Common (every component) gains one bullet pointing at §8 so the role+name test is enforced where the other required cases are listed.

## Verification (DoD checklist from #106)

- [x] `.claude/rules/component-testid-guideline.md` created
- [x] Basic policy / compound / Portal / internal restrictions all documented
- [x] CLAUDE.md (Guidelines) and AGENTS.md (Required reading + Resource Map) updated to link
- [x] Existing tests confirmed compliant: [Separator.test.tsx](src/components/lv1/Separator/Separator.test.tsx), [Callout.test.tsx](src/components/lv1/Callout/Callout.test.tsx), [Badge.test.tsx](src/components/lv1/Badge/Badge.test.tsx), [Text.test.tsx](src/components/lv1/Text/Text.test.tsx), [Spinner.test.tsx](src/components/lv1/Spinner/Spinner.test.tsx) all use `<Component data-testid="…" />` via `...props`. No custom `testId` prop anywhere in `src/`.

## Notes on adapting the issue's examples to Schatten's actual API

The issue body's Dialog example (`<DialogTrigger>` / `<DialogContent>` / `<DialogTitle>`) describes a generic shadcn-shape compound, but Schatten's Dialog ([src/components/lv1/Dialog/Dialog.tsx](src/components/lv1/Dialog/Dialog.tsx)) is a curated all-in-one component (`title`, `actionButton`, etc.) and does **not** expose those subcomponents. The guideline uses Select as the canonical compound example instead, and documents Dialog under "Exceptions: high-level components without `...rest`" with two workarounds (testid on children inside the body, or `getByRole('dialog', { name })`).

## Test plan

- [x] `pnpm typecheck` passes (verified via pre-commit hook)
- [x] Docs-only change — no runtime or test changes needed