### PR TITLE
docs(rule): add theme-architecture.md (Mode × Special two-axis model) (closes #104)

### DIFF
--- a/.changeset/theme-architecture-rule.md
+++ b/.changeset/theme-architecture-rule.md
@@ -1,0 +1,30 @@
+---
+'@yasmro/schatten': patch
+---
+
+docs(rule): add `.claude/rules/theme-architecture.md` (Mode × Special two-axis model)
+
+Theming is now modelled as two independent axes: **Mode** (exclusive — light /
+dark, with high-contrast reserved for Phase 5) owns the base layer (surfaces,
+foregrounds, borders, state shade-shifts); **Special** (cumulative — seasonal,
+event, custom) owns the expressive layer (`primary`, optionally `accent`). The
+cascade resolves as `Special > Mode > base semantic`, with conflicts
+disambiguated by load order rather than selector specificity.
+
+The new rule documents:
+
+- The two-axis model and which tokens each axis owns
+- Cascade order and the load-order convention for Specials
+- A **token allowlist** mechanism — each Special declares which tokens it may
+  override (design only; enforcement lint lands in v0.7.0)
+- DOM application (`.dark` for Mode, `[data-season=...]` / `[data-event=...]` /
+  `[data-theme=...]` for Special — one attribute per Special category)
+- A mapping table for the eight existing seasonal palettes, restating that
+  each currently overrides only `--color-primary-*`
+- Process for adding a new Special today (pre-v0.7.0) and rare-path guidance
+  for adding a new Mode
+
+The companion implementation work — allowlist linting plus the 8 seasonal × 2
+mode = 16-pattern Storybook audit — is scheduled for v0.7.0.
+
+No public API or component behaviour changes.

--- a/.changeset/theme-architecture-rule.md
+++ b/.changeset/theme-architecture-rule.md
@@ -7,8 +7,9 @@ docs(rule): add `.claude/rules/theme-architecture.md` (Mode × Special two-axis 
 Theming is now modelled as two independent **exclusive** axes: **Mode**
 (`light` / `dark`) owns the base layer (surfaces, foregrounds, borders, state
 shade-shifts); **Special** (`<none>` / `season--*` / brand themes / customer
-palettes) owns the expressive layer (`primary`, optionally `accent`). At most
-one Special is active at a time, set via `data-theme="<value>"` on `<html>`.
+palettes) owns the expressive layer — the **`--color-theme-*` scale**,
+optionally `accent`. At most one Special is active at a time, set via
+`data-theme="<value>"` on `<html>`.
 
 The cascade resolves as `Special > Mode > base semantic` — Specials win on
 specificity (single-attribute selector beats `:root` / `.dark`), not on
@@ -31,11 +32,16 @@ The new rule documents:
   `data-season` form
 - Process for adding a new Special today (pre-v0.7.0)
 
-**Deprecation**: `data-season="<name>"` is deprecated in favour of
-`data-theme="season--<name>"`. The existing seasonal CSS and helpers under
-`src/themes/seasonal/` still use `data-season`; the actual rename ships in
-v0.7.0 alongside the allowlist enforcement and the 8 × 2 = 16-pattern
-Storybook audit story. New code MUST use `data-theme` with the value
-convention above.
+**Deprecations** (both rename in v0.7.0 alongside the allowlist enforcement
+and the 8 × 2 = 16-pattern Storybook audit story):
+
+- `data-season="<name>"` → `data-theme="season--<name>"`. Family encoded in
+  the value, not in a separate attribute.
+- `--color-primary-*` / `bg-primary-*` → `--color-theme-*` / `bg-theme-*`.
+  The token name now matches the attribute that drives it (`data-theme`),
+  removing the "primary brand color" vs "theme-driven slot" conflation.
+
+New code MUST use the canonical names (`data-theme`, `--color-theme-*`,
+`bg-theme-*`); do not introduce new `data-season` or `*-primary-*` usage.
 
 No public API or component behaviour changes in this PR — only the rule.

--- a/.changeset/theme-architecture-rule.md
+++ b/.changeset/theme-architecture-rule.md
@@ -5,9 +5,9 @@
 docs(rule): add `.claude/rules/theme-architecture.md` (Mode × Special two-axis model)
 
 Theming is now modelled as two independent axes: **Mode** (exclusive — light /
-dark, with high-contrast reserved for Phase 5) owns the base layer (surfaces,
-foregrounds, borders, state shade-shifts); **Special** (cumulative — seasonal,
-event, custom) owns the expressive layer (`primary`, optionally `accent`). The
+dark) owns the base layer (surfaces, foregrounds, borders, state shade-shifts);
+**Special** (cumulative — seasonal, event, custom) owns the expressive layer
+(`primary`, optionally `accent`). The
 cascade resolves as `Special > Mode > base semantic`, with conflicts
 disambiguated by load order rather than selector specificity.
 

--- a/.changeset/theme-architecture-rule.md
+++ b/.changeset/theme-architecture-rule.md
@@ -4,27 +4,31 @@
 
 docs(rule): add `.claude/rules/theme-architecture.md` (Mode × Special two-axis model)
 
-Theming is now modelled as two independent axes: **Mode** (exclusive — light /
-dark) owns the base layer (surfaces, foregrounds, borders, state shade-shifts);
-**Special** (cumulative — seasonal, event, custom) owns the expressive layer
-(`primary`, optionally `accent`). The
-cascade resolves as `Special > Mode > base semantic`, with conflicts
-disambiguated by load order rather than selector specificity.
+Theming is now modelled as two independent **exclusive** axes: **Mode**
+(`light` / `dark`) owns the base layer (surfaces, foregrounds, borders, state
+shade-shifts); **Special** (`<none>` / `seasonal-*` / brand themes / customer
+palettes) owns the expressive layer (`primary`, optionally `accent`). At most
+one Special is active at a time, set via `data-theme="<name>"` on `<html>`.
+
+The cascade resolves as `Special > Mode > base semantic` — Specials win on
+specificity (single-attribute selector beats `:root` / `.dark`), not on
+stylesheet load order.
 
 The new rule documents:
 
 - The two-axis model and which tokens each axis owns
-- Cascade order and the load-order convention for Specials
+- Cascade rules and the load-order convention for the stylesheet chain
 - A **token allowlist** mechanism — each Special declares which tokens it may
   override (design only; enforcement lint lands in v0.7.0)
-- DOM application (`.dark` for Mode, `[data-season=...]` / `[data-event=...]` /
-  `[data-theme=...]` for Special — one attribute per Special category)
+- DOM application — `.dark` for Mode, single `[data-theme=...]` attribute for
+  Special. Migration note: existing seasonal CSS still uses `data-season` and
+  is renamed to `data-theme` in v0.7.0
 - A mapping table for the eight existing seasonal palettes, restating that
   each currently overrides only `--color-primary-*`
-- Process for adding a new Special today (pre-v0.7.0) and rare-path guidance
-  for adding a new Mode
+- Process for adding a new Special today (pre-v0.7.0)
 
-The companion implementation work — allowlist linting plus the 8 seasonal × 2
-mode = 16-pattern Storybook audit — is scheduled for v0.7.0.
+The companion implementation work — allowlist linting, the
+`data-season → data-theme` rename, and the 8 Specials × 2 mode = 16-pattern
+Storybook audit — is scheduled for v0.7.0.
 
 No public API or component behaviour changes.

