### PR TITLE
docs(rule): add component-api-conventions.md (closes #100)

### DIFF
--- a/.claude/rules/component-api-conventions.md
+++ b/.claude/rules/component-api-conventions.md
@@ -7,219 +7,274 @@ This document is the **source of truth** for the public prop API shape of every
 values per component, so that:
 
 - AI coding assistants do not invent variants that don't exist
-  (`<Button variant="success">` is not a thing, even though `success` is a
-  valid `variant` for other components).
+  (`<Button variant="success">` is not a thing; `<Badge variant="primary">` is
+  not a thing either — each component subscribes to one of two patterns
+  described below).
 - Components stay predictable: once a developer learns the vocabulary in one
-  component, the same vocabulary applies everywhere else.
+  component, the same vocabulary applies to every component in its pattern.
 - Breaking changes are intentional and one-shot, not slow drift.
 
-The implementation work that brings every component into compliance with this
-document is tracked in [#108](https://github.com/yasmro/schatten/issues/108)
-(v0.7.0). Until that lands, some components (notably `Button`,
-`Badge`, `Callout`, `Toast`) still use the legacy vocabulary
-(`primary | secondary | tertiary`, `solid | subtle | outline`). New components
-**must** use the conventions in this document; legacy components will be
-migrated under #108.
+The implementation work that brings every component into compliance is tracked
+in [#108](https://github.com/yasmro/schatten/issues/108) (v0.7.0). The scope
+of that work is mostly the **state-component rename** (`treatment` →
+`appearance`, `default` → `neutral` / `accent`); `Button` requires no
+significant change.
 
-## The two-axis variant model
+## Two patterns
 
-Visual style is decomposed into **two orthogonal axes**:
+The Schatten variant system has **two distinct patterns**, and every
+component picks exactly one. Mixing them in a single component is forbidden.
 
-| Axis | Prop | Answers the question | Examples |
+| Pattern | Used by | Shape | Rationale |
 |---|---|---|---|
-| **Color tone** | `variant` | "What does this *mean*?" | `accent`, `error`, `success`, `destructive` |
-| **Shape / treatment** | `appearance` | "How *strong* is the visual weight?" | `filled`, `outlined`, `soft`, `ghost`, `link` |
+| **A. Role-based (single-axis)** | Action components — `Button`. | `variant` only. Each value names a complete role (color × shape baked together). | Action components have a small, well-known set of UX roles ("primary", "destructive", "link"). Decomposing them into color × shape produces nonsense combinations (`destructive + link`?) and worsens ergonomics for the common case. shadcn/ui — the project base — also keeps Button single-axis. |
+| **B. Tone × Shape (two-axis)** | State / notification components — `Badge`, `Callout`, `Toast`. | `variant` (tone) × `appearance` (shape). Each axis is meaningful in isolation. | Components that signal *state* genuinely need both axes: an "error filled Toast" and an "error soft Callout" both exist, with the same meaning but different visual weight. Naming each pair (e.g. `error-filled`, `error-soft`) would explode the vocabulary. |
 
-Keeping these separate means a single semantic (e.g. "error") can appear as a
-filled solid Toast, a soft Callout, or an outlined Badge without inventing
-three different variant names.
+**How to choose a pattern when designing a new component.** Ask:
+"Do I want a user to dial color independently of visual weight?"
 
-### `variant` vocabulary (global)
+- **No** — the component has a few UX roles each with their own look. → Pattern A.
+- **Yes** — the same color can appear at multiple weights, and the same weight at multiple colors. → Pattern B.
+
+Form components (`Input`, `Textarea`, `Select`, `Checkbox`, `Radio`, `Switch`)
+sit outside both patterns: they have no `variant` at all (always neutral),
+and error state is communicated via the `isError` boolean. `Text` is also
+out-of-pattern — it re-uses `variant` for typography role (`body | label |
+heading`), the **only** approved deviation from these conventions.
+
+## Pattern A — Role-based (single-axis)
+
+For action components, `variant` is a single enum where each value names a
+**role** — i.e. a (color × shape) preset that a UX role-name like "primary"
+or "destructive" already implies.
+
+### Button vocabulary
+
+| `variant` | Role | Visual |
+|---|---|---|
+| `primary` *(default)* | Main CTA. | Brand-accent filled. |
+| `secondary` | Secondary action. | Neutral outlined. |
+| `tertiary` | Low-priority action. | Neutral ghost (no border, transparent bg). |
+| `destructive` | Destructive intent (delete, remove). | `destructive-*` filled. |
+| `inverted` | Ghost button intended for placement on a saturated surface (e.g. solid `Toast`, banner). | Transparent bg + inverted foreground; hover tints with `current/10`. |
+| `link` | Inline text-link styling. | Underline, no padding. |
+
+Rationale notes:
+- **`destructive` stays distinct from `error`.** Even though both ultimately
+  reference vermillion, `destructive` is an *action's intent*, `error` is
+  a *state*. Keeping them as separate names lets us retune them
+  independently. See [state-token-guideline](state-token-guideline.md#destructive-vs-error).
+- **No `success` / `warning` / `info` variants on Button.** Buttons are
+  actions, not state surfaces. State communication belongs on Badge,
+  Callout, Toast.
+- **No `appearance` prop.** Pattern A doesn't expose `appearance`. If you
+  want an outlined-accent button, that's a UX decision that belongs in
+  the role vocabulary — propose a new role (`primary-outline`?) via
+  issue, don't sneak in a second axis.
+
+### When to add a new role
+
+If a real, recurring UX use case doesn't fit the table above, add a new
+role entry rather than reaching for a `appearance` workaround. The roster
+should stay small (target ≤ 8 roles) — if it bloats, that's a sign the
+component should split into two.
+
+## Pattern B — Tone × Shape (two-axis)
+
+For state / notification components, two orthogonal props:
+
+- `variant` → **tone** (what does this mean?)
+- `appearance` → **shape / weight** (how strongly is it presented?)
+
+### Tone vocabulary (`variant`)
 
 | Value | Meaning | Token family |
 |---|---|---|
-| `neutral` | Default, no semantic meaning. The "this is just a button" baseline. | `foreground` / `border-strong` / `surface-hover` |
-| `accent` | Brand accent — used for the main CTA, highlighted Badge, etc. | `solid` (the brand-accent role token) |
+| `neutral` *(default)* | No semantic meaning. The "this is just a chip / banner / toast" baseline. | `foreground` / `border-strong` / `surface-hover` |
+| `accent` | Brand accent — highlighted, "look here" without state semantics. | `solid` (brand-accent role token) |
 | `success` | Positive state (completed, saved). | `success-*` |
 | `error` | Error state (form invalid, request failed). | `error-*` |
-| `warning` | Caution state (about to do something risky). | `warning-*` |
+| `warning` | Caution state. | `warning-*` |
 | `info` | Informational state. | `info-*` |
-| `destructive` | Destructive **intent** of an action (delete, remove). | `destructive-*` |
 
-`destructive` and `error` share the same primitive (vermillion) but are
-**semantically distinct** — `destructive` is an action's *intent*, `error` is
-a *state*. See [state-token-guideline](state-token-guideline.md#destructive-vs-error)
-for the why. We keep them as two separate `variant` values so that if we ever
-retune error red ≠ destructive red, only the semantic mapping needs to change.
+Tone vocabulary does **not** include `destructive` — Pattern B components
+are not actions, so destructive intent doesn't apply.
 
-### `appearance` vocabulary (global)
+### Shape vocabulary (`appearance`)
 
 | Value | Description |
 |---|---|
 | `filled` | Saturated background fill + `*-foreground` text. High visual weight. |
-| `outlined` | Transparent background + border in the variant color. Medium weight. |
-| `soft` | Subtle tinted background (`*-subtle`) + variant-colored text. Low weight. |
-| `ghost` | No border, transparent background. Hover reveals a tinted surface. Lowest weight before `link`. |
-| `link` | Inline text-link styling (underline, no padding). Only for `Button`. |
+| `outlined` | Transparent background + colored border. Medium weight. |
+| `soft` *(default for state surfaces)* | Subtle tinted background (`*-subtle`) + tone-colored text. Low weight. |
 
-Implementation note: the names map to existing tokens — `filled` uses the
-4-token shape's `base` + `foreground`, `soft` uses `subtle` + `base`,
-`outlined` uses `base` for border and text. New components should never
-hard-code primitive colors; consume the semantic tokens via these
-treatments. See [state-token-guideline](state-token-guideline.md).
+Names map to existing tokens via the 4-token shape — `filled` uses `base +
+foreground`, `soft` uses `subtle + base`, `outlined` uses `base` for border
+and text. Never hard-code primitive colors; consume semantic tokens. See
+[state-token-guideline](state-token-guideline.md).
 
-### Per-component matrix
+Pattern B intentionally **does not** include `ghost` or `link` in the
+`appearance` vocabulary — those belong to Pattern A (action) and don't make
+sense for chips/banners.
 
-Not every component supports every `variant` × `appearance` combination. The
-table below is the **complete authoritative matrix**.
+## Per-component matrix
 
-| Component | Supported `variant` | Supported `appearance` | Notes |
-|---|---|---|---|
-| `Button` | `neutral` · `accent` · `destructive` | `filled` · `outlined` · `ghost` · `link` | No state variants (`success`/`error`/...) — buttons are actions, not state. |
-| `Badge` | `neutral` · `accent` · `success` · `error` · `warning` · `info` | `filled` · `outlined` · `soft` | No `ghost` / `link` — Badges have a pill shape; a transparent border-less chip would render as inline text. |
-| `Callout` | `neutral` · `accent` · `success` · `error` · `warning` · `info` | `filled` · `soft` | No `outlined` — Callouts need a tinted surface to convey state. |
-| `Toast` | `neutral` · `accent` · `success` · `error` · `warning` · `info` | `filled` · `soft` | Same as `Callout`. |
-| `Spinner` | (none — single neutral color) | (none) | Inherits color from the nearest `text-*` ancestor via `currentColor`. The legacy `variant: 'inverted'` will be removed when [#108](https://github.com/yasmro/schatten/issues/108) lands — callsites that need an "on saturated surface" spinner should style the *parent* with `text-*-foreground` rather than passing a flag to the Spinner. |
-| `Input` · `Textarea` · `Select` · `Checkbox` · `Radio` · `Switch` | (none — always neutral) | (none — always implicitly outlined) | Error state via the `isError` prop, not `variant`. |
-| `Text` | n/a — Text intentionally re-uses the `variant` prop name for a **different** axis (typography role: `body` \| `label` \| `heading`) | n/a | Typography is structural, not chrome — color belongs on the separate `color` prop. This is the **only** approved deviation from the global vocabulary. |
-| `Tooltip` · `Dialog` · `Separator` · `Field` · `FieldSet` | n/a — no color variants by design | n/a | Tooltip/Dialog are surfaces; Separator/Field/FieldSet are layout. |
+The authoritative table of which pattern (and which subset of values) each
+component uses.
 
-If you find yourself wanting a combination not in this table, **don't add it
-quietly**. Either:
+| Component | Pattern | Supported `variant` | Supported `appearance` | Notes |
+|---|---|---|---|---|
+| `Button` | A | `primary` · `secondary` · `tertiary` · `destructive` · `inverted` · `link` | — | No `appearance` prop. See Pattern A vocabulary. |
+| `Badge` | B | `neutral` · `accent` · `success` · `error` · `warning` · `info` | `filled` · `outlined` · `soft` | All three shapes meaningful (chip, ring, soft fill). |
+| `Callout` | B | `neutral` · `accent` · `success` · `error` · `warning` · `info` | `filled` · `soft` | No `outlined` — Callouts need a tinted surface to convey state. |
+| `Toast` | B | `neutral` · `accent` · `success` · `error` · `warning` · `info` | `filled` · `soft` | Same shape subset as `Callout`. |
+| `Spinner` | — | (none — single neutral color) | — | Inherits color from the nearest `text-*` ancestor via `currentColor`. The legacy `variant: 'inverted'` will be removed; callers wanting an "on saturated surface" spinner should style the *parent* with `text-*-foreground`. |
+| `Input` · `Textarea` · `Select` · `Checkbox` · `Radio` · `Switch` | — | (none — always neutral) | — | Error state via the `isError` prop, not `variant`. |
+| `Text` | (exception) | re-used for typography role: `body` \| `label` \| `heading` | — | Typography is structural, not chrome — color lives on a separate `color` prop. The **only** approved re-use of the `variant` prop name with different semantics. |
+| `Tooltip` · `Dialog` · `Separator` · `Field` · `FieldSet` | — | n/a — no color variants by design | — | Tooltip/Dialog are surfaces; Separator/Field/FieldSet are layout. |
 
-1. Open an issue proposing the addition with a real use case, OR
-2. Compose existing primitives (e.g. wrap a `<Button appearance="ghost">`
-   yourself rather than inventing a new `appearance`).
+If a new component doesn't fit any pattern, **stop and discuss first** —
+either it really wants Pattern A (add to the table) or it's signaling that
+the component should be decomposed into smaller primitives.
 
-### Removed legacy variants
+## Removed legacy variants
 
-These names appeared in pre-v0.7.0 components and **will be removed** by
+These names appeared in pre-v0.7.0 components and will be removed by
 [#108](https://github.com/yasmro/schatten/issues/108). They must not be
 reintroduced.
 
-| Legacy | Replacement |
-|---|---|
-| `Button variant="primary"` | `variant="accent"` (default — usually unspecified) |
-| `Button variant="secondary"` | `variant="neutral" appearance="outlined"` |
-| `Button variant="tertiary"` | `variant="neutral" appearance="ghost"` |
-| `Button variant="destructive"` | `variant="destructive"` (kept — same name) |
-| `Button variant="link"` | `appearance="link"` (variant is irrelevant) |
-| `Button variant="inverted"` | `appearance="ghost"` on a saturated surface — colors flow from `currentColor`. The explicit `inverted` value goes away (no manual context flag). |
-| `Badge/Callout/Toast variant="default"` *(soft / outlined cases)* | `variant="neutral"` |
-| `Badge/Callout/Toast variant="default" treatment="solid"` *(filled case)* | `variant="accent" appearance="filled"` — the legacy `default + solid` was overloaded and used the brand-accent `bg-solid` token, so the migration is to `accent`, not `neutral`. Going forward `neutral + filled` is a gray-ish surface and `accent + filled` is the brand color. |
-| `Badge/Callout/Toast treatment="solid"` | `appearance="filled"` |
-| `Badge/Callout/Toast treatment="subtle"` | `appearance="soft"` |
-| `Badge treatment="outline"` | `appearance="outlined"` |
-| `treatment` (prop name) | `appearance` |
-| `Spinner variant="inverted"` | (removed) Style the parent with `text-{state}-foreground` (or any `text-*` utility) and the Spinner inherits via `currentColor`. |
+| Legacy | Replacement | Notes |
+|---|---|---|
+| `Badge/Callout/Toast variant="default"` *(soft / outlined cases)* | `variant="neutral"` | Rename only. |
+| `Badge/Callout/Toast variant="default" treatment="solid"` *(filled case)* | `variant="accent" appearance="filled"` | The legacy `default + solid` used the brand-accent `bg-solid` token, so the filled case migrates to `accent`, **not** `neutral`. Going forward `neutral + filled` is a gray-ish surface and `accent + filled` is the brand color. |
+| `Badge/Callout/Toast treatment="solid"` | `appearance="filled"` | Rename across the shape axis. |
+| `Badge/Callout/Toast treatment="subtle"` | `appearance="soft"` | |
+| `Badge treatment="outline"` | `appearance="outlined"` | |
+| `treatment` (prop name) | `appearance` | Across the board. |
+| `Spinner variant="inverted"` | (removed) | Style the parent with `text-{state}-foreground` (or any `text-*` utility); Spinner inherits via `currentColor`. |
+
+`Button`'s vocabulary (`primary` / `secondary` / `tertiary` / `destructive` /
+`inverted` / `link`) is **kept as-is**. That was the original intent of
+single-axis Pattern A: the existing role names are already correct, so
+#108's Button scope shrinks to "remove ad-hoc `appearance` mentions in
+TSDoc / stories" (none to remove today).
 
 ## Common props (across all components)
 
-These prop names and types are reserved and must not be reused with different
-semantics in any component.
+These prop names and types are reserved and must not be reused with
+different semantics in any component.
 
 | Prop | Type | Semantics | Where it applies |
 |---|---|---|---|
-| `variant` | union (see matrix) | Color tone — what this means. | Components with color variants (`Button`, `Badge`, `Callout`, `Toast`, …). |
-| `appearance` | union (see matrix) | Shape / visual weight. | Components with multiple visual treatments. |
-| `size` | `'sm' \| 'md' \| 'lg'` | Sizing. Always these three; never `xs` or `xl` on chrome components (typography uses its own scale). | Universal where applicable. Default `'md'`. |
+| `variant` | union — vocabulary depends on the component's pattern | Pattern A: role. Pattern B: tone. | Components that have a variant axis. |
+| `appearance` | union (see Pattern B shape vocabulary) | Visual weight / shape. | **Pattern B components only.** Never on Pattern A. |
+| `size` | `'sm' \| 'md' \| 'lg'` | Sizing. Always these three; never `xs` / `xl` on chrome (typography has its own scale). Default `'md'`. | Universal where applicable. |
 | `isError` | `boolean` | Form-state error indication. | Form components only — `Input`, `Textarea`, `Select`, `Checkbox`, `Radio`, `Switch`, `RadioGroup`. |
 | `isLoading` | `boolean` | Async action in flight; component disables itself and shows a spinner. | Action components — `Button`. `Dialog` exposes the same semantics nested as `actionButton.isLoading` / `subActionButton.isLoading`. |
 | `disabled` | `boolean` | HTML standard. No `is` prefix. | All interactive components. |
 | `readOnly` | `boolean` | HTML standard. No `is` prefix. | Form components that can be displayed without editing. |
 | `required` | `boolean` | HTML standard. No `is` prefix. | Form components inside a `<Field>`. |
-| `id` | `string` | HTML standard. When the component is inside `<Field>`, the field's `id` wins for label-association components (`Input` / `Textarea` / `Select`) — see [field-context-guideline](field-context-guideline.md). |
+| `id` | `string` | HTML standard. When inside `<Field>`, the field's `id` wins for label-association components (`Input` / `Textarea` / `Select`) — see [field-context-guideline](field-context-guideline.md). |
 | `asChild` | `boolean` | Delegates rendering to the child via Radix `Slot`. **Adoption criteria below.** | Only components that satisfy the criteria. |
 
 ### Boolean prop naming
 
-- **`is*` prefix** for schatten-specific state booleans: `isError`, `isLoading`.
-  These describe a component state we own, where adding/removing the prefix
-  would lose meaning (`error?: boolean` vs `isError?: boolean` — the latter
-  reads more clearly as a state flag).
-- **No prefix** for HTML-native attributes: `disabled`, `readOnly`, `required`,
-  `checked`, `open`. Matching the HTML name lets developers and AI tools rely
-  on prior knowledge.
+- **`is*` prefix** for schatten-specific state booleans: `isError`,
+  `isLoading`. These describe a component state we own, where adding the
+  prefix makes the flag read clearly as state (`error?: boolean` vs
+  `isError?: boolean`).
+- **No prefix** for HTML-native attributes: `disabled`, `readOnly`,
+  `required`, `checked`, `open`. Matching the HTML name lets developers
+  and AI tools rely on prior knowledge.
 
-If a new boolean prop is needed and doesn't map to an HTML attribute, prefer
-the `is*` form unless the unprefixed name is unambiguous and idiomatic in
-React (e.g. `multiline`, not `isMultiline`).
+If a new boolean prop is needed and doesn't map to an HTML attribute,
+prefer the `is*` form unless the unprefixed name is unambiguous and
+idiomatic in React (e.g. `multiline`, not `isMultiline`).
 
 ## `asChild` adoption criteria
 
 `asChild` (Radix `Slot`) lets a component delegate its rendering to its
-child, merging props onto the child element. It is powerful but it
-introduces an invisible API contract: every consumer needs to remember which
-props are *forwarded* and which are *consumed* by the wrapper.
+child, merging props onto the child element. It is powerful but introduces
+an invisible API contract: every consumer needs to remember which props
+are *forwarded* and which are *consumed* by the wrapper.
 
 Adopt `asChild` **only** when the component satisfies all three:
 
 1. **There is a real reason to render as a different element.** The most
-   common case is a `<Button>` that should actually be a Next.js `<Link>` or
-   an `<a>` for accessibility/SEO — the *behavior* is button-like but the
-   *element* must be an anchor. Without this need, `asChild` is just
-   ceremony.
+   common case is a `<Button>` that should actually be a Next.js `<Link>`
+   or an `<a>` for accessibility / SEO — the *behavior* is button-like
+   but the *element* must be an anchor. Without this need, `asChild` is
+   just ceremony.
 2. **The component's internal state does not break when the element
    changes.** A component that injects a `<Spinner>` overlay or renders
-   multiple children internally (icon + label + spinner) **must** disable
-   `asChild` features that don't compose — see how
+   multiple children internally (icon + label + spinner) **must**
+   disable `asChild` features that don't compose — see how
    [`Button.tsx`](../../src/components/lv1/Button/Button.tsx) ignores
    `isLoading` when `asChild` is true and emits a `console.warn` to tell
    the developer.
 3. **The component is a leaf-ish primitive.** `asChild` on structural /
    container components (a Field, a Dialog body) tends to break layout
-   assumptions. Keep it on small primitives (`Button`, `Tooltip.Trigger`,
-   `Dialog.Trigger`).
+   assumptions. Keep it on small primitives (`Button`,
+   `Tooltip.Trigger`, `Dialog.Trigger`).
 
 Components that currently expose `asChild`: `Button`, `Tooltip.Trigger`,
 `Dialog.Trigger`, `Dialog.Close`, `Select.Trigger`, `Text`.
 
 **Do not** add `asChild` to: `Input`, `Textarea`, `Checkbox`, `Radio`,
-`Switch`, `Badge`, `Callout`, `Toast` — none of them need to render as a
-non-default element, and Radix Slot composition with form-control internals
-is a footgun.
+`Switch`, `Badge`, `Callout`, `Toast` — none of them need to render as
+a non-default element, and Radix Slot composition with form-control
+internals is a footgun.
 
 ## TSDoc on Props
 
 Every public prop on the `Props` interface MUST carry a TSDoc comment
-(`/** ... */`). TSDoc is the source of truth — Storybook `argTypes.description`
-mirrors it. For full guidance see
+(`/** ... */`). TSDoc is the source of truth — Storybook
+`argTypes.description` mirrors it. For full guidance see
 [storybook-guideline](storybook-guideline.md#tsdoc-on-props-source-of-truth).
 
-For `variant` / `appearance`, list each option's purpose with a bullet list
-inside the TSDoc, and add `@default` matching the CVA `defaultVariants`
-value.
+For `variant` (both patterns) and `appearance` (Pattern B), list each
+option's purpose with a bullet list inside the TSDoc, and add `@default`
+matching the CVA `defaultVariants` value.
 
 ## Defaults
 
 | Prop | Default |
 |---|---|
-| `variant` | `'neutral'` (`Button` defaults to `'accent'` because the main CTA case is overwhelming). |
-| `appearance` | `'filled'` for action components (Button), `'soft'` for state components (Badge, Callout, Toast). |
+| `variant` (Pattern A — Button) | `'primary'`. |
+| `variant` (Pattern B — Badge/Callout/Toast) | `'neutral'`. |
+| `appearance` (Pattern B) | `'soft'` for state surfaces (Callout, Toast). `Badge` also defaults to `'soft'` (current behavior). |
 | `size` | `'md'`. |
 | `isError`, `isLoading`, `disabled`, `readOnly`, `required` | `false`. |
 
-Defaults are encoded in the CVA `defaultVariants` for the visual props, and
-in the destructuring default of the React component for the booleans. Keep
-the two in sync — when you change the CVA default, update the component's
-destructuring default in the same commit.
+Defaults are encoded in the CVA `defaultVariants` for visual props, and
+in the destructuring default of the React component for booleans. Keep
+the two in sync — when you change the CVA default, update the
+component's destructuring default in the same commit.
 
 ## When adding a new component
 
-1. **Decide where it sits in the matrix** before writing code. Pick the
-   `variant` subset and `appearance` subset that apply, and check the
-   defaults make sense for the component's most common use.
-2. **Reuse existing tokens.** Never reach for primitive scales — go through
-   semantic tokens (`bg-error`, `text-error-foreground`, …). See
+1. **Pick a pattern first.** Run the "does color move independently of
+   weight?" test from the *Two patterns* section. Document the decision
+   in the component's TSDoc header.
+2. **Look up vocabularies, don't invent.** For Pattern A: re-use existing
+   roles where possible (`primary` / `secondary` / …). For Pattern B:
+   use the canonical tone (`neutral` / `accent` / `success` / `error` /
+   `warning` / `info`) and shape (`filled` / `outlined` / `soft`)
+   vocabularies. **Subsetting is encouraged; extending requires
+   discussion.**
+3. **Reuse existing tokens.** Never reach for primitive scales — go
+   through semantic tokens (`bg-error`, `text-error-foreground`, …). See
    [state-token-guideline](state-token-guideline.md).
-3. **Reuse existing prop names.** `size` is `'sm' | 'md' | 'lg'`, not
-   `'small' | 'medium' | 'large'`. `isError`, not `error` (when boolean).
-4. **Write the Props interface with TSDoc first.** Storybook `argTypes`,
-   tests, and stories all hang off the same prop names — getting them right
-   the first time saves churn.
-5. **Add stories per the [storybook-guideline](storybook-guideline.md).**
+4. **Reuse existing common-prop names.** `size` is `'sm' | 'md' | 'lg'`,
+   not `'small' | 'medium' | 'large'`. Boolean error is `isError`, not
+   `error`.
+5. **Write the Props interface with TSDoc first.** Storybook `argTypes`,
+   tests, and stories all hang off the same prop names — getting them
+   right the first time saves churn.
+6. **Add stories per the [storybook-guideline](storybook-guideline.md).**
    Always include a `Playground` story; group the rest by prop axis
-   (`AllVariants`, `Appearances`, `Sizes`, `Disabled`, …).
-6. **If the new component genuinely needs a vocabulary not in this
-   document** (e.g. a `pulse` appearance for an animated badge), update
-   this document in the same PR. Don't introduce dialect.
+   (`AllVariants` for Pattern A; `Variants`, `Appearances`, `Combinations`
+   for Pattern B).
+7. **If the new component genuinely needs vocabulary not in this
+   document** (e.g. a `pulse` shape for an animated badge), update this
+   document in the same PR. Don't introduce dialect.

--- a/.claude/rules/component-api-conventions.md
+++ b/.claude/rules/component-api-conventions.md
@@ -1,0 +1,225 @@
+# Component API Conventions
+
+## Overview
+
+This document is the **source of truth** for the public prop API shape of every
+`lv1` / `lv2` component. It locks down naming, types, and the matrix of valid
+values per component, so that:
+
+- AI coding assistants do not invent variants that don't exist
+  (`<Button variant="success">` is not a thing, even though `success` is a
+  valid `variant` for other components).
+- Components stay predictable: once a developer learns the vocabulary in one
+  component, the same vocabulary applies everywhere else.
+- Breaking changes are intentional and one-shot, not slow drift.
+
+The implementation work that brings every component into compliance with this
+document is tracked in [#108](https://github.com/yasmro/schatten/issues/108)
+(v0.7.0). Until that lands, some components (notably `Button`,
+`Badge`, `Callout`, `Toast`) still use the legacy vocabulary
+(`primary | secondary | tertiary`, `solid | subtle | outline`). New components
+**must** use the conventions in this document; legacy components will be
+migrated under #108.
+
+## The two-axis variant model
+
+Visual style is decomposed into **two orthogonal axes**:
+
+| Axis | Prop | Answers the question | Examples |
+|---|---|---|---|
+| **Color tone** | `variant` | "What does this *mean*?" | `accent`, `error`, `success`, `destructive` |
+| **Shape / treatment** | `appearance` | "How *strong* is the visual weight?" | `filled`, `outlined`, `soft`, `ghost`, `link` |
+
+Keeping these separate means a single semantic (e.g. "error") can appear as a
+filled solid Toast, a soft Callout, or an outlined Badge without inventing
+three different variant names.
+
+### `variant` vocabulary (global)
+
+| Value | Meaning | Token family |
+|---|---|---|
+| `neutral` | Default, no semantic meaning. The "this is just a button" baseline. | `foreground` / `border-strong` / `surface-hover` |
+| `accent` | Brand accent — used for the main CTA, highlighted Badge, etc. | `solid` (the brand-accent role token) |
+| `success` | Positive state (completed, saved). | `success-*` |
+| `error` | Error state (form invalid, request failed). | `error-*` |
+| `warning` | Caution state (about to do something risky). | `warning-*` |
+| `info` | Informational state. | `info-*` |
+| `destructive` | Destructive **intent** of an action (delete, remove). | `destructive-*` |
+
+`destructive` and `error` share the same primitive (vermillion) but are
+**semantically distinct** — `destructive` is an action's *intent*, `error` is
+a *state*. See [state-token-guideline](state-token-guideline.md#destructive-vs-error)
+for the why. We keep them as two separate `variant` values so that if we ever
+retune error red ≠ destructive red, only the semantic mapping needs to change.
+
+### `appearance` vocabulary (global)
+
+| Value | Description |
+|---|---|
+| `filled` | Saturated background fill + `*-foreground` text. High visual weight. |
+| `outlined` | Transparent background + border in the variant color. Medium weight. |
+| `soft` | Subtle tinted background (`*-subtle`) + variant-colored text. Low weight. |
+| `ghost` | No border, transparent background. Hover reveals a tinted surface. Lowest weight before `link`. |
+| `link` | Inline text-link styling (underline, no padding). Only for `Button`. |
+
+Implementation note: the names map to existing tokens — `filled` uses the
+4-token shape's `base` + `foreground`, `soft` uses `subtle` + `base`,
+`outlined` uses `base` for border and text. New components should never
+hard-code primitive colors; consume the semantic tokens via these
+treatments. See [state-token-guideline](state-token-guideline.md).
+
+### Per-component matrix
+
+Not every component supports every `variant` × `appearance` combination. The
+table below is the **complete authoritative matrix**.
+
+| Component | Supported `variant` | Supported `appearance` | Notes |
+|---|---|---|---|
+| `Button` | `neutral` · `accent` · `destructive` | `filled` · `outlined` · `ghost` · `link` | No state variants (`success`/`error`/...) — buttons are actions, not state. |
+| `Badge` | `neutral` · `accent` · `success` · `error` · `warning` · `info` | `filled` · `outlined` · `soft` | No `ghost` / `link` — Badges have a pill shape; a transparent border-less chip would render as inline text. |
+| `Callout` | `neutral` · `accent` · `success` · `error` · `warning` · `info` | `filled` · `soft` | No `outlined` — Callouts need a tinted surface to convey state. |
+| `Toast` | `neutral` · `accent` · `success` · `error` · `warning` · `info` | `filled` · `soft` | Same as `Callout`. |
+| `Spinner` | (none — single neutral color) | (none) | Inherits color from the nearest `text-*` ancestor via `currentColor`. The legacy `variant: 'inverted'` will be removed when [#108](https://github.com/yasmro/schatten/issues/108) lands — callsites that need an "on saturated surface" spinner should style the *parent* with `text-*-foreground` rather than passing a flag to the Spinner. |
+| `Input` · `Textarea` · `Select` · `Checkbox` · `Radio` · `Switch` | (none — always neutral) | (none — always implicitly outlined) | Error state via the `isError` prop, not `variant`. |
+| `Text` | n/a — Text intentionally re-uses the `variant` prop name for a **different** axis (typography role: `body` \| `label` \| `heading`) | n/a | Typography is structural, not chrome — color belongs on the separate `color` prop. This is the **only** approved deviation from the global vocabulary. |
+| `Tooltip` · `Dialog` · `Separator` · `Field` · `FieldSet` | n/a — no color variants by design | n/a | Tooltip/Dialog are surfaces; Separator/Field/FieldSet are layout. |
+
+If you find yourself wanting a combination not in this table, **don't add it
+quietly**. Either:
+
+1. Open an issue proposing the addition with a real use case, OR
+2. Compose existing primitives (e.g. wrap a `<Button appearance="ghost">`
+   yourself rather than inventing a new `appearance`).
+
+### Removed legacy variants
+
+These names appeared in pre-v0.7.0 components and **will be removed** by
+[#108](https://github.com/yasmro/schatten/issues/108). They must not be
+reintroduced.
+
+| Legacy | Replacement |
+|---|---|
+| `Button variant="primary"` | `variant="accent"` (default — usually unspecified) |
+| `Button variant="secondary"` | `variant="neutral" appearance="outlined"` |
+| `Button variant="tertiary"` | `variant="neutral" appearance="ghost"` |
+| `Button variant="destructive"` | `variant="destructive"` (kept — same name) |
+| `Button variant="link"` | `appearance="link"` (variant is irrelevant) |
+| `Button variant="inverted"` | `appearance="ghost"` on a saturated surface — colors flow from `currentColor`. The explicit `inverted` value goes away (no manual context flag). |
+| `Badge/Callout/Toast variant="default"` *(soft / outlined cases)* | `variant="neutral"` |
+| `Badge/Callout/Toast variant="default" treatment="solid"` *(filled case)* | `variant="accent" appearance="filled"` — the legacy `default + solid` was overloaded and used the brand-accent `bg-solid` token, so the migration is to `accent`, not `neutral`. Going forward `neutral + filled` is a gray-ish surface and `accent + filled` is the brand color. |
+| `Badge/Callout/Toast treatment="solid"` | `appearance="filled"` |
+| `Badge/Callout/Toast treatment="subtle"` | `appearance="soft"` |
+| `Badge treatment="outline"` | `appearance="outlined"` |
+| `treatment` (prop name) | `appearance` |
+| `Spinner variant="inverted"` | (removed) Style the parent with `text-{state}-foreground` (or any `text-*` utility) and the Spinner inherits via `currentColor`. |
+
+## Common props (across all components)
+
+These prop names and types are reserved and must not be reused with different
+semantics in any component.
+
+| Prop | Type | Semantics | Where it applies |
+|---|---|---|---|
+| `variant` | union (see matrix) | Color tone — what this means. | Components with color variants (`Button`, `Badge`, `Callout`, `Toast`, …). |
+| `appearance` | union (see matrix) | Shape / visual weight. | Components with multiple visual treatments. |
+| `size` | `'sm' \| 'md' \| 'lg'` | Sizing. Always these three; never `xs` or `xl` on chrome components (typography uses its own scale). | Universal where applicable. Default `'md'`. |
+| `isError` | `boolean` | Form-state error indication. | Form components only — `Input`, `Textarea`, `Select`, `Checkbox`, `Radio`, `Switch`, `RadioGroup`. |
+| `isLoading` | `boolean` | Async action in flight; component disables itself and shows a spinner. | Action components — `Button`. `Dialog` exposes the same semantics nested as `actionButton.isLoading` / `subActionButton.isLoading`. |
+| `disabled` | `boolean` | HTML standard. No `is` prefix. | All interactive components. |
+| `readOnly` | `boolean` | HTML standard. No `is` prefix. | Form components that can be displayed without editing. |
+| `required` | `boolean` | HTML standard. No `is` prefix. | Form components inside a `<Field>`. |
+| `id` | `string` | HTML standard. When the component is inside `<Field>`, the field's `id` wins for label-association components (`Input` / `Textarea` / `Select`) — see [field-context-guideline](field-context-guideline.md). |
+| `asChild` | `boolean` | Delegates rendering to the child via Radix `Slot`. **Adoption criteria below.** | Only components that satisfy the criteria. |
+
+### Boolean prop naming
+
+- **`is*` prefix** for schatten-specific state booleans: `isError`, `isLoading`.
+  These describe a component state we own, where adding/removing the prefix
+  would lose meaning (`error?: boolean` vs `isError?: boolean` — the latter
+  reads more clearly as a state flag).
+- **No prefix** for HTML-native attributes: `disabled`, `readOnly`, `required`,
+  `checked`, `open`. Matching the HTML name lets developers and AI tools rely
+  on prior knowledge.
+
+If a new boolean prop is needed and doesn't map to an HTML attribute, prefer
+the `is*` form unless the unprefixed name is unambiguous and idiomatic in
+React (e.g. `multiline`, not `isMultiline`).
+
+## `asChild` adoption criteria
+
+`asChild` (Radix `Slot`) lets a component delegate its rendering to its
+child, merging props onto the child element. It is powerful but it
+introduces an invisible API contract: every consumer needs to remember which
+props are *forwarded* and which are *consumed* by the wrapper.
+
+Adopt `asChild` **only** when the component satisfies all three:
+
+1. **There is a real reason to render as a different element.** The most
+   common case is a `<Button>` that should actually be a Next.js `<Link>` or
+   an `<a>` for accessibility/SEO — the *behavior* is button-like but the
+   *element* must be an anchor. Without this need, `asChild` is just
+   ceremony.
+2. **The component's internal state does not break when the element
+   changes.** A component that injects a `<Spinner>` overlay or renders
+   multiple children internally (icon + label + spinner) **must** disable
+   `asChild` features that don't compose — see how
+   [`Button.tsx`](../../src/components/lv1/Button/Button.tsx) ignores
+   `isLoading` when `asChild` is true and emits a `console.warn` to tell
+   the developer.
+3. **The component is a leaf-ish primitive.** `asChild` on structural /
+   container components (a Field, a Dialog body) tends to break layout
+   assumptions. Keep it on small primitives (`Button`, `Tooltip.Trigger`,
+   `Dialog.Trigger`).
+
+Components that currently expose `asChild`: `Button`, `Tooltip.Trigger`,
+`Dialog.Trigger`, `Dialog.Close`, `Select.Trigger`, `Text`.
+
+**Do not** add `asChild` to: `Input`, `Textarea`, `Checkbox`, `Radio`,
+`Switch`, `Badge`, `Callout`, `Toast` — none of them need to render as a
+non-default element, and Radix Slot composition with form-control internals
+is a footgun.
+
+## TSDoc on Props
+
+Every public prop on the `Props` interface MUST carry a TSDoc comment
+(`/** ... */`). TSDoc is the source of truth — Storybook `argTypes.description`
+mirrors it. For full guidance see
+[storybook-guideline](storybook-guideline.md#tsdoc-on-props-source-of-truth).
+
+For `variant` / `appearance`, list each option's purpose with a bullet list
+inside the TSDoc, and add `@default` matching the CVA `defaultVariants`
+value.
+
+## Defaults
+
+| Prop | Default |
+|---|---|
+| `variant` | `'neutral'` (`Button` defaults to `'accent'` because the main CTA case is overwhelming). |
+| `appearance` | `'filled'` for action components (Button), `'soft'` for state components (Badge, Callout, Toast). |
+| `size` | `'md'`. |
+| `isError`, `isLoading`, `disabled`, `readOnly`, `required` | `false`. |
+
+Defaults are encoded in the CVA `defaultVariants` for the visual props, and
+in the destructuring default of the React component for the booleans. Keep
+the two in sync — when you change the CVA default, update the component's
+destructuring default in the same commit.
+
+## When adding a new component
+
+1. **Decide where it sits in the matrix** before writing code. Pick the
+   `variant` subset and `appearance` subset that apply, and check the
+   defaults make sense for the component's most common use.
+2. **Reuse existing tokens.** Never reach for primitive scales — go through
+   semantic tokens (`bg-error`, `text-error-foreground`, …). See
+   [state-token-guideline](state-token-guideline.md).
+3. **Reuse existing prop names.** `size` is `'sm' | 'md' | 'lg'`, not
+   `'small' | 'medium' | 'large'`. `isError`, not `error` (when boolean).
+4. **Write the Props interface with TSDoc first.** Storybook `argTypes`,
+   tests, and stories all hang off the same prop names — getting them right
+   the first time saves churn.
+5. **Add stories per the [storybook-guideline](storybook-guideline.md).**
+   Always include a `Playground` story; group the rest by prop axis
+   (`AllVariants`, `Appearances`, `Sizes`, `Disabled`, …).
+6. **If the new component genuinely needs a vocabulary not in this
+   document** (e.g. a `pulse` appearance for an animated badge), update
+   this document in the same PR. Don't introduce dialect.

--- a/.claude/rules/lint-rules-guideline.md
+++ b/.claude/rules/lint-rules-guideline.md
@@ -86,6 +86,17 @@ becomes a silent no-op). That's a feature, not noise.
 - **Custom rule banning primitive color classes (`bg-red-*`, …)** — planned
   for v0.8.0. The convention is enforced today via [state-token-guideline](state-token-guideline.md)
   and code review; a Biome custom rule will make it mechanical.
+- **Custom rule enforcing the component API contract** — planned for v0.8.0
+  alongside the primitive-color rule above. [component-api-conventions](component-api-conventions.md)
+  defines two patterns (Role-based for `Button`; Tone × Shape for
+  `Badge` / `Callout` / `Toast`) and a per-component variant matrix, but
+  today the contract is only enforced via TS unions and code review —
+  nothing stops a Pattern A component from sprouting an `appearance` prop,
+  or a matrix-violating CVA variant from slipping in. A Biome custom rule
+  would mechanize the check (e.g. reject `appearance` on `Button`'s
+  variant definition, reject CVA `variants.variant` keys outside the
+  matrix). Until then, the contract document plus reviewer attention is
+  the line of defense.
 
 ## When adding a new rule
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,7 +34,7 @@ src/
 
 Before adding or modifying components, read the guideline files under [`.claude/rules/`](.claude/rules):
 
-- [`component-api-conventions.md`](.claude/rules/component-api-conventions.md) — Public prop API shape: the two-axis `variant` (color tone) × `appearance` (shape) model, common props (`size` / `isError` / `isLoading` / `disabled` / `readOnly`), per-component variant matrix, and `asChild` adoption criteria.
+- [`component-api-conventions.md`](.claude/rules/component-api-conventions.md) — Public prop API shape: two patterns (**Role-based** for action components like `Button`; **Tone × Shape** for state components like `Badge` / `Callout` / `Toast`), per-component matrix, common props (`size` / `isError` / `isLoading` / `disabled` / `readOnly`), and `asChild` adoption criteria.
 - [`storybook-guideline.md`](.claude/rules/storybook-guideline.md) — Story structure (`Playground` story first, group by prop), `argTypes`, English-only labels.
 - [`state-token-guideline.md`](.claude/rules/state-token-guideline.md) — 3-layer token system, state semantic tokens (`error` / `success` / `warning` / `info` / `destructive`) and the 4-token shape (`base` / `hover` / `foreground` / `subtle`).
 - [`field-context-guideline.md`](.claude/rules/field-context-guideline.md) — `FieldContext` integration patterns for form components (Input / Checkbox / Switch / Radio / Select / Textarea).
@@ -71,7 +71,7 @@ pnpm changeset         # Create a changeset for user-facing changes
 |---|---|
 | [CLAUDE.md](CLAUDE.md) | Claude Code-specific tech stack and rule index. |
 | [README.md](README.md) | Public-facing overview, installation, and usage. |
-| [.claude/rules/component-api-conventions.md](.claude/rules/component-api-conventions.md) | Public prop API shape: `variant` × `appearance` matrix, common props, `asChild` criteria. |
+| [.claude/rules/component-api-conventions.md](.claude/rules/component-api-conventions.md) | Public prop API shape: Role-based (Button) vs Tone × Shape (Badge/Callout/Toast) patterns, common props, `asChild` criteria. |
 | [.claude/rules/storybook-guideline.md](.claude/rules/storybook-guideline.md) | Storybook conventions — Playground story, `argTypes`, grouping. |
 | [.claude/rules/state-token-guideline.md](.claude/rules/state-token-guideline.md) | 3-layer token system, 4-token shape, `destructive` vs `error`. |
 | [.claude/rules/field-context-guideline.md](.claude/rules/field-context-guideline.md) | `FieldContext` patterns for form components. |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,6 +34,7 @@ src/
 
 Before adding or modifying components, read the guideline files under [`.claude/rules/`](.claude/rules):
 
+- [`component-api-conventions.md`](.claude/rules/component-api-conventions.md) — Public prop API shape: the two-axis `variant` (color tone) × `appearance` (shape) model, common props (`size` / `isError` / `isLoading` / `disabled` / `readOnly`), per-component variant matrix, and `asChild` adoption criteria.
 - [`storybook-guideline.md`](.claude/rules/storybook-guideline.md) — Story structure (`Playground` story first, group by prop), `argTypes`, English-only labels.
 - [`state-token-guideline.md`](.claude/rules/state-token-guideline.md) — 3-layer token system, state semantic tokens (`error` / `success` / `warning` / `info` / `destructive`) and the 4-token shape (`base` / `hover` / `foreground` / `subtle`).
 - [`field-context-guideline.md`](.claude/rules/field-context-guideline.md) — `FieldContext` integration patterns for form components (Input / Checkbox / Switch / Radio / Select / Textarea).
@@ -70,6 +71,7 @@ pnpm changeset         # Create a changeset for user-facing changes
 |---|---|
 | [CLAUDE.md](CLAUDE.md) | Claude Code-specific tech stack and rule index. |
 | [README.md](README.md) | Public-facing overview, installation, and usage. |
+| [.claude/rules/component-api-conventions.md](.claude/rules/component-api-conventions.md) | Public prop API shape: `variant` × `appearance` matrix, common props, `asChild` criteria. |
 | [.claude/rules/storybook-guideline.md](.claude/rules/storybook-guideline.md) | Storybook conventions — Playground story, `argTypes`, grouping. |
 | [.claude/rules/state-token-guideline.md](.claude/rules/state-token-guideline.md) | 3-layer token system, 4-token shape, `destructive` vs `error`. |
 | [.claude/rules/field-context-guideline.md](.claude/rules/field-context-guideline.md) | `FieldContext` patterns for form components. |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,6 +28,7 @@ When adding or modifying components, follow shadcn/ui conventions (Radix UI + CV
 
 ## Guidelines
 
+- See [.claude/rules/component-api-conventions.md](.claude/rules/component-api-conventions.md) for the public prop API shape (`variant` / `appearance` / `size` / `isError` / `isLoading` / `asChild`) and the per-component variant matrix
 - See [.claude/rules/storybook-guideline.md](.claude/rules/storybook-guideline.md) for Storybook conventions
 - See [.claude/rules/field-context-guideline.md](.claude/rules/field-context-guideline.md) for Field context integration patterns
 - See [.claude/rules/state-token-guideline.md](.claude/rules/state-token-guideline.md) for state semantic tokens (error / success / warning / info / destructive) and the 4-token shape

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,7 @@ When adding or modifying components, follow shadcn/ui conventions (Radix UI + CV
 
 ## Guidelines
 
-- See [.claude/rules/component-api-conventions.md](.claude/rules/component-api-conventions.md) for the public prop API shape (`variant` / `appearance` / `size` / `isError` / `isLoading` / `asChild`) and the per-component variant matrix
+- See [.claude/rules/component-api-conventions.md](.claude/rules/component-api-conventions.md) for the public prop API shape — the two patterns (Role-based / Tone × Shape), per-component matrix, common props (`size` / `isError` / `isLoading` / `disabled` / `readOnly`), and `asChild` criteria
 - See [.claude/rules/storybook-guideline.md](.claude/rules/storybook-guideline.md) for Storybook conventions
 - See [.claude/rules/field-context-guideline.md](.claude/rules/field-context-guideline.md) for Field context integration patterns
 - See [.claude/rules/state-token-guideline.md](.claude/rules/state-token-guideline.md) for state semantic tokens (error / success / warning / info / destructive) and the 4-token shape


### PR DESCRIPTION
## Summary

Add `.claude/rules/component-api-conventions.md` — the **source of truth** for the public prop API shape of every `lv1` / `lv2` component. This is the prerequisite contract that [#108](https://github.com/yasmro/schatten/issues/108) (v0.7.0) will implement.

The rule defines **two patterns**, and every component picks exactly one:

### Pattern A — Role-based (single-axis)

Used by **action components** — `Button`.

- `variant` only. Each value names a complete role (color × shape baked together).
- Vocabulary: `primary | secondary | tertiary | destructive | inverted | link`. (Same as today — no Button migration needed.)
- Rationale: action components have a small, well-known set of UX roles. Decomposing them into color × shape produces nonsense combinations (`destructive + link`?) and worsens ergonomics. shadcn/ui — the project base — also keeps Button single-axis.

### Pattern B — Tone × Shape (two-axis)

Used by **state / notification components** — `Badge`, `Callout`, `Toast`.

- `variant` (tone) × `appearance` (shape) — orthogonal axes.
- Tone vocabulary: `neutral | accent | success | error | warning | info`.
- Shape vocabulary: `filled | outlined | soft`.
- Rationale: state components genuinely need both axes — an "error filled Toast" and an "error soft Callout" both exist and need expression. Naming each pair would explode the vocabulary.

### Other components

- **Form components** (`Input`, `Textarea`, `Select`, `Checkbox`, `Radio`, `Switch`): no `variant` at all; error state via `isError`.
- **`Spinner`**: no variant; inherits color via `currentColor`. Legacy `variant="inverted"` removed in #108.
- **`Text`**: re-uses `variant` for typography role (`body | label | heading`) — the only approved deviation, called out explicitly.

### Other content in the rule

- **Per-component matrix** — authoritative table of which pattern + which value subset each component uses.
- **`destructive` vs `error` stays distinct.** Both reference vermillion but `destructive` is Pattern A action-intent; `error` is Pattern B state-tone. The separation matches existing [state-token-guideline](.claude/rules/state-token-guideline.md#destructive-vs-error).
- **Boolean naming convention.** `is*` for schatten-specific (`isError`, `isLoading`); HTML-native unprefixed (`disabled`, `readOnly`, `required`).
- **`asChild` adoption criteria** — three concrete gates plus current allow/deny list.
- **Legacy → new migration table** — primarily the state-component rename (`treatment` → `appearance`, `default` → `neutral` / `accent`). `Button` is unchanged.

### Impact on #108

Scope of v0.7.0 shrinks significantly: `Button`'s vocabulary is already correct under Pattern A, so #108 becomes mostly the **state-component rename** plus `Spinner.variant="inverted"` removal. Originally #108 envisioned an 18-component refactor — that estimate was based on a "two-axis everywhere" hypothesis this rule rejects.

Indexes updated:
- [CLAUDE.md](CLAUDE.md): added to `## Guidelines`.
- [AGENTS.md](AGENTS.md): added to `## Required reading` and `## Resource Map`.

## Test plan

- [ ] CI passes (lint, typecheck, build, VRT).
- [ ] `no-changeset` label applied (docs-only PR).
- [ ] Open rendered MD in GitHub; verify tables and cross-link anchors resolve.
- [ ] Sanity-check referenced issue/file URLs (`#108`, `Button.tsx`, sibling rules).

## Commits

- `b9cb2de` — initial draft (two-axis everywhere)
- `6c85880` — split into Pattern A (Role-based) / Pattern B (Tone × Shape) — Button kept single-axis to match shadcn/ui and the natural ergonomic split

🤖 Generated with [Claude Code](https://claude.com/claude-code)