### PR TITLE
docs(rule): add .claude/rules/component-architecture.md (closes #101)

### DIFF
--- a/.changeset/component-architecture-rule.md
+++ b/.changeset/component-architecture-rule.md
@@ -2,9 +2,11 @@
 '@yasmro/schatten': patch
 ---
 
-docs(rule): add `.claude/rules/component-architecture.md` (lv1/lv2 folders, compound vs flat, `asChild` not adopted, polymorphic `as` not adopted, unified context consumption, one-way dependency direction, lv1-local `.css` allowlist)
+docs(rule): add `.claude/rules/component-architecture.md` (lv1/lv2 folders, compound vs flat, `asChild` no-new-additions default, polymorphic `as` not adopted, unified context consumption, one-way dependency direction, lv1-local `.css` allowlist)
 
-Codifies the component-level design choices that have been implicit until now:
+Codifies the component-level design choices that have been implicit until now.
+Complements [`component-api-conventions.md`](.claude/rules/component-api-conventions.md)
+(added in #192, which holds the authoritative public prop API shape).
 
 - **lv1 vs lv2 folders**: lv1 is single-responsibility primitives, lv2 is
   composition. The promotion criterion ("when does a recurring composition
@@ -15,12 +17,13 @@ Codifies the component-level design choices that have been implicit until now:
   self-built primitives ship as flat. Self-built composition belongs in lv2,
   not in a compound lv1. `Toast`'s imperative API is called out as the
   notification-class special case.
-- **`asChild` is not adopted on new lv1s**. The replacement is **exporting
-  the CVA variants function** (e.g. `buttonVariants` / `textVariants`,
-  already exported today from `@yasmro/schatten/variants`) and letting
-  consumers apply it directly to their own element. The two existing
-  `asChild` props (`Button.asChild`, `Text.asChild`) are flagged as legacy;
-  removal is tracked in a separate issue.
+- **`asChild` — no new lv1 additions by default**. Cross-references
+  `component-api-conventions.md` for the authoritative adoption list and
+  the 3 criteria. Adds two further constraints on top: form inputs and
+  portal content must never expose `asChild`, regardless of how the 3
+  criteria appear to fit. The variants-function pattern (`buttonVariants` /
+  `textVariants` from `@yasmro/schatten/variants`) is documented as the
+  preferred alternative for "render as a different element" needs.
 - **Polymorphic `as` prop is not adopted** as a general pattern. Carved
   exception: `Text` exposes a fixed enumeration
   `as?: 'p' | 'span' | 'h1'…'h6'` — the union is closed, the attribute
@@ -45,5 +48,4 @@ Codifies the component-level design choices that have been implicit until now:
 The rule is referenced from CLAUDE.md / AGENTS.md and the `review-pr`
 command checklist.
 
-No public API or component behaviour changes in this PR. The `asChild`
-removal is breaking-change work scheduled separately.
+No public API or component behaviour changes.

--- a/.changeset/component-architecture-rule.md
+++ b/.changeset/component-architecture-rule.md
@@ -1,0 +1,49 @@
+---
+'@yasmro/schatten': patch
+---
+
+docs(rule): add `.claude/rules/component-architecture.md` (lv1/lv2 folders, compound vs flat, `asChild` not adopted, polymorphic `as` not adopted, unified context consumption, one-way dependency direction, lv1-local `.css` allowlist)
+
+Codifies the component-level design choices that have been implicit until now:
+
+- **lv1 vs lv2 folders**: lv1 is single-responsibility primitives, lv2 is
+  composition. The promotion criterion ("when does a recurring composition
+  become an lv2?") is intentionally deferred — it will be defined as a
+  follow-up rule when the first lv2 lands (~v0.9.0).
+- **Compound vs flat**: Radix-wrapping components ship as compound (mirror
+  Radix part names one-to-one to preserve ref / context / aria wires);
+  self-built primitives ship as flat. Self-built composition belongs in lv2,
+  not in a compound lv1. `Toast`'s imperative API is called out as the
+  notification-class special case.
+- **`asChild` is not adopted on new lv1s**. The replacement is **exporting
+  the CVA variants function** (e.g. `buttonVariants` / `textVariants`,
+  already exported today from `@yasmro/schatten/variants`) and letting
+  consumers apply it directly to their own element. The two existing
+  `asChild` props (`Button.asChild`, `Text.asChild`) are flagged as legacy;
+  removal is tracked in a separate issue.
+- **Polymorphic `as` prop is not adopted** as a general pattern. Carved
+  exception: `Text` exposes a fixed enumeration
+  `as?: 'p' | 'span' | 'h1'…'h6'` — the union is closed, the attribute
+  surface is uniform, and inference cost is zero.
+- **Context consumption is unified into one rule**: every form lv1 reads
+  `isError` / `disabled` / `describedBy` from `FieldContext` with prop
+  fallback. Only externally-labelled components (`Input`, `Textarea`,
+  `Select`) additionally consume `field.id`. `FieldSetContext` is consumed
+  only by `Field`, which collapses-and-re-provides — form lv1s never read
+  `FieldSetContext` directly.
+- **Dependency direction is strictly one-way**:
+  `lib` / `contexts` / `variants` → `lv1` → `lv2`. `lv1 → lv2` is forbidden
+  (an lv1 needing an lv2 is misclassified); `lv1 → other lv1` is allowed
+  (e.g. `Dialog` embedding `Button` in its action row); barrel-export
+  laundering (reaching `lib` via `lv1/index.ts`) is forbidden.
+- **lv1-local `.css` allowlist**: only for things Tailwind / CVA cannot
+  express — `@keyframes`, `animation-play-state` conditional on data-state,
+  `prefers-reduced-motion`, component-scoped CSS variables. The four
+  existing files (Tooltip.css, Dialog.css, Toast.css, Spinner.css) are all
+  animation-only and comply.
+
+The rule is referenced from CLAUDE.md / AGENTS.md and the `review-pr`
+command checklist.
+
+No public API or component behaviour changes in this PR. The `asChild`
+removal is breaking-change work scheduled separately.

--- a/.claude/commands/review-pr.md
+++ b/.claude/commands/review-pr.md
@@ -24,7 +24,7 @@ PR をセルフレビューし、デザインシステムとして堅牢かチ�
 - [ ] `.claude/rules/component-architecture.md` に準拠しているか
   - lv1 / lv2 の配置が責務分離に沿っているか
   - compound vs flat の選択が妥当か (Radix wrap → compound, 自前 → flat, 自前合成は lv2)
-  - **新規に `asChild` prop が追加されていないか** (lv1 では不採用、`buttonVariants` / `textVariants` を使う代替パターンへ)
+  - **新規に `asChild` prop が追加されていないか** (新規 lv1 は default-off。`buttonVariants` / `textVariants` で代替。form input / portal content には何があっても採用不可。既存採用済みコンポーネントの判定は `component-api-conventions.md` §`asChild` を参照)
   - 依存方向が一方向か (`lv1 → lv2` 禁止、`barrel 経由` 禁止、新規 `lib/` utility は 2 consumer 必要)
   - 新規ファイルとして `.css` が増えていないか — 増えている場合は Tailwind/CVA で表現困難な理由があるか
 - [ ] Context 連携パターンに従っているか (`.claude/rules/field-context-guideline.md` 参照)

--- a/.claude/commands/review-pr.md
+++ b/.claude/commands/review-pr.md
@@ -21,6 +21,12 @@ PR をセルフレビューし、デザインシステムとして堅牢かチ�
 ### 2. コンポーネント設計
 
 - [ ] Props API が直感的で一貫しているか
+- [ ] `.claude/rules/component-architecture.md` に準拠しているか
+  - lv1 / lv2 の配置が責務分離に沿っているか
+  - compound vs flat の選択が妥当か (Radix wrap → compound, 自前 → flat, 自前合成は lv2)
+  - **新規に `asChild` prop が追加されていないか** (lv1 では不採用、`buttonVariants` / `textVariants` を使う代替パターンへ)
+  - 依存方向が一方向か (`lv1 → lv2` 禁止、`barrel 経由` 禁止、新規 `lib/` utility は 2 consumer 必要)
+  - 新規ファイルとして `.css` が増えていないか — 増えている場合は Tailwind/CVA で表現困難な理由があるか
 - [ ] Context 連携パターンに従っているか (`.claude/rules/field-context-guideline.md` 参照)
   - 内部ラベルありコンポーネント: `field?.id` を使わない
   - 内部ラベルなしコンポーネント: `field?.id` を使う

--- a/.claude/rules/component-architecture.md
+++ b/.claude/rules/component-architecture.md
@@ -1,0 +1,295 @@
+# Component Architecture Guideline
+
+## Overview
+
+This file records the design-time choices that go into adding or extending a
+component in Schatten: which folder it lives in, how its API is shaped, what
+escape hatches it exposes, and when a `.css` file is allowed to exist next to
+a `.tsx`. These choices used to live in reviewers' heads — making them
+explicit lets contributors (human and AI) land the right thing the first time
+and lets reviewers anchor feedback on a shared text instead of taste.
+
+Anything not covered here defaults to **shadcn/ui + Radix conventions**.
+
+## 1. lv1 vs lv2 — folder responsibilities
+
+| | lv1 (primitive) | lv2 (composite) |
+|---|---|---|
+| Folder | [`src/components/lv1/`](../../src/components/lv1) | [`src/components/lv2/`](../../src/components/lv2) |
+| Purpose | Single-responsibility primitive. Low-level, focused. | A composition of multiple lv1s shaped as a single component. |
+| Examples (today) | Button, Input, Field, FieldSet, Select, Dialog, Tooltip, … | (empty — first lv2s land in v0.9.0) |
+| Hypothetical lv2 | — | `FormField` = Field + Label + Input + error msg |
+
+**The promotion criterion (when a recurring composition becomes an lv2) is
+intentionally deferred** — it will be defined in a follow-up rule when the
+first lv2 lands (~v0.9.0). Until then, treat any composition of 3+ lv1s as
+a candidate that the DS owner will judge case-by-case.
+
+## 2. Compound vs flat
+
+When designing an lv1, pick between **compound** (multiple named exports the
+consumer composes) and **flat** (one component the consumer uses directly).
+
+### Compound — the consumer composes named parts
+
+```tsx
+<Dialog>
+  <DialogTrigger>Open</DialogTrigger>
+  <DialogContent>
+    <DialogTitle>Confirm</DialogTitle>
+    <DialogDescription>Are you sure?</DialogDescription>
+  </DialogContent>
+</Dialog>
+```
+
+Used by: `Dialog`, `Tooltip`, `Select`, `Radio` (`RadioGroup` + `Radio`).
+
+**When to ship as compound:** when wrapping a Radix primitive that already
+exposes multiple parts. Match Radix's part names one-to-one
+(e.g. [`SelectTrigger`](../../src/components/lv1/Select/Select.tsx) mirrors
+`SelectPrimitive.Trigger`).
+
+**Why match Radix one-to-one rather than collapse:** Radix's parts share refs,
+context, and aria attributes internally. Collapsing them into a single component
+breaks those wires. It also strips the consumer's ability to inject custom
+content into specific slots — a custom icon inside `DialogTitle`, an extra
+className on `DialogContent`, etc.
+
+### Flat — the consumer uses one component
+
+```tsx
+<Button variant="primary" size="md">Save</Button>
+<Input placeholder="email" />
+<Badge variant="success">Active</Badge>
+```
+
+Used by: `Button`, `Input`, `Badge`, `Callout`, `Spinner`, `Text`, `Textarea`,
+`Field`, `FieldSet`, `Checkbox`, `Switch`.
+
+**When to ship as flat:** when the component is one styled tag with variants
+and has at most one content injection point (its `children`). If consumers
+need to inject content at multiple slots, that is a sign you have a
+composition on your hands — and a self-built composition belongs in **lv2,
+not in a compound lv1**.
+
+### Special case — imperative APIs
+
+`Toast` is neither compound nor flat in the usual sense: it exposes an
+imperative `toast()` function plus a `<Toaster />` mount. This shape is
+justified by the consumer ergonomics for toasts (fire-and-forget from
+anywhere in the app, no JSX-tree placement required) and is the rule rather
+than the exception for notification-type primitives. Any new component that
+demands an imperative API should justify the divergence in its PR description.
+
+## 3. `asChild` is NOT adopted on new components
+
+Schatten lv1 components **do not add new `asChild` props**. Two existing
+props (`Button.asChild`, `Text.asChild`) are legacy from the original shadcn
+copy and are tracked for removal — see "Existing legacy" below.
+
+### Why
+
+- `asChild` weakens type safety. `<Component asChild><a>` makes it
+  consumer-implicit which of `Component`'s props forward sensibly to `<a>`,
+  and which fail silently.
+- A cleaner alternative exists for the most common case: **export the CVA
+  variants function** ([`buttonVariants`](../../src/variants/button.ts),
+  [`textVariants`](../../src/variants/text.ts) — already exported from
+  `@yasmro/schatten/variants` today) and let consumers apply it directly to
+  their own element:
+
+  ```tsx
+  // before — fragile asChild
+  <Button asChild><a href="/docs">Docs</a></Button>
+
+  // after — explicit, fully typed
+  <a href="/docs" className={buttonVariants({ variant: 'primary' })}>Docs</a>
+  ```
+
+- Form inputs (`Input`, `Textarea`, `Select`, `Checkbox`, `Switch`, `Radio`)
+  aren't polymorphic at the HTML platform level — `<input>` cannot become
+  `<textarea>`.
+- Portal-rendered parts (`Dialog` content, `Toast`) have positioning math
+  tied to a known DOM shape; letting consumers swap that out breaks layout
+  in subtle ways.
+
+### Radix-internal `asChild` is unaffected
+
+Inside a component's implementation, `<DialogPrimitive.Close asChild>` and
+similar internal `asChild` usages are fine — the rule is about what we
+**expose on the Schatten public API**. The `TooltipTrigger` pattern (omit
+`asChild` from the public type via `Omit<…, 'asChild'>` and decide
+internally based on `isTextOnly`) is the template for any future Trigger-style
+component.
+
+### Existing legacy
+
+- [`Button.asChild`](../../src/components/lv1/Button/Button.tsx) — predates
+  this rule; combining with `isLoading` already triggers a runtime warning
+  (a footgun symptom).
+- [`Text.asChild`](../../src/components/lv1/Text/Text.tsx) — predates this
+  rule; `<Link className={textVariants(...)}>` covers the same need.
+
+Removal is tracked in [#193](https://github.com/yasmro/schatten/issues/193).
+**Do not add new `asChild` props to other lv1 components** in the meantime.
+
+## 4. Polymorphic `as` prop — NOT adopted (with one carved exception)
+
+Schatten follows shadcn / Radix in **not** offering a generic polymorphic API
+like `<Button as="a" href="…">`. The reasons:
+
+- TypeScript type inference for polymorphic components requires complex
+  generic plumbing (`ElementType` + `PolymorphicComponentProp`), which fights
+  `forwardRef` and degrades editor performance in large consumer apps.
+- The CVA-variants-export pattern from §3 covers the same use cases —
+  consumers apply `buttonVariants(...)` / `textVariants(...)` to whatever
+  element they want, fully typed.
+
+**Carved exception — `Text` accepts `as`.** [Text](../../src/components/lv1/Text/Text.tsx)
+exposes `as?: 'p' | 'span' | 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6'` — a
+**fixed enumeration of semantic HTML elements** that all share the same
+character (a text container) and the same DOM attribute surface. The type
+is a union, not `ElementType`, so the inference cost is zero. `as` is
+purely a shorthand for the common "render this paragraph as an h2 instead"
+case.
+
+**Why `as` works on `Text` but not on `Button`:** Text's eight tags accept
+the same attribute set and play the same DOM role (content). `Button → a`
+swaps role (interactive button → navigation link) and required attributes
+(`type` → `href`), which is exactly the shape that polymorphic types
+struggle to narrow. For that case, exporting `buttonVariants` lets the
+consumer hand in a fully-typed `<a>` instead.
+
+**Rule of thumb:** if your `as` would accept arbitrary `ElementType`, refuse.
+If it accepts a closed set of semantically related tags that share the
+same attribute surface and the union is small (≤8), it can ship — but
+justify the call in the PR description.
+
+## 5. Context consumption — unified rule
+
+Form-aware lv1 components consume state from [`FieldContext`](../../src/contexts/field.ts).
+The rule is **one shape** with a single `id` qualifier:
+
+### State (always consumed, all form lv1s)
+
+Every form lv1 reads three values from `FieldContext` with prop fallback:
+
+```ts
+const field = useFieldContext()
+const isError      = field?.isError      ?? props.isError      ?? false
+const disabled     = field?.disabled     ?? props.disabled     ?? false
+const describedBy  = field?.describedBy  ?? props['aria-describedby']
+```
+
+This applies uniformly to `Input`, `Textarea`, `Select`, `Checkbox`, `Switch`,
+`Radio`, and `RadioGroup`.
+
+### `id` (consumed only by externally-labelled components)
+
+`FieldContext.id` is specifically **the hookup id between an external `<label htmlFor>`
+and the input element**. It is consumed only by components that lack their own
+internal label:
+
+| Consumes `field?.id` | Does not consume `field?.id` |
+|---|---|
+| `Input`, `Textarea`, `Select` | `Checkbox`, `Switch`, `Radio` |
+
+Components with internal labels generate their own per-instance id (each
+checkbox is its own field).
+
+### Group components
+
+`RadioGroup` consumes state at the group level and re-provides a group-scoped
+context to its child `Radio`s (which read `name` from that group context).
+
+### `FieldSetContext` is consumed only by `Field`
+
+The collapse-and-provide chain is **`FieldSet` → `Field` → form lv1**.
+[`Field`](../../src/components/lv1/Field/Field.tsx) reads
+`FieldSetContext` for `isError` / `disabled`, merges with its own props,
+and re-provides via `FieldContext`. **Form lv1s never read `FieldSetContext`
+directly** — they only ever see `FieldContext`.
+
+### Precedence
+
+```
+direct prop  >  FieldContext  >  FieldSetContext (already collapsed into FieldContext via Field)  >  default
+```
+
+## 6. Dependency direction — strictly one-way
+
+The source tree is layered, and **a layer may only depend on layers below
+it** (plus itself, where noted). Inverted dependencies (a lower layer
+importing from a higher one) are forbidden.
+
+| Layer | May import from |
+|---|---|
+| [`lib/`](../../src/lib) (`cn`, `mergeRefs`) | external only (React, clsx, tailwind-merge) |
+| [`contexts/`](../../src/contexts), [`variants/`](../../src/variants) | external only (React, cva) |
+| [`components/lv1/`](../../src/components/lv1) | `lib/`, `contexts/`, `variants/`, **other `lv1/`** |
+| [`components/lv2/`](../../src/components/lv2) | `lib/`, `contexts/`, `variants/`, `lv1/`, other `lv2/` |
+
+### Key rules
+
+- **lv1 → lv2 is forbidden.** An lv1 that finds itself needing an lv2 is
+  itself misclassified — promote it to lv2.
+- **lv1 → other lv1 is allowed.** A flat lv1 may use another lv1 as part of
+  its own structure (e.g. `Dialog` rendering a `Button` for its action /
+  cancel rows). This is *not* composition-as-feature — it is "this primitive
+  happens to embed another primitive as a fixed structural part."
+- **No barrel-export laundering.** When `lv2` needs `cn`, it imports from
+  `'../../../lib/utils'`, never via `lv1/index.ts`. Going through a higher
+  layer to reach a lower one is a dependency inversion in disguise.
+- **Adding to `lib/` requires a real second consumer.** A helper used by
+  exactly one component lives next to that component, not in `lib/`.
+  Premature extraction adds a navigation hop without a payoff.
+
+## 7. lv1-local CSS files
+
+Most styling lives in Tailwind classes composed through CVA. A `.css` file
+next to a `.tsx` is allowed **only** when the styling expresses something
+Tailwind / CVA cannot reasonably express:
+
+| Allowed | Not allowed |
+|---|---|
+| `@keyframes` animations (declarative, multi-stop) | Static colors, spacing, typography (use semantic tokens + CVA) |
+| `animation-play-state` / `animation-delay` conditional on `[data-state]` | Hover/focus state styles (use Tailwind variants) |
+| `prefers-reduced-motion` media queries that disable animation | Light/dark adjustments (use CSS variables + `dark:`) |
+| CSS variable definitions scoped to the component (e.g. `--schatten-spinner-duration`) | Layout / flexbox / grid (use Tailwind) |
+
+**Existing exceptions today** (all animation-only, all comply):
+
+- [`Tooltip.css`](../../src/components/lv1/Tooltip/Tooltip.css) — directional
+  enter/exit slide+fade animations driven by Radix `[data-state]` and
+  `[data-side]`. Per-side composed `animation:` shorthand is impractical
+  in Tailwind.
+- [`Dialog.css`](../../src/components/lv1/Dialog/Dialog.css) — overlay
+  fade and content zoom keyframes. Documents the `translate:` /
+  `transform: translate(...)` interaction with Tailwind v4 in an inline
+  comment.
+- [`Toast.css`](../../src/components/lv1/Toast/Toast.css) — dissolve-in /
+  dissolve-out keyframes and swipe-handoff animation.
+- [`Spinner.css`](../../src/components/lv1/Spinner/Spinner.css) — ripple
+  and breathe keyframes; declares two component-scoped CSS variables
+  (`--schatten-spinner-duration`, `--schatten-spinner-ripple-delay`)
+  that consumers can override.
+
+**Review check:** if a PR adds a `.css` file under `src/components/lv1/`,
+the reviewer must verify each rule satisfies the "not expressible in
+Tailwind / CVA" bar above. If any rule could be a Tailwind class, move
+it.
+
+## When this rule changes
+
+- **§1 (lv2 promotion criterion):** will be defined as a follow-up rule
+  when the first lv2 lands (~v0.9.0).
+- **§3 (`asChild` legacy removal):** tracked in
+  [#193](https://github.com/yasmro/schatten/issues/193). When
+  `Button.asChild` / `Text.asChild` are removed, delete the "Existing
+  legacy" subsection.
+- **§4 (polymorphic):** if shadcn / Radix conventions shift toward
+  polymorphic APIs post-1.0, revisit the carved exception first.
+- **§6 (dependency direction):** if lv0 (foundation tokens-as-components)
+  or lv3 (page-level shells) gets introduced, add the new layer to the
+  table and update the resource maps in [CLAUDE.md](../../CLAUDE.md) /
+  [AGENTS.md](../../AGENTS.md).

--- a/.claude/rules/component-architecture.md
+++ b/.claude/rules/component-architecture.md
@@ -81,57 +81,64 @@ anywhere in the app, no JSX-tree placement required) and is the rule rather
 than the exception for notification-type primitives. Any new component that
 demands an imperative API should justify the divergence in its PR description.
 
-## 3. `asChild` is NOT adopted on new components
+## 3. `asChild` — no new lv1 additions
 
-Schatten lv1 components **do not add new `asChild` props**. Two existing
-props (`Button.asChild`, `Text.asChild`) are legacy from the original shadcn
-copy and are tracked for removal — see "Existing legacy" below.
+The authoritative list of components that **currently** expose `asChild`,
+together with the three adoption criteria they satisfy, lives in
+[component-api-conventions.md §`asChild` adoption criteria](component-api-conventions.md).
+This section adds two further constraints on top of that rule.
 
-### Why
+### Default: do not add `asChild` to a new lv1
 
-- `asChild` weakens type safety. `<Component asChild><a>` makes it
-  consumer-implicit which of `Component`'s props forward sensibly to `<a>`,
-  and which fail silently.
-- A cleaner alternative exists for the most common case: **export the CVA
-  variants function** ([`buttonVariants`](../../src/variants/button.ts),
-  [`textVariants`](../../src/variants/text.ts) — already exported from
-  `@yasmro/schatten/variants` today) and let consumers apply it directly to
-  their own element:
+When designing a new lv1 component, ship it **without** an `asChild` prop.
+The variants-function pattern (below) covers the most common case, and
+adding `asChild` later is non-breaking — adding it eagerly and removing
+it later is breaking. Bias toward the smaller surface.
 
-  ```tsx
-  // before — fragile asChild
-  <Button asChild><a href="/docs">Docs</a></Button>
+### Prefer the variants-function pattern
 
-  // after — explicit, fully typed
-  <a href="/docs" className={buttonVariants({ variant: 'primary' })}>Docs</a>
-  ```
+For "render as a different element" needs, the design system already
+exports the CVA variants functions — [`buttonVariants`](../../src/variants/button.ts) and
+[`textVariants`](../../src/variants/text.ts) from
+`@yasmro/schatten/variants`. Consumers apply them directly to their own
+element:
 
-- Form inputs (`Input`, `Textarea`, `Select`, `Checkbox`, `Switch`, `Radio`)
-  aren't polymorphic at the HTML platform level — `<input>` cannot become
-  `<textarea>`.
-- Portal-rendered parts (`Dialog` content, `Toast`) have positioning math
-  tied to a known DOM shape; letting consumers swap that out breaks layout
-  in subtle ways.
+```tsx
+// styled link without asChild
+<a href="/docs" className={buttonVariants({ variant: 'primary' })}>Docs</a>
+<NextLink href="/docs" className={textVariants({ variant: 'body', size: 'md' })}>Docs</NextLink>
+```
+
+This pattern:
+
+- keeps the consumer's element fully typed (their `<a>` / `<NextLink>`
+  retains its native prop signature)
+- avoids the prop-forwarding ambiguity that `asChild` introduces
+- works equally well for framework Link components (Next, React Router,
+  Remix), which already accept `className` directly
+
+### Hard exclusions, even if #192's 3 criteria seem to fit
+
+Two categories of component must **never** expose `asChild`, regardless
+of how cleanly the 3 criteria appear to apply:
+
+- **Form inputs** (`Input`, `Textarea`, `Select` trigger, `Checkbox`,
+  `Switch`, `Radio`) — HTML form elements aren't polymorphic at the
+  platform level (`<input>` cannot become `<textarea>`).
+- **Portal-rendered content** (`Dialog` content, `Toast`) — positioning
+  math is tied to a known DOM shape; swapping the element out breaks
+  layout in subtle ways. (`DialogTrigger` / `DialogClose` /
+  `TooltipTrigger` etc. are *not* portal content — they live in the
+  consumer's tree and may continue to expose `asChild` per #192.)
 
 ### Radix-internal `asChild` is unaffected
 
-Inside a component's implementation, `<DialogPrimitive.Close asChild>` and
-similar internal `asChild` usages are fine — the rule is about what we
-**expose on the Schatten public API**. The `TooltipTrigger` pattern (omit
-`asChild` from the public type via `Omit<…, 'asChild'>` and decide
-internally based on `isTextOnly`) is the template for any future Trigger-style
-component.
-
-### Existing legacy
-
-- [`Button.asChild`](../../src/components/lv1/Button/Button.tsx) — predates
-  this rule; combining with `isLoading` already triggers a runtime warning
-  (a footgun symptom).
-- [`Text.asChild`](../../src/components/lv1/Text/Text.tsx) — predates this
-  rule; `<Link className={textVariants(...)}>` covers the same need.
-
-Removal is tracked in [#193](https://github.com/yasmro/schatten/issues/193).
-**Do not add new `asChild` props to other lv1 components** in the meantime.
+Inside a component's implementation, `<DialogPrimitive.Close asChild>`
+and similar internal `asChild` usages are fine — the rules here are
+about the **public Schatten API surface**. The `TooltipTrigger` pattern
+(omit `asChild` from the public type via `Omit<…, 'asChild'>` and decide
+internally based on `isTextOnly`) is the template for any future
+Trigger-style component that wants to hide the prop from consumers.
 
 ## 4. Polymorphic `as` prop — NOT adopted (with one carved exception)
 
@@ -283,10 +290,11 @@ it.
 
 - **§1 (lv2 promotion criterion):** will be defined as a follow-up rule
   when the first lv2 lands (~v0.9.0).
-- **§3 (`asChild` legacy removal):** tracked in
-  [#193](https://github.com/yasmro/schatten/issues/193). When
-  `Button.asChild` / `Text.asChild` are removed, delete the "Existing
-  legacy" subsection.
+- **§3 (`asChild`):** the authoritative adoption list lives in
+  [component-api-conventions.md](component-api-conventions.md). Keep
+  this file's §3 narrowed to the *additional* constraints
+  ("no new additions by default" + hard exclusions for form inputs /
+  portal content). If those constraints change, update both files.
 - **§4 (polymorphic):** if shadcn / Radix conventions shift toward
   polymorphic APIs post-1.0, revisit the carved exception first.
 - **§6 (dependency direction):** if lv0 (foundation tokens-as-components)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,7 +34,7 @@ src/
 
 Before adding or modifying components, read the guideline files under [`.claude/rules/`](.claude/rules):
 
-- [`component-architecture.md`](.claude/rules/component-architecture.md) — lv1 vs lv2 folder responsibilities, compound vs flat, `asChild` not adopted on new components (with `buttonVariants` / `textVariants` as the replacement pattern), polymorphic `as` not adopted, unified `FieldContext` consumption, one-way dependency direction (lv1 → lv2 forbidden, no barrel laundering), when an lv1-local `.css` file is allowed.
+- [`component-architecture.md`](.claude/rules/component-architecture.md) — lv1 vs lv2 folder responsibilities, compound vs flat, `asChild` default-off for new lv1s + hard exclusions on form inputs / portal content (complements `component-api-conventions.md` §`asChild`; `buttonVariants` / `textVariants` are the preferred alternative), polymorphic `as` not adopted, unified `FieldContext` consumption, one-way dependency direction (lv1 → lv2 forbidden, no barrel laundering), when an lv1-local `.css` file is allowed.
 - [`component-api-conventions.md`](.claude/rules/component-api-conventions.md) — Public prop API shape: two patterns (**Role-based** for action components like `Button`; **Tone × Shape** for state components like `Badge` / `Callout` / `Toast`), per-component matrix, common props (`size` / `isError` / `isLoading` / `disabled` / `readOnly`), and `asChild` adoption criteria.
 - [`storybook-guideline.md`](.claude/rules/storybook-guideline.md) — Story structure (`Playground` story first, group by prop), `argTypes`, English-only labels.
 - [`state-token-guideline.md`](.claude/rules/state-token-guideline.md) — 3-layer token system, state semantic tokens (`error` / `success` / `warning` / `info` / `destructive`) and the 4-token shape (`base` / `hover` / `foreground` / `subtle`).
@@ -72,7 +72,7 @@ pnpm changeset         # Create a changeset for user-facing changes
 |---|---|
 | [CLAUDE.md](CLAUDE.md) | Claude Code-specific tech stack and rule index. |
 | [README.md](README.md) | Public-facing overview, installation, and usage. |
-| [.claude/rules/component-architecture.md](.claude/rules/component-architecture.md) | Component-level design choices — lv1 / lv2 folders, compound vs flat, `asChild` not adopted, unified context consumption, one-way dependency direction, lv1-local `.css` criteria. |
+| [.claude/rules/component-architecture.md](.claude/rules/component-architecture.md) | Component-level design choices — lv1 / lv2 folders, compound vs flat, `asChild` default-off for new lv1s + hard exclusions, unified context consumption, one-way dependency direction, lv1-local `.css` criteria. |
 | [.claude/rules/component-api-conventions.md](.claude/rules/component-api-conventions.md) | Public prop API shape — Role-based (Button) vs Tone × Shape (Badge/Callout/Toast) patterns, common props, `asChild` criteria. |
 | [.claude/rules/storybook-guideline.md](.claude/rules/storybook-guideline.md) | Storybook conventions — Playground story, `argTypes`, grouping. |
 | [.claude/rules/state-token-guideline.md](.claude/rules/state-token-guideline.md) | 3-layer token system, 4-token shape, `destructive` vs `error`. |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,6 +34,7 @@ src/
 
 Before adding or modifying components, read the guideline files under [`.claude/rules/`](.claude/rules):
 
+- [`component-architecture.md`](.claude/rules/component-architecture.md) — lv1 vs lv2 folder responsibilities, compound vs flat, `asChild` not adopted on new components (with `buttonVariants` / `textVariants` as the replacement pattern), polymorphic `as` not adopted, unified `FieldContext` consumption, one-way dependency direction (lv1 → lv2 forbidden, no barrel laundering), when an lv1-local `.css` file is allowed.
 - [`component-api-conventions.md`](.claude/rules/component-api-conventions.md) — Public prop API shape: two patterns (**Role-based** for action components like `Button`; **Tone × Shape** for state components like `Badge` / `Callout` / `Toast`), per-component matrix, common props (`size` / `isError` / `isLoading` / `disabled` / `readOnly`), and `asChild` adoption criteria.
 - [`storybook-guideline.md`](.claude/rules/storybook-guideline.md) — Story structure (`Playground` story first, group by prop), `argTypes`, English-only labels.
 - [`state-token-guideline.md`](.claude/rules/state-token-guideline.md) — 3-layer token system, state semantic tokens (`error` / `success` / `warning` / `info` / `destructive`) and the 4-token shape (`base` / `hover` / `foreground` / `subtle`).
@@ -71,7 +72,8 @@ pnpm changeset         # Create a changeset for user-facing changes
 |---|---|
 | [CLAUDE.md](CLAUDE.md) | Claude Code-specific tech stack and rule index. |
 | [README.md](README.md) | Public-facing overview, installation, and usage. |
-| [.claude/rules/component-api-conventions.md](.claude/rules/component-api-conventions.md) | Public prop API shape: Role-based (Button) vs Tone × Shape (Badge/Callout/Toast) patterns, common props, `asChild` criteria. |
+| [.claude/rules/component-architecture.md](.claude/rules/component-architecture.md) | Component-level design choices — lv1 / lv2 folders, compound vs flat, `asChild` not adopted, unified context consumption, one-way dependency direction, lv1-local `.css` criteria. |
+| [.claude/rules/component-api-conventions.md](.claude/rules/component-api-conventions.md) | Public prop API shape — Role-based (Button) vs Tone × Shape (Badge/Callout/Toast) patterns, common props, `asChild` criteria. |
 | [.claude/rules/storybook-guideline.md](.claude/rules/storybook-guideline.md) | Storybook conventions — Playground story, `argTypes`, grouping. |
 | [.claude/rules/state-token-guideline.md](.claude/rules/state-token-guideline.md) | 3-layer token system, 4-token shape, `destructive` vs `error`. |
 | [.claude/rules/field-context-guideline.md](.claude/rules/field-context-guideline.md) | `FieldContext` patterns for form components. |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,6 +28,7 @@ When adding or modifying components, follow shadcn/ui conventions (Radix UI + CV
 
 ## Guidelines
 
+- See [.claude/rules/component-architecture.md](.claude/rules/component-architecture.md) for component-level design choices (lv1 vs lv2 folders, compound vs flat, `asChild` not adopted, polymorphic `as` not adopted, unified context consumption, one-way dependency direction, when an lv1-local `.css` file is allowed)
 - See [.claude/rules/component-api-conventions.md](.claude/rules/component-api-conventions.md) for the public prop API shape — the two patterns (Role-based / Tone × Shape), per-component matrix, common props (`size` / `isError` / `isLoading` / `disabled` / `readOnly`), and `asChild` criteria
 - See [.claude/rules/storybook-guideline.md](.claude/rules/storybook-guideline.md) for Storybook conventions
 - See [.claude/rules/field-context-guideline.md](.claude/rules/field-context-guideline.md) for Field context integration patterns

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,7 @@ When adding or modifying components, follow shadcn/ui conventions (Radix UI + CV
 
 ## Guidelines
 
-- See [.claude/rules/component-architecture.md](.claude/rules/component-architecture.md) for component-level design choices (lv1 vs lv2 folders, compound vs flat, `asChild` not adopted, polymorphic `as` not adopted, unified context consumption, one-way dependency direction, when an lv1-local `.css` file is allowed)
+- See [.claude/rules/component-architecture.md](.claude/rules/component-architecture.md) for component-level design choices (lv1 vs lv2 folders, compound vs flat, `asChild` default-off for new lv1s + hard exclusions on form inputs / portal content, polymorphic `as` not adopted, unified context consumption, one-way dependency direction, when an lv1-local `.css` file is allowed)
 - See [.claude/rules/component-api-conventions.md](.claude/rules/component-api-conventions.md) for the public prop API shape — the two patterns (Role-based / Tone × Shape), per-component matrix, common props (`size` / `isError` / `isLoading` / `disabled` / `readOnly`), and `asChild` criteria
 - See [.claude/rules/storybook-guideline.md](.claude/rules/storybook-guideline.md) for Storybook conventions
 - See [.claude/rules/field-context-guideline.md](.claude/rules/field-context-guideline.md) for Field context integration patterns


### PR DESCRIPTION
## Summary

lv1 / lv2 の責務分離、compound vs flat、`asChild` 採否、polymorphic `as` の方針、Context 消費の統一ルール、依存方向の規範、lv1 内 `.css` の許容基準など、コンポーネント追加・拡張時の設計判断を [`.claude/rules/component-architecture.md`](.claude/rules/component-architecture.md) に 7 セクションで明文化した。

closes #101 / 親: v0.6.0

## 主な内容

### §1 lv1 / lv2 — フォルダの責務分離
- lv1 = プリミティブ (単一責務)、lv2 = lv1 の合成
- 昇格基準 (「3 lv1s × 2 consumer products」など) は意図的に保留。v0.9.0 で最初の lv2 が land するタイミングで別 rule として定義する

### §2 compound vs flat
- **compound** (Radix wrap 時のデフォルト): Dialog / Tooltip / Select / Radio。Radix の part 名と 1:1 (`SelectTrigger` = `SelectPrimitive.Trigger`)
- **flat** (自前のデフォルト): Button / Input / Badge / Callout / Spinner / Text / Textarea / Field / FieldSet / Checkbox / Switch
- 自前で合成が必要なら lv2 (compound lv1 にしない)
- Toast は imperative API の特殊例として明記

### §3 `asChild` は新規 lv1 では採用しない
- 代替パターンとして既に export 済みの **CVA variants 関数** (`buttonVariants` / `textVariants`) を使う
- 既存の `Button.asChild` / `Text.asChild` は legacy として残し、削除を別 issue で追跡 → #193
- form input / Portal レンダリング parts には今後も採用しない
- `TooltipTrigger` の「公開 API から `Omit<…, 'asChild'>` で除外し内部で自動判定」パターンを Trigger 系のテンプレとして明記

### §4 polymorphic `as` prop は採用しない
- `<Button as=\"a\">` のような generic polymorphic API は採用しない (型推論複雑化、forwardRef 衝突)
- carved exception: **Text の `as: 'p' | 'span' | 'h1'…'h6'`** (固定 enum、同一属性面、union ≤8、推論コストゼロ)
- 判定の rule of thumb: 任意 `ElementType` を受けるなら却下、閉じた enum で属性面が一致するなら PR で正当化した上で許容

### §5 Context 消費の統一ルール
- **全 form lv1 が `FieldContext` から `isError` / `disabled` / `describedBy` を消費** (prop fallback あり)
- `id` は「外部ラベル ↔ input element の hookup 用」に限定 → `Input` / `Textarea` / `Select` のみ消費
- `Checkbox` / `Switch` / `Radio` は自身で内部ラベルを生成するため `field?.id` を消費しない
- `FieldSetContext` は `Field` のみが消費し collapse-and-provide。**form lv1 は `FieldSetContext` を直接読まない**

### §6 依存方向は一方向
| Layer | May import from |
|---|---|
| `lib/` | external のみ |
| `contexts/`, `variants/` | external のみ |
| `components/lv1/` | `lib/`, `contexts/`, `variants/`, 他の lv1 |
| `components/lv2/` | `lib/`, `contexts/`, `variants/`, `lv1/`, 他の lv2 |

- **lv1 → lv2 は禁止** (必要になったら lv2 へ昇格)
- **lv1 → 他の lv1 は許容** (Dialog 内で Button を使う等の構造的合成)
- **barrel 経由の laundering 禁止** (lv2 が `cn` を欲しい時は `lib/utils` 直接、`lv1/index.ts` 経由 NG)

### §7 lv1 内 `.css` 許容基準
- 許容: `@keyframes` / `animation-play-state` 等の `[data-state]` 条件付 / `prefers-reduced-motion` / コンポ固有 CSS 変数
- 不許容: 静的色・spacing・タイポ / hover/focus styles / light/dark 調整 / layout
- 既存 4 ファイル (Tooltip.css / Dialog.css / Toast.css / Spinner.css) は全て animation-only で許容基準を満たすことを個別検証して記載

## 棚卸し結果

- **lv1/lv2 配置**: lv2 は空、違反なし
- **compound vs flat**: 既存全コンポーネントが分類どおり
- **asChild**: Button / Text のみ採用 (legacy 扱いとして §3 に明記、#193 で削除)。form input / Portal parts では未採用
- **polymorphic `as`**: Text のみ採用 (carved exception として §4 で明文化)
- **依存方向**: 違反なし
- **lv1 内 `.css`**: Tooltip / Dialog / Toast / Spinner の 4 ファイルが許容基準を満たす

## 横展開

- [CLAUDE.md](CLAUDE.md) Guidelines + [AGENTS.md](AGENTS.md) Required reading / Resource Map から参照
- [`.claude/commands/review-pr.md`](.claude/commands/review-pr.md) のチェックリストに本 rule への準拠項目を追加

## 関連

- Parent issue: #101
- 子 issue (実装側): #193 (Button.asChild / Text.asChild 削除 → variants 関数 API へ移行)

## Test plan

本 PR は rule 文書化のみで public API / コンポーネント挙動の変更なし。

- [x] `pnpm typecheck` (pre-commit hook で実行済み)
- [x] CLAUDE.md / AGENTS.md / review-pr.md の index 同期
- [x] Changeset (patch bump) 追加

🤖 Generated with [Claude Code](https://claude.com/claude-code)