### PR TITLE
docs(rule): add .claude/rules/spacing-conventions.md (closes #102)

### DIFF
--- a/.claude/rules/spacing-conventions.md
+++ b/.claude/rules/spacing-conventions.md
@@ -18,8 +18,8 @@ The rule applies differently depending on **who is writing the class**:
 
 | Surface | Examples | Half-scale (`*-1.5`, `*-2.5`, …) | Off-scale (`*-5`, `*-7`, `*-9`, `*-11`) | Arbitrary (`*-[10px]`) |
 |---|---|---|---|---|
-| **Consumer** — app code using Schatten | `<div className="flex gap-3 p-4">…</div>` in a downstream app | ❌ | ❌ | ❌ |
-| **Implementer** — Schatten library code | [`src/variants/*.ts`](../../src/variants), `src/components/lv1/**/*.tsx` JSX | ✅ allowed for visual fine-tuning, VRT-verified | ❌ (avoid; migrate when possible) | ❌ |
+| **Consumer** — app code using Schatten | `<div className="flex gap-3 p-4">…</div>` in a downstream app | No | No | No |
+| **Implementer** — Schatten library code | [`src/variants/*.ts`](../../src/variants), `src/components/lv1/**/*.tsx` JSX | OK for visual fine-tuning, VRT-verified | No (avoid; migrate when possible) | No |
 
 The consumer-facing scale below is the bar Schatten asks downstream apps to
 hold. Library internals get an ergonomic escape hatch (half-scale) because

--- a/.claude/rules/spacing-conventions.md
+++ b/.claude/rules/spacing-conventions.md
@@ -16,7 +16,7 @@ stays disciplined. It complements the [state token guideline](state-token-guidel
 
 The rule applies differently depending on **who is writing the class**:
 
-| Surface | Examples | Half-scale (`*-1.5`, `*-2.5`, …) | Off-scale (`*-5`, `*-7`, `*-9`, `*-11`) | Arbitrary (`*-[10px]`) |
+| Surface | Examples | Half-scale (`*-1.5`, `*-2.5`, …) | Off-scale (per utility — see below) | Arbitrary (`*-[10px]`) |
 |---|---|---|---|---|
 | **Consumer** — app code using Schatten | `<div className="flex gap-3 p-4">…</div>` in a downstream app | No | No | No |
 | **Implementer** — Schatten library code | [`src/variants/*.ts`](../../src/variants), `src/components/lv1/**/*.tsx` JSX | OK for visual fine-tuning, VRT-verified | No (avoid; migrate when possible) | No |
@@ -27,41 +27,75 @@ some details — vertical text centering inside a button, the gap between a
 small icon and an `xs`-sized label — genuinely don't snap to the integer
 scale at typical font sizes.
 
+Note: the three spacing utilities (`gap`, `p`, `m`) have **different
+scales** because they answer different layout questions. See each section.
+
 ## Consumer-facing scale
 
-### Inner — `gap-*`, `p-*` (within a component / card / section)
+### `gap-*` — between siblings in flex / grid
 
 | Class | px | Typical use |
 |---|---|---|
-| `*-1` | 4px | tight icon adjacency, badge interior |
-| `*-2` | 8px | inline form controls, tight grid |
-| `*-3` | 12px | default inline spacing, form rows |
-| `*-4` | 16px | default block spacing inside a card |
-| `*-6` | 24px | section interior padding |
-| `*-8` | 32px | generous card padding |
+| `gap-1` | 4px | tight icon adjacency, badge interior |
+| `gap-2` | 8px | inline form controls, tight grid |
+| `gap-3` | 12px | default inline spacing, form rows |
+| `gap-4` | 16px | default block spacing inside a card |
+| `gap-6` | 24px | section interior spacing |
+| `gap-8` | 32px | generous separation between groups |
 
-### Outer — `m-*` (between components / between sections)
+`gap-5` / `gap-7` / `gap-9` / `gap-11` are intentionally excluded. The
+between-sibling rhythm doesn't tune to anything physical the way padding
+tunes to control height — reaching for `gap-5` almost always means the
+visual hierarchy needs adjustment (heading size, group, divider) rather
+than a one-step bump.
+
+### `p-*` — interior padding
 
 | Class | px | Typical use |
 |---|---|---|
-| `*-4` | 16px | sibling block spacing |
-| `*-6` | 24px | sibling section spacing |
-| `*-8` | 32px | major block separators |
-| `*-12` | 48px | top-level section gaps |
-| `*-16` | 64px | hero / page-level gaps |
+| `p-1` | 4px | tight badge interior |
+| `p-2` | 8px | `h-6` controls, tag-style buttons |
+| `p-3` | 12px | `h-8` controls (Input/Button `sm`) |
+| `p-4` | 16px | default block padding inside a card |
+| `p-5` | 20px | `h-10` controls (Input/Button `md`) |
+| `p-6` | 24px | section interior padding |
+| `p-7` | 28px | `h-12` controls (Input/Button `lg`) |
+| `p-8` | 32px | generous card padding |
 
-`5` is intentionally excluded — `4` or `6` is almost always the right choice;
-reaching for `5` is a smell that the scale is being eyeballed rather than
-followed.
+Padding includes `5` and `7` because **interior padding tunes to control
+height**: the shadcn-derived `h-8 px-3 / h-10 px-5 / h-12 px-7` rhythm is a
+load-bearing aesthetic choice, not a scale leak. Values above `8` are not
+part of the consumer scale — sections that need more should compose
+multiple containers rather than reach for `p-12`.
+
+### `m-*` — between blocks / between sections
+
+| Class | px | Typical use |
+|---|---|---|
+| `m-2` | 8px | tight pairing of closely related items |
+| `m-4` | 16px | sibling block spacing |
+| `m-6` | 24px | sibling section spacing |
+| `m-8` | 32px | major block separators |
+| `m-12` | 48px | top-level section gaps |
+| `m-16` | 64px | hero / page-level gaps |
+
+`m-3` / `m-5` / `m-7` / `m-9` / `m-10` / `m-11` are excluded — the steps
+between blocks are coarse hierarchy decisions, and intermediate values
+don't add expressive resolution.
 
 ## NG patterns (consumer-facing)
 
-- **`gap-1.5`, `gap-2.5`, `gap-3.5`, `py-1.5`, …** — half-scale values.
+- **`gap-1.5`, `gap-2.5`, `py-1.5`, `mt-2.5`, …** — half-scale anywhere.
   Reserved for library internals (see below). Consumers should snap to the
   integer scale.
-- **`gap-5`, `gap-7`, `gap-9`, `gap-11`** — off-scale even though they're
-  integers. They almost always indicate "I wanted `gap-4` but it looked
-  slightly tight." Move the visual hierarchy with type or grouping instead.
+- **`gap-5`, `gap-7`, `gap-9`, `gap-11`** — off-scale for `gap` even though
+  they're integers (see `gap-*` section for the rationale). Move the visual
+  hierarchy with type or grouping instead.
+- **`p-9`, `p-10`, `p-11`, `p-12+`** — beyond the padding scale. Compose
+  containers if you need more inner room; a single block doesn't.
+- **`m-3`, `m-5`, `m-7`, `m-9`, `m-10`, `m-11`** — between integer
+  margin steps. The block-hierarchy decisions don't gain resolution from
+  these.
 - **`gap-[10px]`, `p-[14px]`, arbitrary values** — bypass the scale entirely.
   No exceptions for consumer code. If the design genuinely needs a value
   outside the scale, that's a token discussion, not a one-off override.
@@ -90,12 +124,12 @@ Constraints when you use a half-scale:
 3. **Add a one-line comment** next to the value if the intent is non-obvious
    (e.g. why `py-2.5` rather than `py-2`).
 
-Off-scale integers (`px-5`, `gap-7`, …) and arbitrary values (`p-[14px]`) are
-**not** part of the implementer exception. A handful exist in
-[`src/variants/`](../../src/variants) today (notably `px-5` carried over from
-shadcn defaults) and are tracked for migration in
+Off-scale integers (e.g. `gap-7`, `m-5`) and arbitrary values (`p-[14px]`)
+are **not** part of the implementer exception either. Note that `px-5` and
+`px-7` are **on-scale for padding** (see the `p-*` section) — these are
+not violations. The remaining audit items are tracked in
 [issue #186](https://github.com/yasmro/schatten/issues/186). Don't add new
-ones.
+off-scale values.
 
 ## Why no `Stack` / `HStack` / `VStack`
 
@@ -118,7 +152,8 @@ in Phase 5. The evaluation report § 1.3 tracks this signal.
 
 ## Future enforcement
 
-- **Biome custom rule (v0.8.0)** — mechanical enforcement of `gap-(5|7|9|11)`,
+- **Biome custom rule (v0.8.0)** — mechanical enforcement of off-scale
+  patterns per utility: `gap-(5|7|9|11)`, `p-(9|10|11)`, `m-(3|5|7|9|10|11)`,
   half-scales in JSX (excluding CVA strings), and arbitrary-value patterns.
   Tracked alongside the primitive-color custom rule mentioned in
   [lint-rules-guideline](lint-rules-guideline.md).

--- a/.claude/rules/spacing-conventions.md
+++ b/.claude/rules/spacing-conventions.md
@@ -1,0 +1,137 @@
+# Spacing Conventions Guideline
+
+## Overview
+
+Schatten **does not ship Layout primitives** (`Stack` / `HStack` / `VStack` /
+`Cluster`). Composition is done with Tailwind utilities directly. The trade-off
+is that without a primitive policing the spacing scale, any author — human or
+AI — can sprinkle `gap-3`, `gap-5`, `gap-7`, `gap-[10px]` etc. across an app
+and erode visual rhythm.
+
+This rule defines the **canonical spacing scale** so utility-direct authoring
+stays disciplined. It complements the [state token guideline](state-token-guideline.md)
+(which polices color) by doing the same for spacing.
+
+## Audience: consumer vs implementer
+
+The rule applies differently depending on **who is writing the class**:
+
+| Surface | Examples | Half-scale (`*-1.5`, `*-2.5`, …) | Off-scale (`*-5`, `*-7`, `*-9`, `*-11`) | Arbitrary (`*-[10px]`) |
+|---|---|---|---|---|
+| **Consumer** — app code using Schatten | `<div className="flex gap-3 p-4">…</div>` in a downstream app | ❌ | ❌ | ❌ |
+| **Implementer** — Schatten library code | [`src/variants/*.ts`](../../src/variants), `src/components/lv1/**/*.tsx` JSX | ✅ allowed for visual fine-tuning, VRT-verified | ❌ (avoid; migrate when possible) | ❌ |
+
+The consumer-facing scale below is the bar Schatten asks downstream apps to
+hold. Library internals get an ergonomic escape hatch (half-scale) because
+some details — vertical text centering inside a button, the gap between a
+small icon and an `xs`-sized label — genuinely don't snap to the integer
+scale at typical font sizes.
+
+## Consumer-facing scale
+
+### Inner — `gap-*`, `p-*` (within a component / card / section)
+
+| Class | px | Typical use |
+|---|---|---|
+| `*-1` | 4px | tight icon adjacency, badge interior |
+| `*-2` | 8px | inline form controls, tight grid |
+| `*-3` | 12px | default inline spacing, form rows |
+| `*-4` | 16px | default block spacing inside a card |
+| `*-6` | 24px | section interior padding |
+| `*-8` | 32px | generous card padding |
+
+### Outer — `m-*` (between components / between sections)
+
+| Class | px | Typical use |
+|---|---|---|
+| `*-4` | 16px | sibling block spacing |
+| `*-6` | 24px | sibling section spacing |
+| `*-8` | 32px | major block separators |
+| `*-12` | 48px | top-level section gaps |
+| `*-16` | 64px | hero / page-level gaps |
+
+`5` is intentionally excluded — `4` or `6` is almost always the right choice;
+reaching for `5` is a smell that the scale is being eyeballed rather than
+followed.
+
+## NG patterns (consumer-facing)
+
+- **`gap-1.5`, `gap-2.5`, `gap-3.5`, `py-1.5`, …** — half-scale values.
+  Reserved for library internals (see below). Consumers should snap to the
+  integer scale.
+- **`gap-5`, `gap-7`, `gap-9`, `gap-11`** — off-scale even though they're
+  integers. They almost always indicate "I wanted `gap-4` but it looked
+  slightly tight." Move the visual hierarchy with type or grouping instead.
+- **`gap-[10px]`, `p-[14px]`, arbitrary values** — bypass the scale entirely.
+  No exceptions for consumer code. If the design genuinely needs a value
+  outside the scale, that's a token discussion, not a one-off override.
+
+## Implementer exceptions
+
+Inside the Schatten library — CVA variant strings in [`src/variants/`](../../src/variants)
+and JSX in [`src/components/lv1/`](../../src/components/lv1) — **half-scale
+spacing is allowed** for visual fine-tuning. Concretely:
+
+- The gap between an icon and a label inside a sized button or input
+  (`gap-1.5`, `gap-2.5`) — the integer scale is visibly off at small font
+  sizes.
+- Vertical padding tuned to a fixed-height control (`py-1.5` inside an
+  `h-8` Badge, `py-2.5` inside an `h-12` Input).
+- Optical micro-shifts (`-mt-1.5` to lift a description into a label's
+  baseline).
+
+Constraints when you use a half-scale:
+
+1. **It must live inside the library**, not be a className prop a consumer is
+   expected to compose with.
+2. **VRT must cover it.** If you change a half-scale value, the affected
+   component's VRT snapshot will move — that's the safety net. See
+   [vrt-spec-guideline](vrt-spec-guideline.md).
+3. **Add a one-line comment** next to the value if the intent is non-obvious
+   (e.g. why `py-2.5` rather than `py-2`).
+
+Off-scale integers (`px-5`, `gap-7`, …) and arbitrary values (`p-[14px]`) are
+**not** part of the implementer exception. A handful exist in
+[`src/variants/`](../../src/variants) today (notably `px-5` carried over from
+shadcn defaults) and are tracked for migration in
+[issue #186](https://github.com/yasmro/schatten/issues/186). Don't add new
+ones.
+
+## Why no `Stack` / `HStack` / `VStack`
+
+The trade-off was deliberate:
+
+- **AI affinity.** Tailwind utilities have orders of magnitude more training
+  data than any custom primitive. Tools like Copilot, Cursor, Claude Code,
+  and v0 produce correct utility-class layouts on the first attempt; a
+  bespoke `<Stack gap={3}>` primitive forces a "remember this library exists"
+  step they often skip.
+- **DX.** One fewer component to import, one fewer API to memorize. Layout
+  composes from the same utilities that already style everything else.
+- **Cost.** Without a primitive enforcing the scale, scale escape is a real
+  risk — this rule plus the Biome custom rule planned for v0.8.0 is the
+  mitigation.
+
+If, in practice, this rule fails to hold the line (audits keep finding
+violations, AI-generated code keeps regressing) we revisit Layout primitives
+in Phase 5. The evaluation report § 1.3 tracks this signal.
+
+## Future enforcement
+
+- **Biome custom rule (v0.8.0)** — mechanical enforcement of `gap-(5|7|9|11)`,
+  half-scales in JSX (excluding CVA strings), and arbitrary-value patterns.
+  Tracked alongside the primitive-color custom rule mentioned in
+  [lint-rules-guideline](lint-rules-guideline.md).
+- **`Patterns / Layout` Storybook story (v0.10.0)** — a recipe page showing
+  the canonical compositions (form row, card, page header, two-column layout)
+  using only this scale, so authors have something concrete to copy.
+
+## Adding to this rule
+
+1. **Don't add a new "everyone gets to use this" value without evidence.**
+   If you find yourself wanting `gap-5`, look for whether a hierarchy
+   adjustment (heading size, group, divider) is the right answer instead.
+2. **Don't expand the implementer exception silently.** If a component needs
+   an off-scale integer or an arbitrary value, raise it — that's a token
+   conversation, not a local choice.
+3. **Always update VRT** when changing half-scale values inside the library.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,6 +36,7 @@ Before adding or modifying components, read the guideline files under [`.claude/
 
 - [`storybook-guideline.md`](.claude/rules/storybook-guideline.md) — Story structure (`Playground` story first, group by prop), `argTypes`, English-only labels.
 - [`state-token-guideline.md`](.claude/rules/state-token-guideline.md) — 3-layer token system, state semantic tokens (`error` / `success` / `warning` / `info` / `destructive`) and the 4-token shape (`base` / `hover` / `foreground` / `subtle`).
+- [`spacing-conventions.md`](.claude/rules/spacing-conventions.md) — Canonical `gap` / `padding` / `margin` scale, half-scale exception for library internals, no Stack/HStack rationale.
 - [`field-context-guideline.md`](.claude/rules/field-context-guideline.md) — `FieldContext` integration patterns for form components (Input / Checkbox / Switch / Radio / Select / Textarea).
 - [`vrt-spec-guideline.md`](.claude/rules/vrt-spec-guideline.md) — Playwright VRT spec template, story-id mapping, snapshot naming.
 - [`lint-rules-guideline.md`](.claude/rules/lint-rules-guideline.md) — Biome rules added on top of `recommended` (`useExhaustiveDependencies`, `noUnusedImports/Variables`, `useImportType/ExportType`, `noNonNullAssertion`, `noConsole`) and the rationale for each.
@@ -72,6 +73,7 @@ pnpm changeset         # Create a changeset for user-facing changes
 | [README.md](README.md) | Public-facing overview, installation, and usage. |
 | [.claude/rules/storybook-guideline.md](.claude/rules/storybook-guideline.md) | Storybook conventions — Playground story, `argTypes`, grouping. |
 | [.claude/rules/state-token-guideline.md](.claude/rules/state-token-guideline.md) | 3-layer token system, 4-token shape, `destructive` vs `error`. |
+| [.claude/rules/spacing-conventions.md](.claude/rules/spacing-conventions.md) | Canonical spacing scale, half-scale exception for library internals. |
 | [.claude/rules/field-context-guideline.md](.claude/rules/field-context-guideline.md) | `FieldContext` patterns for form components. |
 | [.claude/rules/vrt-spec-guideline.md](.claude/rules/vrt-spec-guideline.md) | Playwright VRT spec template and snapshot naming. |
 | [.claude/rules/lint-rules-guideline.md](.claude/rules/lint-rules-guideline.md) | Biome rules added on top of `recommended` and the rationale for each. |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,5 +31,6 @@ When adding or modifying components, follow shadcn/ui conventions (Radix UI + CV
 - See [.claude/rules/storybook-guideline.md](.claude/rules/storybook-guideline.md) for Storybook conventions
 - See [.claude/rules/field-context-guideline.md](.claude/rules/field-context-guideline.md) for Field context integration patterns
 - See [.claude/rules/state-token-guideline.md](.claude/rules/state-token-guideline.md) for state semantic tokens (error / success / warning / info / destructive) and the 4-token shape
+- See [.claude/rules/spacing-conventions.md](.claude/rules/spacing-conventions.md) for the canonical `gap` / `padding` / `margin` scale, half-scale rules, and the consumer-vs-implementer distinction
 - See [.claude/rules/vrt-spec-guideline.md](.claude/rules/vrt-spec-guideline.md) for VRT spec conventions
 - See [.claude/rules/lint-rules-guideline.md](.claude/rules/lint-rules-guideline.md) for the Biome rules added on top of `recommended` and the rationale for each


### PR DESCRIPTION
## Summary

Adds [`.claude/rules/spacing-conventions.md`](.claude/rules/spacing-conventions.md), the spacing-side counterpart to [`state-token-guideline.md`](.claude/rules/state-token-guideline.md). Closes #102.

Schatten **does not ship Layout primitives** (`Stack` / `HStack` / `VStack` / `Cluster`) — composition is done with Tailwind utilities directly. The trade-off is that without a primitive policing the scale, an AI (or a human) can sprinkle `gap-3`, `gap-5`, `gap-7`, `gap-[10px]` across an app and erode visual rhythm. This rule defines the canonical scale so utility-direct authoring stays disciplined.

- Canonical inner scale (`gap`, `p-*`): `1` / `2` / `3` / `4` / `6` / `8` — intentionally no `5`
- Canonical outer scale (`m-*`): `4` / `6` / `8` / `12` / `16`
- **Half-scale** (`gap-1.5`, `py-2.5`, …) reserved for library internals — the visual fine-tuning that doesn't snap to the integer scale at small font sizes; consumers should not reach for these
- **Off-scale integers** (`gap-5/7/9/11`) and **arbitrary values** (`p-[14px]`) are forbidden everywhere
- Documents the **consumer vs. implementer** distinction explicitly so the half-scale escape hatch stays scoped to the library, not leaked into app code

Wired into both index files:
- [CLAUDE.md](CLAUDE.md) — `Guidelines` section
- [AGENTS.md](AGENTS.md) — `Required reading` + `Resource Map`

## Follow-up

Audit + migration of existing off-scale violations (notably `px-5` in CVA carried over from shadcn defaults, and `px-5` / `gap-5` in `src/docs/*.stories.tsx`) is tracked in #186 — scheduled for v0.8.0 alongside the Biome custom rule that will enforce this mechanically.

## Test plan

- [x] `pnpm lint` — passes
- [x] `pnpm typecheck` — passes
- [x] CLAUDE.md / AGENTS.md cross-links open the new rule file
- [x] `no-changeset` label applied — docs-only, no consumer-visible code change (follows the precedent set by #173 / AGENTS.md introduction)

🤖 Generated with [Claude Code](https://claude.com/claude-code)