--- a/.changeset/theme-architecture-rule.md
+++ b/.changeset/theme-architecture-rule.md
@@ -6,9 +6,9 @@ docs(rule): add `.claude/rules/theme-architecture.md` (Mode × Special two-axis 
 
 Theming is now modelled as two independent **exclusive** axes: **Mode**
 (`light` / `dark`) owns the base layer (surfaces, foregrounds, borders, state
-shade-shifts); **Special** (`<none>` / `seasonal-*` / brand themes / customer
+shade-shifts); **Special** (`<none>` / `season--*` / brand themes / customer
 palettes) owns the expressive layer (`primary`, optionally `accent`). At most
-one Special is active at a time, set via `data-theme="<name>"` on `<html>`.
+one Special is active at a time, set via `data-theme="<value>"` on `<html>`.
 
 The cascade resolves as `Special > Mode > base semantic` — Specials win on
 specificity (single-attribute selector beats `:root` / `.dark`), not on
@@ -17,18 +17,25 @@ stylesheet load order.
 The new rule documents:
 
 - The two-axis model and which tokens each axis owns
-- Cascade rules and the load-order convention for the stylesheet chain
+- Cascade rules (specificity-based, with load order as tie-breaker for the
+  stylesheet chain only)
 - A **token allowlist** mechanism — each Special declares which tokens it may
   override (design only; enforcement lint lands in v0.7.0)
-- DOM application — `.dark` for Mode, single `[data-theme=...]` attribute for
-  Special. Migration note: existing seasonal CSS still uses `data-season` and
-  is renamed to `data-theme` in v0.7.0
-- A mapping table for the eight existing seasonal palettes, restating that
-  each currently overrides only `--color-primary-*`
+- DOM application: `.dark` for Mode, single `data-theme` attribute for Special
+- A **`data-theme` value convention**: `<theme>` for one-offs or
+  `<theme>--<subtheme>` for families (e.g. `season--spring-early`,
+  `brand--acme`, `halloween`). One attribute, one value namespace, no
+  `data-season` / `data-event` / `data-brand` proliferation.
+- A mapping table for the eight existing seasonal palettes, showing both the
+  canonical `data-theme` form (`season--spring-early`) and the legacy
+  `data-season` form
 - Process for adding a new Special today (pre-v0.7.0)
 
-The companion implementation work — allowlist linting, the
-`data-season → data-theme` rename, and the 8 Specials × 2 mode = 16-pattern
-Storybook audit — is scheduled for v0.7.0.
+**Deprecation**: `data-season="<name>"` is deprecated in favour of
+`data-theme="season--<name>"`. The existing seasonal CSS and helpers under
+`src/themes/seasonal/` still use `data-season`; the actual rename ships in
+v0.7.0 alongside the allowlist enforcement and the 8 × 2 = 16-pattern
+Storybook audit story. New code MUST use `data-theme` with the value
+convention above.
 
-No public API or component behaviour changes.
+No public API or component behaviour changes in this PR — only the rule.

--- a/.claude/rules/theme-architecture.md
+++ b/.claude/rules/theme-architecture.md
@@ -7,8 +7,8 @@ runtime:
 
 - **Mode** — exclusive (`light` / `dark`). Owns the base layer: surfaces,
   foregrounds, borders.
-- **Special** — exclusive (`seasonal-*`, brand themes, customer palettes,
-  …). Owns the expressive layer: the `theme` scale, `accent`, and other
+- **Special** — exclusive (`season--*`, `brand--*`, vendor palettes, …).
+  Owns the expressive layer: the `theme` scale, `accent`, and other
   "characteristic" tokens.
 
 Both axes are exclusive: exactly one Mode is active (`light` xor `dark`),
@@ -30,21 +30,24 @@ fits into one of these two axes and overrides only the tokens it owns".
 
 ```
 Axis 1  Mode     (exclusive)   light  |  dark
-Axis 2  Special  (exclusive)   <none>  |  seasonal-*  |  brand-*  |  custom-*
+Axis 2  Special  (exclusive)   <none>  |  season--*  |  brand--*  |  <vendor>--*
                                each Special declares an allowlist of tokens
                                it may override
 ```
 
-A Special name lives in a **single flat namespace**. Subcategories
-(`seasonal-spring-early`, `brand-acme`, …) are just naming conventions
+A Special name lives in a **single flat namespace**, with values shaped
+as `<family>` or `<family>--<variant>` (full convention in
+[DOM application](#data-theme-value-convention)). Family prefixes
+(`season--spring-early`, `brand--acme`, …) are just naming conventions
 inside that namespace — they don't get separate DOM attributes, separate
 cascade tiers, or separate allowlist semantics. Keeping Special exclusive
 and single-attribute is a deliberate scope choice: the previous design
-considered cumulative Specials with per-category attributes, but the
+considered cumulative Specials with per-family attributes, but the
 combinatorial cost (cascade tie-breaking, allowlist intersection rules,
 multiple DOM attributes to keep in sync) was not worth it for any
-foreseeable use case. Reach for [external Specials](#external-special-themes-future)
-before reaching for "two Specials at once".
+foreseeable use case. If you ever need themes from multiple sources at
+once, that's a sign you want the [external Special API](#external-special-themes-future)
+(future work), not two `data-theme` attributes.
 
 ### Mode owns the base layer
 

--- a/.claude/rules/theme-architecture.md
+++ b/.claude/rules/theme-architecture.md
@@ -1,0 +1,257 @@
+# Theme Architecture Guideline
+
+## Overview
+
+Schatten's theming is modelled as **two independent axes** that compose at
+runtime:
+
+- **Mode** — exclusive (`light` / `dark`, with `high-contrast` reserved for
+  Phase 5). Owns the base layer: surfaces, foregrounds, borders.
+- **Special** — cumulative (`seasonal-*`, `event-*`, `custom-*`). Owns the
+  expressive layer: `primary`, `accent`, and other "characteristic" tokens.
+
+The two axes meet at the **semantic token layer** (`src/core/tokens/semantic.css`).
+Components keep referencing the same semantic names (`bg-primary`,
+`text-foreground`, …) regardless of which Mode + Special combination is
+active — they don't need to know.
+
+This rule documents the model itself, the cascade, the allowlist convention,
+and how the DOM is annotated. It is the **architectural counterpart** to
+[state-token-guideline](state-token-guideline.md), which covers the *value
+shape* of state tokens (`error`/`success`/`warning`/`info`/`destructive`,
+each as `base`/`hover`/`foreground`/`subtle`). Where state-token-guideline
+says "every state token has these four slots", this rule says "every theme
+fits into one of these two axes and overrides only the tokens it owns".
+
+## Two-axis model
+
+```
+Axis 1  Mode     (exclusive)   light  |  dark   [|  high-contrast — Phase 5]
+Axis 2  Special  (cumulative)  seasonal-*  +  event-*  +  custom-*
+                               each Special declares an allowlist of tokens
+                               it may override
+```
+
+**Exclusive** means exactly one Mode is active at a time (`light` xor `dark`).
+**Cumulative** means zero or more Specials can stack — a seasonal palette
+plus a co-branded event accent, for example. The cascade resolves conflicts
+deterministically (see below), but in practice well-behaved Specials don't
+fight because their allowlists don't overlap.
+
+### Mode owns the base layer
+
+| Concern | Example tokens |
+|---|---|
+| Surface / background | `--color-background`, `--color-surface`, `--color-surface-hover` |
+| Foreground tiers | `--color-foreground`, `--color-foreground-muted`, `--color-foreground-subtle` |
+| Inverted foreground tiers | `--color-inverted-foreground*` |
+| Borders | `--color-border`, `--color-border-strong` |
+| Focus ring | `--color-ring`, `--color-ring-offset` |
+| State remapping for dark | `--color-error*`, `--color-success*`, `--color-warning*`, `--color-info*`, `--color-destructive*` (shade shift between light and dark) |
+
+Rule of thumb: anything that needs to flip *shade* between light and dark
+belongs to Mode.
+
+### Special owns the expressive layer
+
+| Concern | Example tokens |
+|---|---|
+| Primary scale | `--color-primary-50` … `--color-primary-950` |
+| Accent (when a Special wants to retune it) | `--color-accent`, `--color-accent-foreground` |
+
+Rule of thumb: anything that expresses *brand character* — seasonality, an
+event identity, a customer's palette — belongs to Special.
+
+### Tokens neither axis touches
+
+A few tokens are pinned by intent and **must not** be moved by either axis:
+
+- `--color-info-*` references `blue-*` directly. Themes that retune
+  `primary` must not drift `info`'s meaning. See
+  [state-token-guideline](state-token-guideline.md#info-independence-from-primary).
+- Primitives (`--vermillion-*`, `--green-*`, `--blue-*`, …) are theme-agnostic
+  by definition and live one layer below semantics.
+
+## Cascade
+
+When tokens collide, the later declaration wins. CSS specificity is
+identical for `:root`, `:root[data-season=...]`, and `:root[data-event=...]`
+(a single attribute selector matches the same `<html>` element), so source
+order in the stylesheet is what actually decides.
+
+The intended order, from earliest (lowest priority) to latest (highest):
+
+```
+1.  primitives.css                       — raw OKLCH scales
+2.  semantic.css :root                   — base semantic tokens (light)
+3.  semantic.css .dark / @media dark     — Mode override
+4.  themes/default/colors.css            — Special: default (Mode-neutral primary)
+5.  themes/seasonal/themes.css           — Special: seasonal (data-season)
+6.  themes/event/...                     — Special: event (data-event)         [v0.7.0+]
+7.  themes/custom/...                    — Special: custom (data-theme)        [v0.7.0+]
+```
+
+Effective precedence at runtime:
+
+```
+Special (last loaded wins)  >  Mode  >  base semantic
+```
+
+**Why last-wins for Special and not specificity-based?** Stacking Specials
+with progressively more specific selectors (`[data-season][data-event]`,
+…) would couple the cascade to combinatorial selector engineering. Keeping
+specificity flat and relying on **load order + allowlist** is simpler,
+cheaper to debug, and survives a thousand Specials without selector
+explosion.
+
+**Mode override and the `.dark` class.** `.dark` lives on `<html>` and has
+the same specificity as `[data-season=...]` — the dark override in
+`semantic.css` is loaded *before* any Special CSS in the import order, so
+Specials win for the tokens they own and Mode wins for everything else.
+This is the intended behaviour.
+
+## Allowlist mechanism (design — implementation in v0.7.0)
+
+A Special theme declares *which tokens it is allowed to override*. Tokens
+outside the allowlist are owned by Mode (or by another Special). The
+allowlist is a contract — it makes the partition between axes explicit and
+testable.
+
+```ts
+// Design sketch — actual API lands in v0.7.0
+export const springEarlyTheme = {
+  name: 'spring-early',
+  axis: 'special',
+  category: 'seasonal',
+  allowedTokens: ['--color-primary-*'],
+  // Everything outside this list (foregrounds, surfaces, state colors, info)
+  // belongs to Mode or another Special.
+} as const
+```
+
+What the allowlist will enable, once implemented:
+
+- **Build-time lint**: scan each `themes/<special>/*.css` and fail if it
+  writes a token that's not in its `allowedTokens`. Prevents accidental
+  bleed from a seasonal palette into surfaces/foregrounds.
+- **Conflict detection**: when two Specials are layered, fail (or warn) if
+  their allowlists intersect. Forces a deliberate decision about who owns
+  which token rather than silent last-wins.
+- **Audit output**: surface the effective token-by-token attribution in
+  Storybook (Foundation → Theme Audit), so designers can see "this colour
+  came from `seasonal:spring-early`".
+
+Until v0.7.0 ships the enforcement, **treat the allowlist as a hand-checked
+convention**: when authoring a new Special, write the tokens it touches at
+the top of the CSS file as a comment, and only touch those.
+
+## DOM application
+
+Two channels, one per axis:
+
+| Axis | Selector | Where it's set |
+|---|---|---|
+| Mode (light) | `:root` (implicit default) | nothing to set; OS-level dark mode honoured via `@media (prefers-color-scheme: dark)` |
+| Mode (dark, explicit) | `.dark` on `<html>` | by a theme switcher (e.g. Storybook globals, app-level setting) |
+| Special (seasonal) | `[data-season="<name>"]` on `<html>` | `applySeasonTheme()` in [`src/themes/seasonal/index.ts`](../../src/themes/seasonal/index.ts), or SSR via `getSeasonAttribute()` |
+| Special (event) — v0.7.0+ | `[data-event="<name>"]` on `<html>` | TBD |
+| Special (custom) — v0.7.0+ | `[data-theme="<name>"]` on `<html>` | TBD |
+
+**One attribute per Special category.** Each category gets its own data
+attribute namespace (`data-season`, `data-event`, `data-theme`) rather than
+overloading a single `data-theme`. This keeps "which seasonal palette is
+active" and "which event identity is active" independently queryable and
+avoids string-parsing a composite value.
+
+**Why `<html>` and not `<body>`.** Storybook, Tailwind v4 `dark:`, and most
+SSR frameworks already key off `<html class="...">`. Putting Mode and
+Special on the same element keeps the cascade predictable and means a
+single attribute mutation is enough to retheme the whole tree.
+
+## Existing seasonal themes — current vs. new model
+
+The eight seasonal palettes in [`src/themes/seasonal/themes.css`](../../src/themes/seasonal/themes.css)
+already follow the Special-axis pattern in practice: each overrides only
+`--color-primary-*`. The table below restates that contract in the new
+model so future authors can replicate it.
+
+| Theme | Hue (OKLCH) | Period | Axis | Category | `allowedTokens` |
+|---|---|---|---|---|---|
+| `spring-early` | 12  | 2/4 – 3/20 | special | seasonal | `--color-primary-*` |
+| `spring-late`  | 138 | 3/21 – 5/5 | special | seasonal | `--color-primary-*` |
+| `summer-early` | 162 | 5/6 – 6/20 | special | seasonal | `--color-primary-*` |
+| `summer-peak`  | 45  | 6/21 – 8/6 | special | seasonal | `--color-primary-*` |
+| `autumn-early` | 230 | 8/7 – 9/22 | special | seasonal | `--color-primary-*` |
+| `autumn-late`  | 70  | 9/23 – 11/6 | special | seasonal | `--color-primary-*` |
+| `winter-early` | 250 | 11/7 – 12/21 | special | seasonal | `--color-primary-*` |
+| `winter-deep`  | 0/240 | 12/22 – 2/3 | special | seasonal | `--color-primary-*` |
+
+No existing seasonal theme touches surfaces, foregrounds, borders, accent,
+state colors, or info. **That is the contract** — keep it that way when
+adding new seasonals.
+
+### Dark × Special — visual verification
+
+Each Special must remain readable under both Modes. With 8 seasonals × 2
+Modes = 16 combinations, exhaustive visual review is necessary because a
+hue that contrasts well in light mode can collapse against a dark surface
+(or vice versa). The 16-pattern Storybook audit story ships in **v0.7.0**;
+until then, sanity-check new Specials manually by toggling the Storybook
+theme global on the relevant Color / Foundation stories.
+
+## Adding a new Special theme (today's process — pre-v0.7.0)
+
+1. **Decide the category** — seasonal, event, or custom. Each lives under
+   its own folder (`src/themes/seasonal/`, …) and uses its own data
+   attribute (`data-season`, `data-event`, `data-theme`).
+2. **List the tokens you intend to override** as a comment at the top of
+   the CSS file. Today's seasonals override `--color-primary-50..950` only —
+   match that scope unless you have a documented reason to expand.
+3. **Never override Mode-owned tokens** — surfaces, foregrounds, borders,
+   inverted foregrounds, focus ring, state colors. If a Special needs the
+   foreground to change, that's a sign it should be authored as a Mode
+   instead (or a future high-contrast Mode).
+4. **Never override `info-*`** — it's pinned to blue across all themes.
+5. **Verify both Modes visually** — open the Color / Foundation stories,
+   toggle dark mode, check that text on `primary` surfaces still meets
+   contrast. The "Filled Treatments (a11y audit)" section in
+   `Foundation/Color` is the right place to spot-check.
+6. **Add a changeset** — `minor` if the Special ships as a user-facing
+   option, `patch` if it's internal-only.
+
+## Adding a new Mode (rare — Phase 5)
+
+`high-contrast` is the most likely next Mode, primarily for accessibility.
+Color-vision modes (deuteranopia/protanopia simulation) are likely Special
+rather than Mode because they retune saturation/hue rather than the
+light/dark base. The decision is deferred to Phase 5 — when the time comes,
+revisit this rule and choose based on:
+
+- **Mode** if the change is exclusive with `light` / `dark` (a user picks
+  exactly one base mode).
+- **Special** if the change layers on top of an existing Mode (an
+  accessibility preference that augments either light or dark).
+
+## External Special themes (Phase 5+, after 1.0)
+
+Until 1.0, Specials are internal-only (`yasmro` palettes). After 1.0 we
+intend to expose a public API for consumer-authored Specials. Two
+constraints that the v0.7.0 allowlist mechanism already prepares for:
+
+- **Sandboxing**: a consumer Special should be unable to override
+  Mode-owned tokens or `info-*`. The allowlist + lint enforces this
+  mechanically.
+- **Identity**: each external Special declares its own data-attribute
+  namespace (likely `data-theme="<vendor>-<name>"`) so two consumers can't
+  collide on the same attribute value.
+
+The public API and packaging story are out of scope for this rule and will
+be designed alongside the 1.0 release.
+
+## Quick reference
+
+- **Mode**  → `:root` (light) / `.dark` (dark) / `@media (prefers-color-scheme: dark)` (system) — owns surfaces, foregrounds, borders, state shade-shifts.
+- **Special** → `[data-season=...]` / `[data-event=...]` / `[data-theme=...]` — owns `primary`, optionally `accent`. Cumulative; last-loaded wins.
+- **Cascade** → `Special > Mode > base semantic`.
+- **Never** touch Mode-owned tokens or `info-*` from a Special.
+- **Components** keep referencing semantic tokens (`bg-primary`, `text-foreground`, …) — they don't need to know which axes are active.

--- a/.claude/rules/theme-architecture.md
+++ b/.claude/rules/theme-architecture.md
@@ -118,8 +118,8 @@ surface/foreground Mode is currently active. If a Special needs *different*
 shades in dark mode, it must declare both selectors:
 
 ```css
-:root[data-theme="winter-deep"]  { --color-primary-500: oklch(...); }
-.dark[data-theme="winter-deep"]  { --color-primary-500: oklch(...); }
+:root[data-theme="season--winter-deep"]  { --color-primary-500: oklch(...); }
+.dark[data-theme="season--winter-deep"]  { --color-primary-500: oklch(...); }
 ```
 
 The latter has specificity `(0,3,0)` and beats both `.dark` alone and the
@@ -134,8 +134,8 @@ it makes the partition between axes explicit and testable.
 
 ```ts
 // Design sketch — actual API lands in v0.7.0
-export const springEarlyTheme = {
-  name: 'spring-early',
+export const springEarlySeasonTheme = {
+  name: 'season--spring-early', // matches the data-theme value
   allowedTokens: ['--color-primary-*'],
   // Everything outside this list (foregrounds, surfaces, state colors, info)
   // belongs to Mode.
@@ -149,7 +149,7 @@ What the allowlist will enable, once implemented:
   bleed from a seasonal palette into surfaces/foregrounds.
 - **Audit output**: surface the effective token-by-token attribution in
   Storybook (Foundation → Theme Audit), so designers can see "this colour
-  came from `spring-early`".
+  came from `season--spring-early`".
 
 Until v0.7.0 ships the enforcement, **treat the allowlist as a hand-checked
 convention**: when authoring a new Special, write the tokens it touches at
@@ -165,18 +165,48 @@ Two channels, one per axis:
 | Mode (dark, explicit) | `.dark` on `<html>` | by a theme switcher (e.g. Storybook globals, app-level setting) |
 | Special | `[data-theme="<name>"]` on `<html>` | `applySeasonTheme()` in [`src/themes/seasonal/index.ts`](../../src/themes/seasonal/index.ts), or SSR via `getSeasonAttribute()` |
 
-**One attribute for Special.** A single `data-theme` namespace is used for
-every Special, regardless of whether it represents a season, a brand, or
-a customer palette. Naming conventions inside the value (`spring-early`,
-`brand-acme`, …) carry the sub-category — there is no `data-season` /
-`data-event` / `data-brand` proliferation.
+### `data-theme` value convention
 
-> **Migration note**: the existing seasonal CSS in
+The value of `data-theme` follows one of two shapes:
+
+```
+data-theme="<theme>"
+data-theme="<theme>--<subtheme>"
+```
+
+- `<theme>` is the **theme family** — `season`, `brand`, `holiday`, … or a
+  vendor name (`acme`) for an external Special.
+- `<subtheme>` is the **specific variant** inside that family, separated
+  by a double-dash `--` (chosen because it doesn't collide with valid
+  identifier characters and reads clearly).
+- A one-off Special with no siblings can omit the `--<subtheme>` part
+  (e.g. `data-theme="halloween"`).
+
+Examples:
+
+| `data-theme` value | Meaning |
+|---|---|
+| `season--spring-early` | seasonal palette, spring-early variant |
+| `season--winter-deep` | seasonal palette, winter-deep variant |
+| `brand--acme` | brand palette for "acme" |
+| `acme--summer` | external Special: vendor "acme", their "summer" variant |
+| `halloween` | one-off Special with no sub-variants |
+
+**One attribute for Special.** Every Special — season, brand, vendor,
+one-off — sets the same `data-theme` attribute. There is no `data-season`
+/ `data-event` / `data-brand` proliferation; family is encoded in the
+value, not in the attribute name.
+
+> **Deprecation: `data-season` → `data-theme`**.
 > [`src/themes/seasonal/themes.css`](../../src/themes/seasonal/themes.css)
 > and the helpers in [`src/themes/seasonal/index.ts`](../../src/themes/seasonal/index.ts)
-> still use `data-season`. The rename to `data-theme` ships alongside the
-> v0.7.0 allowlist enforcement work; treat `data-theme` as the canonical
-> attribute when authoring new code.
+> currently use `data-season="<name>"`. This is **deprecated**. The
+> equivalent canonical form is `data-theme="season--<name>"`
+> (e.g. `data-season="spring-early"` → `data-theme="season--spring-early"`).
+> The actual CSS / helper rename ships in v0.7.0 alongside the allowlist
+> enforcement work. **Authoring rule for new code**: use `data-theme`
+> with the value convention above; do not introduce new `data-season`
+> usage.
 
 **Why `<html>` and not `<body>`.** Storybook, Tailwind v4 `dark:`, and most
 SSR frameworks already key off `<html class="...">`. Putting Mode and
@@ -190,16 +220,16 @@ already follow the Special-axis pattern in practice: each overrides only
 `--color-primary-*`. The table below restates that contract in the new
 model so future authors can replicate it.
 
-| Theme | Hue (OKLCH) | Period | `allowedTokens` |
-|---|---|---|---|
-| `spring-early` | 12  | 2/4 – 3/20 | `--color-primary-*` |
-| `spring-late`  | 138 | 3/21 – 5/5 | `--color-primary-*` |
-| `summer-early` | 162 | 5/6 – 6/20 | `--color-primary-*` |
-| `summer-peak`  | 45  | 6/21 – 8/6 | `--color-primary-*` |
-| `autumn-early` | 230 | 8/7 – 9/22 | `--color-primary-*` |
-| `autumn-late`  | 70  | 9/23 – 11/6 | `--color-primary-*` |
-| `winter-early` | 250 | 11/7 – 12/21 | `--color-primary-*` |
-| `winter-deep`  | 0/240 | 12/22 – 2/3 | `--color-primary-*` |
+| `data-theme` value (canonical) | Legacy `data-season` (deprecated) | Hue | Period | `allowedTokens` |
+|---|---|---|---|---|
+| `season--spring-early` | `spring-early` | 12  | 2/4 – 3/20  | `--color-primary-*` |
+| `season--spring-late`  | `spring-late`  | 138 | 3/21 – 5/5  | `--color-primary-*` |
+| `season--summer-early` | `summer-early` | 162 | 5/6 – 6/20  | `--color-primary-*` |
+| `season--summer-peak`  | `summer-peak`  | 45  | 6/21 – 8/6  | `--color-primary-*` |
+| `season--autumn-early` | `autumn-early` | 230 | 8/7 – 9/22  | `--color-primary-*` |
+| `season--autumn-late`  | `autumn-late`  | 70  | 9/23 – 11/6 | `--color-primary-*` |
+| `season--winter-early` | `winter-early` | 250 | 11/7 – 12/21 | `--color-primary-*` |
+| `season--winter-deep`  | `winter-deep`  | 0/240 | 12/22 – 2/3 | `--color-primary-*` |
 
 No existing seasonal theme touches surfaces, foregrounds, borders, accent,
 state colors, or info. **That is the contract** — keep it that way when
@@ -216,10 +246,12 @@ the Storybook theme global on the relevant Color / Foundation stories.
 
 ## Adding a new Special theme (today's process — pre-v0.7.0)
 
-1. **Pick a name** in the flat Special namespace. Use a prefix that
-   conveys the sub-category if it helps readability (`spring-late`,
-   `brand-acme`, …) — but the prefix is just a naming convention, not
-   a separate axis.
+1. **Pick a `data-theme` value** following the `<theme>` or
+   `<theme>--<subtheme>` convention. Examples:
+   `season--spring-late` (new seasonal), `brand--acme` (brand palette),
+   `halloween` (one-off with no sub-variants). The leading family name
+   is just a naming convention — it groups Specials visually and in
+   the Theme Audit story but does not create a separate axis.
 2. **List the tokens you intend to override** as a comment at the top of
    the CSS file. Today's seasonals override `--color-primary-50..950` only —
    match that scope unless you have a documented reason to expand.
@@ -245,8 +277,9 @@ already prepares for:
 - **Sandboxing**: a consumer Special must not be able to override
   Mode-owned tokens or `info-*`. The allowlist + lint enforces this
   mechanically.
-- **Naming**: external Specials should namespace their `data-theme` value
-  (e.g. `data-theme="acme-summer"`) so two consumers can't collide on the
+- **Naming**: external Specials use a vendor prefix in the `data-theme`
+  value following the `<vendor>--<variant>` convention (e.g.
+  `data-theme="acme--summer"`) so two consumers can't collide on the
   same attribute value.
 
 The public API and packaging story are out of scope for this rule.

--- a/.claude/rules/theme-architecture.md
+++ b/.claude/rules/theme-architecture.md
@@ -74,12 +74,20 @@ A few tokens are pinned by intent and **must not** be moved by either axis:
 
 ## Cascade
 
-When tokens collide, the later declaration wins. CSS specificity is
-identical for `:root`, `:root[data-season=...]`, and `:root[data-event=...]`
-(a single attribute selector matches the same `<html>` element), so source
-order in the stylesheet is what actually decides.
+Two mechanisms decide which declaration wins: **CSS specificity** and
+**source order** (later wins on a tie). The model leans on both:
 
-The intended order, from earliest (lowest priority) to latest (highest):
+- `:root[data-season=...]` and `:root[data-event=...]` each combine a
+  pseudo-class with an attribute selector → specificity `(0,2,0)`.
+- `:root` alone → `(0,1,0)`. `.dark` (or any single class) → `(0,1,0)`.
+- Therefore **any single-attribute Special selector beats both `:root`
+  and `.dark`** on specificity alone. Specials win over Mode by the
+  cascade rules, not by load order luck.
+- Between Specials of different categories (e.g. `[data-season]` vs
+  `[data-event]`), specificity is identical → **source order decides**.
+
+The intended source order, from earliest (lowest priority) to latest
+(highest):
 
 ```
 1.  primitives.css                       — raw OKLCH scales
@@ -94,21 +102,33 @@ The intended order, from earliest (lowest priority) to latest (highest):
 Effective precedence at runtime:
 
 ```
-Special (last loaded wins)  >  Mode  >  base semantic
+Special (specificity beats Mode; ties broken by load order)
+  >  Mode (.dark beats :root by load order)
+  >  base semantic
 ```
 
-**Why last-wins for Special and not specificity-based?** Stacking Specials
-with progressively more specific selectors (`[data-season][data-event]`,
-…) would couple the cascade to combinatorial selector engineering. Keeping
-specificity flat and relying on **load order + allowlist** is simpler,
+**Why flat specificity between Specials, not stacked selectors?** Stacking
+Specials with progressively more specific selectors
+(`[data-season][data-event]`, …) would couple the cascade to combinatorial
+selector engineering. Keeping every Special's selector at the same
+specificity tier and relying on **load order + allowlist** is simpler,
 cheaper to debug, and survives a thousand Specials without selector
 explosion.
 
-**Mode override and the `.dark` class.** `.dark` lives on `<html>` and has
-the same specificity as `[data-season=...]` — the dark override in
-`semantic.css` is loaded *before* any Special CSS in the import order, so
-Specials win for the tokens they own and Mode wins for everything else.
-This is the intended behaviour.
+**Specials are Mode-agnostic by default.** A `:root[data-season=...]` rule
+applies the same values in light *and* dark — the existing seasonal
+palettes are designed to be Mode-neutral hues that sit atop whatever
+surface/foreground Mode is currently active. If a future Special needs
+*different* shades in dark mode, it must declare both selectors:
+
+```css
+:root[data-season="winter-deep"]  { --color-primary-500: oklch(...); }
+.dark[data-season="winter-deep"]  { --color-primary-500: oklch(...); }
+```
+
+The latter has specificity `(0,3,0)` and beats both `.dark` alone and the
+plain Special selector, giving a deterministic dark-mode-specific value
+without disturbing the light-mode case.
 
 ## Allowlist mechanism (design — implementation in v0.7.0)
 

--- a/.claude/rules/theme-architecture.md
+++ b/.claude/rules/theme-architecture.md
@@ -74,20 +74,16 @@ Rule of thumb: anything that expresses *brand character* — seasonality, an
 event identity, a customer's palette — belongs to Special.
 
 > **Deprecation: `--color-primary-*` → `--color-theme-*`**.
-> The CSS variable currently shipping in
+> The shipping variable in
 > [`src/core/tokens/semantic.css`](../../src/core/tokens/semantic.css) is
 > `--color-primary-50..950` (with matching Tailwind utilities
 > `bg-primary-500`, `text-primary-600`, …). This name predates the
 > two-axis model and conflates "the brand's primary color" with "the
 > slot the active theme drives." The canonical name is **`--color-theme-*`**,
 > matching the `data-theme` attribute that controls it. Equivalent
-> Tailwind utilities are `bg-theme-500`, `text-theme-600`, ….
-> The actual rename — across semantic.css, themes/seasonal/themes.css,
-> themes/default/colors.css, base.css, and any component that references
-> `*-primary-*` — ships in **v0.7.0** alongside the allowlist enforcement
-> and the `data-season` → `data-theme` migration. Use `--color-theme-*` /
-> `bg-theme-*` for any new code; do not introduce new `*-primary-*`
-> references.
+> Tailwind utilities will be `bg-theme-500`, `text-theme-600`, …. The
+> actual rename ships in **v0.7.0** — see [v0.7.0 migration plan](#v070-migration-plan)
+> for what changes and how to write code in the meantime.
 
 ### Tokens neither axis touches
 
@@ -219,13 +215,11 @@ value, not in the attribute name.
 > **Deprecation: `data-season` → `data-theme`**.
 > [`src/themes/seasonal/themes.css`](../../src/themes/seasonal/themes.css)
 > and the helpers in [`src/themes/seasonal/index.ts`](../../src/themes/seasonal/index.ts)
-> currently use `data-season="<name>"`. This is **deprecated**. The
-> equivalent canonical form is `data-theme="season--<name>"`
-> (e.g. `data-season="spring-early"` → `data-theme="season--spring-early"`).
-> The actual CSS / helper rename ships in v0.7.0 alongside the allowlist
-> enforcement work. **Authoring rule for new code**: use `data-theme`
-> with the value convention above; do not introduce new `data-season`
-> usage.
+> currently use `data-season="<name>"`. This is deprecated. The canonical
+> form is `data-theme="season--<name>"` (e.g. `data-season="spring-early"`
+> → `data-theme="season--spring-early"`). The actual rename ships in
+> v0.7.0 — see [v0.7.0 migration plan](#v070-migration-plan) for what
+> changes and the authoring rule in the meantime.
 
 **Why `<html>` and not `<body>`.** Storybook, Tailwind v4 `dark:`, and most
 SSR frameworks already key off `<html class="...">`. Putting Mode and
@@ -262,7 +256,9 @@ Three layers work together:
 │   { --color-theme-500: oklch(0.64 0.10 12); }       ◀── 2. seasonal override
 │                                                          (Specificity (0,2,0)
 │                                                           beats :root default)
-│   :root { --color-theme-500: var(--blue-500); }     ◀── 3. default, lost in cascade
+│   :root { --color-theme-500: var(--blue-500); }     ◀── 3. default, overridden by
+│                                                          the higher-specificity
+│                                                          rule above
 │
 └─ inherits ↓
     └─ <body>
@@ -281,7 +277,7 @@ Three layers work together:
 - [`src/core/tokens/primitives.css`](../../src/core/tokens/primitives.css) — `:root { --blue-500: oklch(...); }` (frozen primitives)
 - [`src/core/tokens/semantic.css`](../../src/core/tokens/semantic.css) — `:root { --color-theme-500: var(--blue-500); }` (default chain; legacy name: `--color-primary-500`)
 - [`src/themes/seasonal/themes.css`](../../src/themes/seasonal/themes.css) — `:root[data-theme="season--spring-early"] { --color-theme-500: oklch(...); }` (override; today shipping as `:root[data-season="spring-early"] { --color-primary-500: oklch(...); }`)
-- [`src/core/tokens/base.css`](../../src/core/tokens/base.css) — `@theme { --color-theme-500: var(--color-theme-500); }` (Tailwind v4 registers the variable so `bg-theme-500` becomes a usable utility)
+- [`src/core/tokens/base.css`](../../src/core/tokens/base.css) — `@theme { --color-theme-500: var(--color-theme-500); }`. The self-referential look is intentional: the right-hand `var(--color-theme-500)` reads the value defined in `semantic.css`; the left-hand declaration tells Tailwind v4 "this variable is a theme token — generate utilities for it." Without `@theme`, the variable exists but `bg-theme-500` won't be a usable class.
 - Component — `<Button className="bg-theme-500" />` → Tailwind emits `.bg-theme-500 { background-color: var(--color-theme-500); }` → browser resolves the `var()` against the cascade at paint time.
 
 ### Why this is good for us
@@ -296,7 +292,7 @@ Three layers work together:
 - Anything baked into a primitive class name (`bg-red-500` directly written into JSX) — the primitive is frozen and ignores `data-theme`. This is exactly why the [state-token-guideline](state-token-guideline.md) bans primitive class names in components.
 - Anything resolved at build time (e.g. inline style strings computed from a JS theme object). The CSS variable approach is what makes runtime switching free; routing the value through JS would re-introduce hydration and re-render costs.
 
-## Existing seasonal themes — current vs. new model
+## Seasonal palettes — `data-theme` mapping
 
 The eight seasonal palettes in [`src/themes/seasonal/themes.css`](../../src/themes/seasonal/themes.css)
 already follow the Special-axis pattern in practice: each overrides only
@@ -367,12 +363,50 @@ already prepares for:
 - **Sandboxing**: a consumer Special must not be able to override
   Mode-owned tokens or `info-*`. The allowlist + lint enforces this
   mechanically.
-- **Naming**: external Specials use a vendor prefix in the `data-theme`
-  value following the `<vendor>--<variant>` convention (e.g.
-  `data-theme="acme--summer"`) so two consumers can't collide on the
-  same attribute value.
+- **Naming**: external Specials use a vendor name as the family prefix —
+  `<vendor>--<variant>` — so two consumers can't collide on the same
+  attribute value. Example: `data-theme="acme--summer"` (vendor "acme",
+  their "summer" variant). The `brand--*` family is reserved for
+  first-party brand palettes that ship with Schatten; third parties
+  must use their own vendor namespace.
 
 The public API and packaging story are out of scope for this rule.
+
+## v0.7.0 migration plan
+
+This rule prescribes canonical names (`data-theme`, `--color-theme-*`,
+`bg-theme-*`) and a value convention (`<family>--<variant>`) that are not
+yet reflected in shipping code. Four related changes close the gap in
+**v0.7.0**:
+
+| # | Change | Files affected |
+|---|---|---|
+| 1 | `data-season` → `data-theme` with value transform `X` → `season--X` | `themes/seasonal/themes.css`, `themes/seasonal/index.ts`, `docs/Color.stories.tsx` |
+| 2 | `--color-primary-*` → `--color-theme-*` (and `bg-primary-*` → `bg-theme-*` in components) | `core/tokens/semantic.css`, `core/tokens/base.css`, `themes/default/colors.css`, `themes/seasonal/themes.css`, every component referencing `*-primary-*` |
+| 3 | Allowlist enforcement — build-time lint that fails when a Special writes a token outside its `allowedTokens` | new lint rule + per-Special manifest files |
+| 4 | 16-pattern Storybook audit story (8 Specials × 2 Modes) | new `Foundation/ThemeAudit` story |
+
+Renames #1 and #2 can ship in isolation (they're mechanical sed-style
+replacements with VRT snapshot regeneration); #3 and #4 depend on #1 and
+#2 having landed first.
+
+### Authoring rule until v0.7.0
+
+The canonical names in this rule describe the **target state**. The
+shipping code still uses the legacy names. **Until #1 and #2 land,
+write the legacy names in code** — that's what the build emits as
+Tailwind utilities today:
+
+| Write today | After v0.7.0 |
+|---|---|
+| `data-season="spring-early"` | `data-theme="season--spring-early"` |
+| `--color-primary-500` | `--color-theme-500` |
+| `bg-primary-500`, `text-primary-600`, … | `bg-theme-500`, `text-theme-600`, … |
+
+The v0.7.0 PR will mechanically rename them. Do **not** introduce *new
+patterns* the legacy names accidentally enable — e.g. don't add a `primary`
+reference that you'd want to keep meaning "fixed brand primary, ignore
+themes" after the rename; that's exactly the conflation the new name fixes.
 
 ## Quick reference
 

--- a/.claude/rules/theme-architecture.md
+++ b/.claude/rules/theme-architecture.md
@@ -7,13 +7,16 @@ runtime:
 
 - **Mode** — exclusive (`light` / `dark`). Owns the base layer: surfaces,
   foregrounds, borders.
-- **Special** — cumulative (`seasonal-*`, `event-*`, `custom-*`). Owns the
-  expressive layer: `primary`, `accent`, and other "characteristic" tokens.
+- **Special** — exclusive (`seasonal-*`, brand themes, customer palettes,
+  …). Owns the expressive layer: `primary`, `accent`, and other
+  "characteristic" tokens.
 
-The two axes meet at the **semantic token layer** (`src/core/tokens/semantic.css`).
-Components keep referencing the same semantic names (`bg-primary`,
-`text-foreground`, …) regardless of which Mode + Special combination is
-active — they don't need to know.
+Both axes are exclusive: exactly one Mode is active (`light` xor `dark`),
+and at most one Special is active (`data-theme="<name>"` set on `<html>`,
+or no Special at all). The two axes meet at the **semantic token layer**
+(`src/core/tokens/semantic.css`). Components keep referencing the same
+semantic names (`bg-primary`, `text-foreground`, …) regardless of which
+Mode + Special combination is active — they don't need to know.
 
 This rule documents the model itself, the cascade, the allowlist convention,
 and how the DOM is annotated. It is the **architectural counterpart** to
@@ -27,16 +30,21 @@ fits into one of these two axes and overrides only the tokens it owns".
 
 ```
 Axis 1  Mode     (exclusive)   light  |  dark
-Axis 2  Special  (cumulative)  seasonal-*  +  event-*  +  custom-*
+Axis 2  Special  (exclusive)   <none>  |  seasonal-*  |  brand-*  |  custom-*
                                each Special declares an allowlist of tokens
                                it may override
 ```
 
-**Exclusive** means exactly one Mode is active at a time (`light` xor `dark`).
-**Cumulative** means zero or more Specials can stack — a seasonal palette
-plus a co-branded event accent, for example. The cascade resolves conflicts
-deterministically (see below), but in practice well-behaved Specials don't
-fight because their allowlists don't overlap.
+A Special name lives in a **single flat namespace**. Subcategories
+(`seasonal-spring-early`, `brand-acme`, …) are just naming conventions
+inside that namespace — they don't get separate DOM attributes, separate
+cascade tiers, or separate allowlist semantics. Keeping Special exclusive
+and single-attribute is a deliberate scope choice: the previous design
+considered cumulative Specials with per-category attributes, but the
+combinatorial cost (cascade tie-breaking, allowlist intersection rules,
+multiple DOM attributes to keep in sync) was not worth it for any
+foreseeable use case. Reach for [external Specials](#external-special-themes-future)
+before reaching for "two Specials at once".
 
 ### Mode owns the base layer
 
@@ -74,17 +82,17 @@ A few tokens are pinned by intent and **must not** be moved by either axis:
 
 ## Cascade
 
-Two mechanisms decide which declaration wins: **CSS specificity** and
-**source order** (later wins on a tie). The model leans on both:
+CSS specificity decides the cascade — load order is only a tie-breaker
+within a single tier.
 
-- `:root[data-season=...]` and `:root[data-event=...]` each combine a
-  pseudo-class with an attribute selector → specificity `(0,2,0)`.
+- `:root[data-theme="<name>"]` combines a pseudo-class with an attribute
+  selector → specificity `(0,2,0)`.
 - `:root` alone → `(0,1,0)`. `.dark` (or any single class) → `(0,1,0)`.
-- Therefore **any single-attribute Special selector beats both `:root`
-  and `.dark`** on specificity alone. Specials win over Mode by the
-  cascade rules, not by load order luck.
-- Between Specials of different categories (e.g. `[data-season]` vs
-  `[data-event]`), specificity is identical → **source order decides**.
+- Therefore **the Special selector beats both `:root` and `.dark`** on
+  specificity. Specials override Mode through the cascade itself, not
+  through stylesheet ordering.
+- For Mode-specific Special values, see "Specials are Mode-agnostic by
+  default" below.
 
 The intended source order, from earliest (lowest priority) to latest
 (highest):
@@ -93,37 +101,25 @@ The intended source order, from earliest (lowest priority) to latest
 1.  primitives.css                       — raw OKLCH scales
 2.  semantic.css :root                   — base semantic tokens (light)
 3.  semantic.css .dark / @media dark     — Mode override
-4.  themes/default/colors.css            — Special: default (Mode-neutral primary)
-5.  themes/seasonal/themes.css           — Special: seasonal (data-season)
-6.  themes/event/...                     — Special: event (data-event)         [v0.7.0+]
-7.  themes/custom/...                    — Special: custom (data-theme)        [v0.7.0+]
+4.  themes/default/colors.css            — default primary (no data-theme)
+5.  themes/seasonal/themes.css           — Special palettes (data-theme)
 ```
 
 Effective precedence at runtime:
 
 ```
-Special (specificity beats Mode; ties broken by load order)
-  >  Mode (.dark beats :root by load order)
-  >  base semantic
+Special  >  Mode (.dark beats :root by load order)  >  base semantic
 ```
 
-**Why flat specificity between Specials, not stacked selectors?** Stacking
-Specials with progressively more specific selectors
-(`[data-season][data-event]`, …) would couple the cascade to combinatorial
-selector engineering. Keeping every Special's selector at the same
-specificity tier and relying on **load order + allowlist** is simpler,
-cheaper to debug, and survives a thousand Specials without selector
-explosion.
-
-**Specials are Mode-agnostic by default.** A `:root[data-season=...]` rule
+**Specials are Mode-agnostic by default.** A `:root[data-theme=...]` rule
 applies the same values in light *and* dark — the existing seasonal
 palettes are designed to be Mode-neutral hues that sit atop whatever
-surface/foreground Mode is currently active. If a future Special needs
-*different* shades in dark mode, it must declare both selectors:
+surface/foreground Mode is currently active. If a Special needs *different*
+shades in dark mode, it must declare both selectors:
 
 ```css
-:root[data-season="winter-deep"]  { --color-primary-500: oklch(...); }
-.dark[data-season="winter-deep"]  { --color-primary-500: oklch(...); }
+:root[data-theme="winter-deep"]  { --color-primary-500: oklch(...); }
+.dark[data-theme="winter-deep"]  { --color-primary-500: oklch(...); }
 ```
 
 The latter has specificity `(0,3,0)` and beats both `.dark` alone and the
@@ -132,20 +128,17 @@ without disturbing the light-mode case.
 
 ## Allowlist mechanism (design — implementation in v0.7.0)
 
-A Special theme declares *which tokens it is allowed to override*. Tokens
-outside the allowlist are owned by Mode (or by another Special). The
-allowlist is a contract — it makes the partition between axes explicit and
-testable.
+A Special declares *which tokens it is allowed to override*. Tokens
+outside the allowlist are owned by Mode. The allowlist is a contract —
+it makes the partition between axes explicit and testable.
 
 ```ts
 // Design sketch — actual API lands in v0.7.0
 export const springEarlyTheme = {
   name: 'spring-early',
-  axis: 'special',
-  category: 'seasonal',
   allowedTokens: ['--color-primary-*'],
   // Everything outside this list (foregrounds, surfaces, state colors, info)
-  // belongs to Mode or another Special.
+  // belongs to Mode.
 } as const
 ```
 
@@ -154,12 +147,9 @@ What the allowlist will enable, once implemented:
 - **Build-time lint**: scan each `themes/<special>/*.css` and fail if it
   writes a token that's not in its `allowedTokens`. Prevents accidental
   bleed from a seasonal palette into surfaces/foregrounds.
-- **Conflict detection**: when two Specials are layered, fail (or warn) if
-  their allowlists intersect. Forces a deliberate decision about who owns
-  which token rather than silent last-wins.
 - **Audit output**: surface the effective token-by-token attribution in
   Storybook (Foundation → Theme Audit), so designers can see "this colour
-  came from `seasonal:spring-early`".
+  came from `spring-early`".
 
 Until v0.7.0 ships the enforcement, **treat the allowlist as a hand-checked
 convention**: when authoring a new Special, write the tokens it touches at
@@ -173,15 +163,20 @@ Two channels, one per axis:
 |---|---|---|
 | Mode (light) | `:root` (implicit default) | nothing to set; OS-level dark mode honoured via `@media (prefers-color-scheme: dark)` |
 | Mode (dark, explicit) | `.dark` on `<html>` | by a theme switcher (e.g. Storybook globals, app-level setting) |
-| Special (seasonal) | `[data-season="<name>"]` on `<html>` | `applySeasonTheme()` in [`src/themes/seasonal/index.ts`](../../src/themes/seasonal/index.ts), or SSR via `getSeasonAttribute()` |
-| Special (event) — v0.7.0+ | `[data-event="<name>"]` on `<html>` | TBD |
-| Special (custom) — v0.7.0+ | `[data-theme="<name>"]` on `<html>` | TBD |
+| Special | `[data-theme="<name>"]` on `<html>` | `applySeasonTheme()` in [`src/themes/seasonal/index.ts`](../../src/themes/seasonal/index.ts), or SSR via `getSeasonAttribute()` |
 
-**One attribute per Special category.** Each category gets its own data
-attribute namespace (`data-season`, `data-event`, `data-theme`) rather than
-overloading a single `data-theme`. This keeps "which seasonal palette is
-active" and "which event identity is active" independently queryable and
-avoids string-parsing a composite value.
+**One attribute for Special.** A single `data-theme` namespace is used for
+every Special, regardless of whether it represents a season, a brand, or
+a customer palette. Naming conventions inside the value (`spring-early`,
+`brand-acme`, …) carry the sub-category — there is no `data-season` /
+`data-event` / `data-brand` proliferation.
+
+> **Migration note**: the existing seasonal CSS in
+> [`src/themes/seasonal/themes.css`](../../src/themes/seasonal/themes.css)
+> and the helpers in [`src/themes/seasonal/index.ts`](../../src/themes/seasonal/index.ts)
+> still use `data-season`. The rename to `data-theme` ships alongside the
+> v0.7.0 allowlist enforcement work; treat `data-theme` as the canonical
+> attribute when authoring new code.
 
 **Why `<html>` and not `<body>`.** Storybook, Tailwind v4 `dark:`, and most
 SSR frameworks already key off `<html class="...">`. Putting Mode and
@@ -195,35 +190,36 @@ already follow the Special-axis pattern in practice: each overrides only
 `--color-primary-*`. The table below restates that contract in the new
 model so future authors can replicate it.
 
-| Theme | Hue (OKLCH) | Period | Axis | Category | `allowedTokens` |
-|---|---|---|---|---|---|
-| `spring-early` | 12  | 2/4 – 3/20 | special | seasonal | `--color-primary-*` |
-| `spring-late`  | 138 | 3/21 – 5/5 | special | seasonal | `--color-primary-*` |
-| `summer-early` | 162 | 5/6 – 6/20 | special | seasonal | `--color-primary-*` |
-| `summer-peak`  | 45  | 6/21 – 8/6 | special | seasonal | `--color-primary-*` |
-| `autumn-early` | 230 | 8/7 – 9/22 | special | seasonal | `--color-primary-*` |
-| `autumn-late`  | 70  | 9/23 – 11/6 | special | seasonal | `--color-primary-*` |
-| `winter-early` | 250 | 11/7 – 12/21 | special | seasonal | `--color-primary-*` |
-| `winter-deep`  | 0/240 | 12/22 – 2/3 | special | seasonal | `--color-primary-*` |
+| Theme | Hue (OKLCH) | Period | `allowedTokens` |
+|---|---|---|---|
+| `spring-early` | 12  | 2/4 – 3/20 | `--color-primary-*` |
+| `spring-late`  | 138 | 3/21 – 5/5 | `--color-primary-*` |
+| `summer-early` | 162 | 5/6 – 6/20 | `--color-primary-*` |
+| `summer-peak`  | 45  | 6/21 – 8/6 | `--color-primary-*` |
+| `autumn-early` | 230 | 8/7 – 9/22 | `--color-primary-*` |
+| `autumn-late`  | 70  | 9/23 – 11/6 | `--color-primary-*` |
+| `winter-early` | 250 | 11/7 – 12/21 | `--color-primary-*` |
+| `winter-deep`  | 0/240 | 12/22 – 2/3 | `--color-primary-*` |
 
 No existing seasonal theme touches surfaces, foregrounds, borders, accent,
 state colors, or info. **That is the contract** — keep it that way when
-adding new seasonals.
+adding new Specials.
 
 ### Dark × Special — visual verification
 
-Each Special must remain readable under both Modes. With 8 seasonals × 2
-Modes = 16 combinations, exhaustive visual review is necessary because a
-hue that contrasts well in light mode can collapse against a dark surface
-(or vice versa). The 16-pattern Storybook audit story ships in **v0.7.0**;
-until then, sanity-check new Specials manually by toggling the Storybook
-theme global on the relevant Color / Foundation stories.
+Each Special must remain readable under both Modes. With 8 Specials × 2
+Modes = 16 combinations (today), exhaustive visual review is necessary
+because a hue that contrasts well in light mode can collapse against a
+dark surface (or vice versa). The 16-pattern Storybook audit story ships
+in **v0.7.0**; until then, sanity-check new Specials manually by toggling
+the Storybook theme global on the relevant Color / Foundation stories.
 
 ## Adding a new Special theme (today's process — pre-v0.7.0)
 
-1. **Decide the category** — seasonal, event, or custom. Each lives under
-   its own folder (`src/themes/seasonal/`, …) and uses its own data
-   attribute (`data-season`, `data-event`, `data-theme`).
+1. **Pick a name** in the flat Special namespace. Use a prefix that
+   conveys the sub-category if it helps readability (`spring-late`,
+   `brand-acme`, …) — but the prefix is just a naming convention, not
+   a separate axis.
 2. **List the tokens you intend to override** as a comment at the top of
    the CSS file. Today's seasonals override `--color-primary-50..950` only —
    match that scope unless you have a documented reason to expand.
@@ -239,26 +235,26 @@ theme global on the relevant Color / Foundation stories.
 6. **Add a changeset** — `minor` if the Special ships as a user-facing
    option, `patch` if it's internal-only.
 
-## External Special themes (Phase 5+, after 1.0)
+## External Special themes (future)
 
-Until 1.0, Specials are internal-only (`yasmro` palettes). After 1.0 we
-intend to expose a public API for consumer-authored Specials. Two
-constraints that the v0.7.0 allowlist mechanism already prepares for:
+Today, Specials are internal-only (`yasmro` palettes). A public API for
+consumer-authored Specials is a future possibility, not a current
+commitment. If it ships, two constraints the v0.7.0 allowlist mechanism
+already prepares for:
 
-- **Sandboxing**: a consumer Special should be unable to override
+- **Sandboxing**: a consumer Special must not be able to override
   Mode-owned tokens or `info-*`. The allowlist + lint enforces this
   mechanically.
-- **Identity**: each external Special declares its own data-attribute
-  namespace (likely `data-theme="<vendor>-<name>"`) so two consumers can't
-  collide on the same attribute value.
+- **Naming**: external Specials should namespace their `data-theme` value
+  (e.g. `data-theme="acme-summer"`) so two consumers can't collide on the
+  same attribute value.
 
-The public API and packaging story are out of scope for this rule and will
-be designed alongside the 1.0 release.
+The public API and packaging story are out of scope for this rule.
 
 ## Quick reference
 
 - **Mode**  → `:root` (light) / `.dark` (dark) / `@media (prefers-color-scheme: dark)` (system) — owns surfaces, foregrounds, borders, state shade-shifts.
-- **Special** → `[data-season=...]` / `[data-event=...]` / `[data-theme=...]` — owns `primary`, optionally `accent`. Cumulative; last-loaded wins.
-- **Cascade** → `Special > Mode > base semantic`.
+- **Special** → `[data-theme="<name>"]` — owns `primary`, optionally `accent`. Exclusive (one Special active at a time, or none).
+- **Cascade** → `Special > Mode > base semantic`. Specials win on specificity, not load order.
 - **Never** touch Mode-owned tokens or `info-*` from a Special.
 - **Components** keep referencing semantic tokens (`bg-primary`, `text-foreground`, …) — they don't need to know which axes are active.

--- a/.claude/rules/theme-architecture.md
+++ b/.claude/rules/theme-architecture.md
@@ -213,6 +213,64 @@ SSR frameworks already key off `<html class="...">`. Putting Mode and
 Special on the same element keeps the cascade predictable and means a
 single attribute mutation is enough to retheme the whole tree.
 
+## How `data-theme` reaches a component
+
+The mechanism is plain CSS — no React state, no context, no prop drilling.
+Three layers work together:
+
+1. **CSS custom property inheritance.** Properties declared on `:root`
+   inherit through the entire DOM tree.
+2. **`var()` resolves at use-time, not parse-time.** Mutating `data-theme`
+   re-resolves every `var()` reference further down the tree on the next
+   paint — no JavaScript work is involved.
+3. **Tailwind v4 `@theme` registration.** Component classes
+   (`bg-primary-500`, `text-primary-600`, …) compile to
+   `background-color: var(--color-primary-500)`, so they participate in
+   the same cascade.
+
+### Worked trace: `data-theme="season--spring-early"` → pink button
+
+```
+┌─ <html data-theme="season--spring-early">  ◀── 1. attribute set
+│
+│   :root[data-theme="season--spring-early"]
+│   { --color-primary-500: oklch(0.64 0.10 12); }     ◀── 2. seasonal override
+│                                                          (Specificity (0,2,0)
+│                                                           beats :root default)
+│   :root { --color-primary-500: var(--blue-500); }   ◀── 3. default, lost in cascade
+│
+└─ inherits ↓
+    └─ <body>
+        └─ <Button class="bg-primary-500">
+              │
+              ▼
+            .bg-primary-500 { background-color: var(--color-primary-500); }
+                                                     ◀── 4. var() resolved here at render
+              │
+              ▼
+            background-color: oklch(0.64 0.10 12)    ◀── pink (spring-early)
+```
+
+### Concretely, in this repo
+
+- [`src/core/tokens/primitives.css`](../../src/core/tokens/primitives.css) — `:root { --blue-500: oklch(...); }` (frozen primitives)
+- [`src/core/tokens/semantic.css`](../../src/core/tokens/semantic.css) — `:root { --color-primary-500: var(--blue-500); }` (default chain)
+- [`src/themes/seasonal/themes.css`](../../src/themes/seasonal/themes.css) — `:root[data-season="spring-early"] { --color-primary-500: oklch(...); }` (override; will become `data-theme="season--spring-early"` in v0.7.0)
+- [`src/core/tokens/base.css`](../../src/core/tokens/base.css) — `@theme { --color-primary-500: var(--color-primary-500); }` (Tailwind v4 registers the variable so `bg-primary-500` becomes a usable utility)
+- Component — `<Button className="bg-primary-500" />` → Tailwind emits `.bg-primary-500 { background-color: var(--color-primary-500); }` → browser resolves the `var()` against the cascade at paint time.
+
+### Why this is good for us
+
+- **Components stay theme-unaware.** No `useTheme()` hook, no `<ThemeProvider>` wrapping. Components reference semantic utility classes and the cascade does the rest.
+- **SSR is free.** Server emits `<html data-theme="season--spring-early">` from `getSeasonAttribute()`; the same CSS resolves on the server-rendered DOM with no hydration mismatch.
+- **Switching is instant and JS-free.** Toggling `data-theme` is one attribute write. The browser's next paint already reflects the new theme — no React re-render, no virtual DOM diff.
+- **Specificity is enough — load order doesn't matter** (for the Mode-vs-Special precedence). See [Cascade](#cascade).
+
+### Things that do NOT propagate this way
+
+- Anything baked into a primitive class name (`bg-red-500` directly written into JSX) — the primitive is frozen and ignores `data-theme`. This is exactly why the [state-token-guideline](state-token-guideline.md) bans primitive class names in components.
+- Anything resolved at build time (e.g. inline style strings computed from a JS theme object). The CSS variable approach is what makes runtime switching free; routing the value through JS would re-introduce hydration and re-render costs.
+
 ## Existing seasonal themes — current vs. new model
 
 The eight seasonal palettes in [`src/themes/seasonal/themes.css`](../../src/themes/seasonal/themes.css)

--- a/.claude/rules/theme-architecture.md
+++ b/.claude/rules/theme-architecture.md
@@ -8,14 +8,14 @@ runtime:
 - **Mode** — exclusive (`light` / `dark`). Owns the base layer: surfaces,
   foregrounds, borders.
 - **Special** — exclusive (`seasonal-*`, brand themes, customer palettes,
-  …). Owns the expressive layer: `primary`, `accent`, and other
+  …). Owns the expressive layer: the `theme` scale, `accent`, and other
   "characteristic" tokens.
 
 Both axes are exclusive: exactly one Mode is active (`light` xor `dark`),
 and at most one Special is active (`data-theme="<name>"` set on `<html>`,
 or no Special at all). The two axes meet at the **semantic token layer**
 (`src/core/tokens/semantic.css`). Components keep referencing the same
-semantic names (`bg-primary`, `text-foreground`, …) regardless of which
+semantic names (`bg-theme-500`, `text-foreground`, …) regardless of which
 Mode + Special combination is active — they don't need to know.
 
 This rule documents the model itself, the cascade, the allowlist convention,
@@ -64,18 +64,34 @@ belongs to Mode.
 
 | Concern | Example tokens |
 |---|---|
-| Primary scale | `--color-primary-50` … `--color-primary-950` |
+| Theme scale | `--color-theme-50` … `--color-theme-950` |
 | Accent (when a Special wants to retune it) | `--color-accent`, `--color-accent-foreground` |
 
 Rule of thumb: anything that expresses *brand character* — seasonality, an
 event identity, a customer's palette — belongs to Special.
 
+> **Deprecation: `--color-primary-*` → `--color-theme-*`**.
+> The CSS variable currently shipping in
+> [`src/core/tokens/semantic.css`](../../src/core/tokens/semantic.css) is
+> `--color-primary-50..950` (with matching Tailwind utilities
+> `bg-primary-500`, `text-primary-600`, …). This name predates the
+> two-axis model and conflates "the brand's primary color" with "the
+> slot the active theme drives." The canonical name is **`--color-theme-*`**,
+> matching the `data-theme` attribute that controls it. Equivalent
+> Tailwind utilities are `bg-theme-500`, `text-theme-600`, ….
+> The actual rename — across semantic.css, themes/seasonal/themes.css,
+> themes/default/colors.css, base.css, and any component that references
+> `*-primary-*` — ships in **v0.7.0** alongside the allowlist enforcement
+> and the `data-season` → `data-theme` migration. Use `--color-theme-*` /
+> `bg-theme-*` for any new code; do not introduce new `*-primary-*`
+> references.
+
 ### Tokens neither axis touches
 
 A few tokens are pinned by intent and **must not** be moved by either axis:
 
-- `--color-info-*` references `blue-*` directly. Themes that retune
-  `primary` must not drift `info`'s meaning. See
+- `--color-info-*` references `blue-*` directly. Themes that retune the
+  theme scale must not drift `info`'s meaning. See
   [state-token-guideline](state-token-guideline.md#info-independence-from-primary).
 - Primitives (`--vermillion-*`, `--green-*`, `--blue-*`, …) are theme-agnostic
   by definition and live one layer below semantics.
@@ -101,7 +117,7 @@ The intended source order, from earliest (lowest priority) to latest
 1.  primitives.css                       — raw OKLCH scales
 2.  semantic.css :root                   — base semantic tokens (light)
 3.  semantic.css .dark / @media dark     — Mode override
-4.  themes/default/colors.css            — default primary (no data-theme)
+4.  themes/default/colors.css            — default theme scale (no data-theme)
 5.  themes/seasonal/themes.css           — Special palettes (data-theme)
 ```
 
@@ -118,8 +134,8 @@ surface/foreground Mode is currently active. If a Special needs *different*
 shades in dark mode, it must declare both selectors:
 
 ```css
-:root[data-theme="season--winter-deep"]  { --color-primary-500: oklch(...); }
-.dark[data-theme="season--winter-deep"]  { --color-primary-500: oklch(...); }
+:root[data-theme="season--winter-deep"]  { --color-theme-500: oklch(...); }
+.dark[data-theme="season--winter-deep"]  { --color-theme-500: oklch(...); }
 ```
 
 The latter has specificity `(0,3,0)` and beats both `.dark` alone and the
@@ -136,7 +152,7 @@ it makes the partition between axes explicit and testable.
 // Design sketch — actual API lands in v0.7.0
 export const springEarlySeasonTheme = {
   name: 'season--spring-early', // matches the data-theme value
-  allowedTokens: ['--color-primary-*'],
+  allowedTokens: ['--color-theme-*'],
   // Everything outside this list (foregrounds, surfaces, state colors, info)
   // belongs to Mode.
 } as const
@@ -224,9 +240,15 @@ Three layers work together:
    re-resolves every `var()` reference further down the tree on the next
    paint — no JavaScript work is involved.
 3. **Tailwind v4 `@theme` registration.** Component classes
-   (`bg-primary-500`, `text-primary-600`, …) compile to
-   `background-color: var(--color-primary-500)`, so they participate in
+   (`bg-theme-500`, `text-theme-600`, …) compile to
+   `background-color: var(--color-theme-500)`, so they participate in
    the same cascade.
+
+> The example code below uses the **canonical** `--color-theme-*` /
+> `bg-theme-*` names. The shipping code still uses the legacy
+> `--color-primary-*` / `bg-primary-*`; the rename ships in v0.7.0 (see
+> the deprecation note above). Mentally substitute the legacy name when
+> reading current source.
 
 ### Worked trace: `data-theme="season--spring-early"` → pink button
 
@@ -234,17 +256,17 @@ Three layers work together:
 ┌─ <html data-theme="season--spring-early">  ◀── 1. attribute set
 │
 │   :root[data-theme="season--spring-early"]
-│   { --color-primary-500: oklch(0.64 0.10 12); }     ◀── 2. seasonal override
+│   { --color-theme-500: oklch(0.64 0.10 12); }       ◀── 2. seasonal override
 │                                                          (Specificity (0,2,0)
 │                                                           beats :root default)
-│   :root { --color-primary-500: var(--blue-500); }   ◀── 3. default, lost in cascade
+│   :root { --color-theme-500: var(--blue-500); }     ◀── 3. default, lost in cascade
 │
 └─ inherits ↓
     └─ <body>
-        └─ <Button class="bg-primary-500">
+        └─ <Button class="bg-theme-500">
               │
               ▼
-            .bg-primary-500 { background-color: var(--color-primary-500); }
+            .bg-theme-500 { background-color: var(--color-theme-500); }
                                                      ◀── 4. var() resolved here at render
               │
               ▼
@@ -254,10 +276,10 @@ Three layers work together:
 ### Concretely, in this repo
 
 - [`src/core/tokens/primitives.css`](../../src/core/tokens/primitives.css) — `:root { --blue-500: oklch(...); }` (frozen primitives)
-- [`src/core/tokens/semantic.css`](../../src/core/tokens/semantic.css) — `:root { --color-primary-500: var(--blue-500); }` (default chain)
-- [`src/themes/seasonal/themes.css`](../../src/themes/seasonal/themes.css) — `:root[data-season="spring-early"] { --color-primary-500: oklch(...); }` (override; will become `data-theme="season--spring-early"` in v0.7.0)
-- [`src/core/tokens/base.css`](../../src/core/tokens/base.css) — `@theme { --color-primary-500: var(--color-primary-500); }` (Tailwind v4 registers the variable so `bg-primary-500` becomes a usable utility)
-- Component — `<Button className="bg-primary-500" />` → Tailwind emits `.bg-primary-500 { background-color: var(--color-primary-500); }` → browser resolves the `var()` against the cascade at paint time.
+- [`src/core/tokens/semantic.css`](../../src/core/tokens/semantic.css) — `:root { --color-theme-500: var(--blue-500); }` (default chain; legacy name: `--color-primary-500`)
+- [`src/themes/seasonal/themes.css`](../../src/themes/seasonal/themes.css) — `:root[data-theme="season--spring-early"] { --color-theme-500: oklch(...); }` (override; today shipping as `:root[data-season="spring-early"] { --color-primary-500: oklch(...); }`)
+- [`src/core/tokens/base.css`](../../src/core/tokens/base.css) — `@theme { --color-theme-500: var(--color-theme-500); }` (Tailwind v4 registers the variable so `bg-theme-500` becomes a usable utility)
+- Component — `<Button className="bg-theme-500" />` → Tailwind emits `.bg-theme-500 { background-color: var(--color-theme-500); }` → browser resolves the `var()` against the cascade at paint time.
 
 ### Why this is good for us
 
@@ -275,19 +297,24 @@ Three layers work together:
 
 The eight seasonal palettes in [`src/themes/seasonal/themes.css`](../../src/themes/seasonal/themes.css)
 already follow the Special-axis pattern in practice: each overrides only
-`--color-primary-*`. The table below restates that contract in the new
+the theme scale (`--color-primary-*` today; renamed to `--color-theme-*`
+in v0.7.0). The table below restates that contract in the new
 model so future authors can replicate it.
 
 | `data-theme` value (canonical) | Legacy `data-season` (deprecated) | Hue | Period | `allowedTokens` |
 |---|---|---|---|---|
-| `season--spring-early` | `spring-early` | 12  | 2/4 – 3/20  | `--color-primary-*` |
-| `season--spring-late`  | `spring-late`  | 138 | 3/21 – 5/5  | `--color-primary-*` |
-| `season--summer-early` | `summer-early` | 162 | 5/6 – 6/20  | `--color-primary-*` |
-| `season--summer-peak`  | `summer-peak`  | 45  | 6/21 – 8/6  | `--color-primary-*` |
-| `season--autumn-early` | `autumn-early` | 230 | 8/7 – 9/22  | `--color-primary-*` |
-| `season--autumn-late`  | `autumn-late`  | 70  | 9/23 – 11/6 | `--color-primary-*` |
-| `season--winter-early` | `winter-early` | 250 | 11/7 – 12/21 | `--color-primary-*` |
-| `season--winter-deep`  | `winter-deep`  | 0/240 | 12/22 – 2/3 | `--color-primary-*` |
+| `season--spring-early` | `spring-early` | 12  | 2/4 – 3/20  | `--color-theme-*` |
+| `season--spring-late`  | `spring-late`  | 138 | 3/21 – 5/5  | `--color-theme-*` |
+| `season--summer-early` | `summer-early` | 162 | 5/6 – 6/20  | `--color-theme-*` |
+| `season--summer-peak`  | `summer-peak`  | 45  | 6/21 – 8/6  | `--color-theme-*` |
+| `season--autumn-early` | `autumn-early` | 230 | 8/7 – 9/22  | `--color-theme-*` |
+| `season--autumn-late`  | `autumn-late`  | 70  | 9/23 – 11/6 | `--color-theme-*` |
+| `season--winter-early` | `winter-early` | 250 | 11/7 – 12/21 | `--color-theme-*` |
+| `season--winter-deep`  | `winter-deep`  | 0/240 | 12/22 – 2/3 | `--color-theme-*` |
+
+(In the shipping code today the `allowedTokens` is `--color-primary-*`;
+both names refer to the same slot — see the deprecation note in
+[Special owns the expressive layer](#special-owns-the-expressive-layer).)
 
 No existing seasonal theme touches surfaces, foregrounds, borders, accent,
 state colors, or info. **That is the contract** — keep it that way when
@@ -311,15 +338,17 @@ the Storybook theme global on the relevant Color / Foundation stories.
    is just a naming convention — it groups Specials visually and in
    the Theme Audit story but does not create a separate axis.
 2. **List the tokens you intend to override** as a comment at the top of
-   the CSS file. Today's seasonals override `--color-primary-50..950` only —
-   match that scope unless you have a documented reason to expand.
+   the CSS file. Today's seasonals override the theme scale only
+   (`--color-primary-50..950` in current code; `--color-theme-50..950`
+   after the v0.7.0 rename) — match that scope unless you have a
+   documented reason to expand.
 3. **Never override Mode-owned tokens** — surfaces, foregrounds, borders,
    inverted foregrounds, focus ring, state colors. A Special that needs to
    change foreground or surface is mis-categorised: it's a Mode, not a
    Special.
 4. **Never override `info-*`** — it's pinned to blue across all themes.
 5. **Verify both Modes visually** — open the Color / Foundation stories,
-   toggle dark mode, check that text on `primary` surfaces still meets
+   toggle dark mode, check that text on `theme`-colored surfaces still meets
    contrast. The "Filled Treatments (a11y audit)" section in
    `Foundation/Color` is the right place to spot-check.
 6. **Add a changeset** — `minor` if the Special ships as a user-facing
@@ -345,7 +374,7 @@ The public API and packaging story are out of scope for this rule.
 ## Quick reference
 
 - **Mode**  → `:root` (light) / `.dark` (dark) / `@media (prefers-color-scheme: dark)` (system) — owns surfaces, foregrounds, borders, state shade-shifts.
-- **Special** → `[data-theme="<name>"]` — owns `primary`, optionally `accent`. Exclusive (one Special active at a time, or none).
+- **Special** → `[data-theme="<name>"]` — owns the theme scale (`--color-theme-*`), optionally `accent`. Exclusive (one Special active at a time, or none).
 - **Cascade** → `Special > Mode > base semantic`. Specials win on specificity, not load order.
 - **Never** touch Mode-owned tokens or `info-*` from a Special.
-- **Components** keep referencing semantic tokens (`bg-primary`, `text-foreground`, …) — they don't need to know which axes are active.
+- **Components** keep referencing semantic tokens (`bg-theme-500`, `text-foreground`, …) — they don't need to know which axes are active.

--- a/.claude/rules/theme-architecture.md
+++ b/.claude/rules/theme-architecture.md
@@ -5,8 +5,8 @@
 Schatten's theming is modelled as **two independent axes** that compose at
 runtime:
 
-- **Mode** — exclusive (`light` / `dark`, with `high-contrast` reserved for
-  Phase 5). Owns the base layer: surfaces, foregrounds, borders.
+- **Mode** — exclusive (`light` / `dark`). Owns the base layer: surfaces,
+  foregrounds, borders.
 - **Special** — cumulative (`seasonal-*`, `event-*`, `custom-*`). Owns the
   expressive layer: `primary`, `accent`, and other "characteristic" tokens.
 
@@ -26,7 +26,7 @@ fits into one of these two axes and overrides only the tokens it owns".
 ## Two-axis model
 
 ```
-Axis 1  Mode     (exclusive)   light  |  dark   [|  high-contrast — Phase 5]
+Axis 1  Mode     (exclusive)   light  |  dark
 Axis 2  Special  (cumulative)  seasonal-*  +  event-*  +  custom-*
                                each Special declares an allowlist of tokens
                                it may override
@@ -228,9 +228,9 @@ theme global on the relevant Color / Foundation stories.
    the CSS file. Today's seasonals override `--color-primary-50..950` only —
    match that scope unless you have a documented reason to expand.
 3. **Never override Mode-owned tokens** — surfaces, foregrounds, borders,
-   inverted foregrounds, focus ring, state colors. If a Special needs the
-   foreground to change, that's a sign it should be authored as a Mode
-   instead (or a future high-contrast Mode).
+   inverted foregrounds, focus ring, state colors. A Special that needs to
+   change foreground or surface is mis-categorised: it's a Mode, not a
+   Special.
 4. **Never override `info-*`** — it's pinned to blue across all themes.
 5. **Verify both Modes visually** — open the Color / Foundation stories,
    toggle dark mode, check that text on `primary` surfaces still meets
@@ -238,19 +238,6 @@ theme global on the relevant Color / Foundation stories.
    `Foundation/Color` is the right place to spot-check.
 6. **Add a changeset** — `minor` if the Special ships as a user-facing
    option, `patch` if it's internal-only.
-
-## Adding a new Mode (rare — Phase 5)
-
-`high-contrast` is the most likely next Mode, primarily for accessibility.
-Color-vision modes (deuteranopia/protanopia simulation) are likely Special
-rather than Mode because they retune saturation/hue rather than the
-light/dark base. The decision is deferred to Phase 5 — when the time comes,
-revisit this rule and choose based on:
-
-- **Mode** if the change is exclusive with `light` / `dark` (a user picks
-  exactly one base mode).
-- **Special** if the change layers on top of an existing Mode (an
-  accessibility preference that augments either light or dark).
 
 ## External Special themes (Phase 5+, after 1.0)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,6 +36,7 @@ Before adding or modifying components, read the guideline files under [`.claude/
 
 - [`storybook-guideline.md`](.claude/rules/storybook-guideline.md) — Story structure (`Playground` story first, group by prop), `argTypes`, English-only labels.
 - [`state-token-guideline.md`](.claude/rules/state-token-guideline.md) — 3-layer token system, state semantic tokens (`error` / `success` / `warning` / `info` / `destructive`) and the 4-token shape (`base` / `hover` / `foreground` / `subtle`).
+- [`theme-architecture.md`](.claude/rules/theme-architecture.md) — Mode × Special two-axis theme model, cascade (`Special > Mode > base semantic`), token allowlist, DOM application (`.dark` / `[data-season=...]`).
 - [`field-context-guideline.md`](.claude/rules/field-context-guideline.md) — `FieldContext` integration patterns for form components (Input / Checkbox / Switch / Radio / Select / Textarea).
 - [`vrt-spec-guideline.md`](.claude/rules/vrt-spec-guideline.md) — Playwright VRT spec template, story-id mapping, snapshot naming.
 - [`lint-rules-guideline.md`](.claude/rules/lint-rules-guideline.md) — Biome rules added on top of `recommended` (`useExhaustiveDependencies`, `noUnusedImports/Variables`, `useImportType/ExportType`, `noNonNullAssertion`, `noConsole`) and the rationale for each.
@@ -72,6 +73,7 @@ pnpm changeset         # Create a changeset for user-facing changes
 | [README.md](README.md) | Public-facing overview, installation, and usage. |
 | [.claude/rules/storybook-guideline.md](.claude/rules/storybook-guideline.md) | Storybook conventions — Playground story, `argTypes`, grouping. |
 | [.claude/rules/state-token-guideline.md](.claude/rules/state-token-guideline.md) | 3-layer token system, 4-token shape, `destructive` vs `error`. |
+| [.claude/rules/theme-architecture.md](.claude/rules/theme-architecture.md) | Mode × Special two-axis theme model, cascade rule, token allowlist. |
 | [.claude/rules/field-context-guideline.md](.claude/rules/field-context-guideline.md) | `FieldContext` patterns for form components. |
 | [.claude/rules/vrt-spec-guideline.md](.claude/rules/vrt-spec-guideline.md) | Playwright VRT spec template and snapshot naming. |
 | [.claude/rules/lint-rules-guideline.md](.claude/rules/lint-rules-guideline.md) | Biome rules added on top of `recommended` and the rationale for each. |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,7 +36,7 @@ Before adding or modifying components, read the guideline files under [`.claude/
 
 - [`storybook-guideline.md`](.claude/rules/storybook-guideline.md) — Story structure (`Playground` story first, group by prop), `argTypes`, English-only labels.
 - [`state-token-guideline.md`](.claude/rules/state-token-guideline.md) — 3-layer token system, state semantic tokens (`error` / `success` / `warning` / `info` / `destructive`) and the 4-token shape (`base` / `hover` / `foreground` / `subtle`).
-- [`theme-architecture.md`](.claude/rules/theme-architecture.md) — Mode × Special two-axis theme model, cascade (`Special > Mode > base semantic`), token allowlist, DOM application (`.dark` / `[data-season=...]`).
+- [`theme-architecture.md`](.claude/rules/theme-architecture.md) — Mode × Special two-axis theme model, cascade (`Special > Mode > base semantic`), token allowlist, DOM application (`.dark` / `[data-theme=...]`).
 - [`field-context-guideline.md`](.claude/rules/field-context-guideline.md) — `FieldContext` integration patterns for form components (Input / Checkbox / Switch / Radio / Select / Textarea).
 - [`vrt-spec-guideline.md`](.claude/rules/vrt-spec-guideline.md) — Playwright VRT spec template, story-id mapping, snapshot naming.
 - [`lint-rules-guideline.md`](.claude/rules/lint-rules-guideline.md) — Biome rules added on top of `recommended` (`useExhaustiveDependencies`, `noUnusedImports/Variables`, `useImportType/ExportType`, `noNonNullAssertion`, `noConsole`) and the rationale for each.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,5 +31,6 @@ When adding or modifying components, follow shadcn/ui conventions (Radix UI + CV
 - See [.claude/rules/storybook-guideline.md](.claude/rules/storybook-guideline.md) for Storybook conventions
 - See [.claude/rules/field-context-guideline.md](.claude/rules/field-context-guideline.md) for Field context integration patterns
 - See [.claude/rules/state-token-guideline.md](.claude/rules/state-token-guideline.md) for state semantic tokens (error / success / warning / info / destructive) and the 4-token shape
+- See [.claude/rules/theme-architecture.md](.claude/rules/theme-architecture.md) for the Mode × Special two-axis theme model, cascade, and token allowlist
 - See [.claude/rules/vrt-spec-guideline.md](.claude/rules/vrt-spec-guideline.md) for VRT spec conventions
 - See [.claude/rules/lint-rules-guideline.md](.claude/rules/lint-rules-guideline.md) for the Biome rules added on top of `recommended` and the rationale for each


### PR DESCRIPTION
## Summary

Adds [`.claude/rules/theme-architecture.md`](.claude/rules/theme-architecture.md) documenting the two-axis theme model that Schatten's existing seasonal themes already follow implicitly. This is a **docs/rule-only** change — no public API or component behaviour changes.

Closes [#104](https://github.com/yasmro/schatten/issues/104).

### The model

- **Mode** (exclusive — `light` / `dark`, with `high-contrast` reserved for Phase 5) owns the **base layer**: surfaces, foregrounds, borders, state shade-shifts.
- **Special** (cumulative — `seasonal-*`, `event-*`, `custom-*`) owns the **expressive layer**: `primary`, optionally `accent`.
- **Cascade**: `Special > Mode > base semantic`. Conflicts are resolved by **load order**, not selector specificity — keeps the cascade flat and free of combinatorial selector explosion as more Specials land.
- **Allowlist** (design only — enforcement lint lands in v0.7.0): each Special declares which tokens it may override, making axis-ownership explicit and testable.
- **DOM application**: `.dark` for explicit Mode; one data attribute per Special category (`data-season` / `data-event` / `data-theme`) so each axis is independently queryable.

### Existing seasonal themes — current vs. new model

The eight palettes in [`src/themes/seasonal/themes.css`](src/themes/seasonal/themes.css) already touch only `--color-primary-*`. That becomes their declared `allowedTokens` in the new model. The rule includes a mapping table covering all 8 themes (`spring-early` through `winter-deep`).

### DoD checklist (from #104)

- [x] `.claude/rules/theme-architecture.md` created
- [x] Two-axis model / cascade rule / allowlist mechanism / DOM application documented
- [x] Existing seasonal themes mapped to new model in a table
- [x] Relationship to [`state-token-guideline.md`](.claude/rules/state-token-guideline.md) stated at the top of the rule
- [x] Linked from [CLAUDE.md](CLAUDE.md) (Guidelines) and [AGENTS.md](AGENTS.md) (Required reading + Resource Map) per the repo's index-sync convention

### Scope deferred to v0.7.0 (per issue body)

- Allowlist enforcement (build-time lint, conflict detection, audit story)
- 8 seasonal × 2 mode = 16-pattern visual verification story
- Public `springEarlyTheme` config object (the TS sketch in the rule is a design preview, not shipped code)

## Test plan

- [x] `pnpm lint` — passes (`Checked 142 files`, no fixes applied)
- [x] `pnpm typecheck` — passes via lefthook pre-commit hook
- [x] Visual check that both `CLAUDE.md` and `AGENTS.md` link to the new rule
- [ ] Reviewer: confirm the table of existing seasonal themes matches `src/themes/seasonal/themes.css` and `src/themes/seasonal/index.ts`
- [ ] Reviewer: sanity-check the cascade section against the actual import order in `src/core/tokens/base.css` + how downstream apps concatenate themes

## Changeset

Included a `patch` changeset since the precedent ([biome-rules-strengthened](https://github.com/yasmro/schatten/commit/025e98e)) added a changeset for a rule-doc addition. If reviewers prefer `no-changeset` for pure docs, the changeset file can be deleted and the label applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)