### PR TITLE
refactor(themes): apply data-theme + --color-theme-* renames

### DIFF
--- a/.changeset/rename-color-primary-to-color-theme.md
+++ b/.changeset/rename-color-primary-to-color-theme.md
@@ -1,0 +1,51 @@
+---
+'@yasmro/schatten': patch
+---
+
+refactor(tokens): rename `--color-primary-*` → `--color-theme-*` (and `bg-primary-*` utilities → `bg-theme-*`)
+
+The CSS variable that drives the Special-axis color scale is renamed from
+`--color-primary-*` to `--color-theme-*`, matching the `data-theme` attribute
+that controls it. The legacy `--color-primary-*` name conflated "the brand's
+primary color" with "the slot the active theme drives" — the new name fixes
+the conflation. See [`.claude/rules/theme-architecture.md`](.claude/rules/theme-architecture.md)
+(PR #189) for the full Mode × Special two-axis model.
+
+Changes:
+
+- [`src/core/tokens/semantic.css`](src/core/tokens/semantic.css) — the default
+  chain `--color-primary-50..950: var(--blue-*)` becomes `--color-theme-50..950`.
+- [`src/core/tokens/base.css`](src/core/tokens/base.css) — Tailwind v4 `@theme`
+  registration updated, so `bg-theme-500` / `text-theme-600` / etc. are the
+  generated utility classes.
+- [`src/themes/default/colors.css`](src/themes/default/colors.css) — default
+  theme references the new names.
+- [`src/themes/seasonal/themes.css`](src/themes/seasonal/themes.css) — eight
+  seasonal palettes (88 declarations + the transition list) use the new names.
+- [`src/tokens.ts`](src/tokens.ts) — the TS-typed `tokens.color` export renames
+  `primary50..primary950` keys to `theme50..theme950`, pointing at
+  `var(--color-theme-*)`.
+- [`src/docs/Color.stories.tsx`](src/docs/Color.stories.tsx) — the "Primary"
+  scale subsection becomes "Theme" and uses `bg-theme-*` utilities.
+
+This is a breaking change for any consumer that references `--color-primary-*`,
+`bg-primary-*` / `text-primary-*` / `border-primary-*` utility classes, or the
+`tokens.color.primary*` TS keys. Migrate via:
+
+```diff
+- background-color: var(--color-primary-500);
++ background-color: var(--color-theme-500);
+
+- <div className="bg-primary-500" />
++ <div className="bg-theme-500" />
+
+- const fill = tokens.color.primary500
++ const fill = tokens.color.theme500
+```
+
+The `info` semantic is unaffected — it remains pinned to `blue-*` directly,
+independent of the theme scale. Action-component `variant="primary"` (on
+`Button`) is also unaffected — that's a *role* name, not a token name.
+
+Out of scope (lands in v0.7.0): allowlist enforcement, 16-pattern audit story,
+and the matching `data-season` → `data-theme` rename (shipped separately).

--- a/.changeset/rename-data-season-to-data-theme.md
+++ b/.changeset/rename-data-season-to-data-theme.md
@@ -1,0 +1,38 @@
+---
+'@yasmro/schatten': patch
+---
+
+refactor(themes): rename `data-season` → `data-theme` with `season--*` value prefix
+
+The seasonal theming attribute is renamed from `data-season="<name>"` to the
+unified `data-theme="season--<name>"`, matching the Mode × Special two-axis
+model documented in [`.claude/rules/theme-architecture.md`](.claude/rules/theme-architecture.md)
+(PR #189). The single `data-theme` attribute is now the channel for *every*
+Special theme (seasonal, brand, vendor, one-off) — the family is encoded in
+the value, not in a proliferation of attribute names.
+
+Changes:
+
+- [`src/themes/seasonal/themes.css`](src/themes/seasonal/themes.css) — the eight
+  `:root[data-season="X"]` selectors become `:root[data-theme="season--X"]`.
+- [`src/themes/seasonal/index.ts`](src/themes/seasonal/index.ts) — `applySeasonTheme`
+  / `getSeasonAttribute` / `removeSeasonTheme` keep their function names; only
+  the underlying attribute name + value transform change.
+- [`.storybook/preview.tsx`](.storybook/preview.tsx) — the Storybook theme toolbar
+  decorator follows the same transform.
+- [`src/docs/Color.stories.tsx`](src/docs/Color.stories.tsx) — text reference updated.
+
+This is a breaking change for any consumer that targets `[data-season=...]` in
+their own CSS, or sets the attribute manually. Migrate via:
+
+```diff
+- <html data-season="spring-early">
++ <html data-theme="season--spring-early">
+```
+
+Consumers using the SDK helpers (`applySeasonTheme`, `getSeasonAttribute`,
+`removeSeasonTheme`) require no code change — the new attribute is applied
+transparently.
+
+Out of scope (lands in v0.7.0): allowlist enforcement, 16-pattern (8 Specials
+× 2 Modes) Storybook audit story.

--- a/.claude/rules/state-token-guideline.md
+++ b/.claude/rules/state-token-guideline.md
@@ -19,7 +19,7 @@ Layer 2: Semantic (meaning — light/dark mapping happens here)
    destructive ◀── vermillion ──▶ error
    success     ◀── green
    warning     ◀── amber
-   info        ◀── blue (independent of `primary`)
+   info        ◀── blue (independent of the theme scale)
 
 Layer 3: Components (consume semantic only)
    bg-error / text-error / border-error / ring-error / bg-error-subtle ...
@@ -58,11 +58,11 @@ no component churn.
 **Rule**: form components and notification components reference `error-*`. Action surfaces
 reference `destructive-*`.
 
-## `info` independence from `primary`
+## `info` independence from the theme scale
 
-`info` references `blue-*` directly rather than `primary-*`. Themes that retune `primary`
-(seasonal themes, custom brand themes) **must not** drift `info`'s meaning. Keep `info`
-pinned to blue.
+`info` references `blue-*` directly rather than `theme-*`. Themes that retune the
+theme scale (seasonal themes, custom brand themes) **must not** drift `info`'s
+meaning. Keep `info` pinned to blue.
 
 ## Light / dark mapping
 

--- a/.claude/rules/theme-architecture.md
+++ b/.claude/rules/theme-architecture.md
@@ -73,25 +73,13 @@ belongs to Mode.
 Rule of thumb: anything that expresses *brand character* — seasonality, an
 event identity, a customer's palette — belongs to Special.
 
-> **Deprecation: `--color-primary-*` → `--color-theme-*`**.
-> The shipping variable in
-> [`src/core/tokens/semantic.css`](../../src/core/tokens/semantic.css) is
-> `--color-primary-50..950` (with matching Tailwind utilities
-> `bg-primary-500`, `text-primary-600`, …). This name predates the
-> two-axis model and conflates "the brand's primary color" with "the
-> slot the active theme drives." The canonical name is **`--color-theme-*`**,
-> matching the `data-theme` attribute that controls it. Equivalent
-> Tailwind utilities will be `bg-theme-500`, `text-theme-600`, …. The
-> actual rename ships in **v0.7.0** — see [v0.7.0 migration plan](#v070-migration-plan)
-> for what changes and how to write code in the meantime.
-
 ### Tokens neither axis touches
 
 A few tokens are pinned by intent and **must not** be moved by either axis:
 
 - `--color-info-*` references `blue-*` directly. Themes that retune the
   theme scale must not drift `info`'s meaning. See
-  [state-token-guideline](state-token-guideline.md#info-independence-from-primary).
+  [state-token-guideline](state-token-guideline.md#info-independence-from-the-theme-scale).
 - Primitives (`--vermillion-*`, `--green-*`, `--blue-*`, …) are theme-agnostic
   by definition and live one layer below semantics.
 
@@ -212,15 +200,6 @@ one-off — sets the same `data-theme` attribute. There is no `data-season`
 / `data-event` / `data-brand` proliferation; family is encoded in the
 value, not in the attribute name.
 
-> **Deprecation: `data-season` → `data-theme`**.
-> [`src/themes/seasonal/themes.css`](../../src/themes/seasonal/themes.css)
-> and the helpers in [`src/themes/seasonal/index.ts`](../../src/themes/seasonal/index.ts)
-> currently use `data-season="<name>"`. This is deprecated. The canonical
-> form is `data-theme="season--<name>"` (e.g. `data-season="spring-early"`
-> → `data-theme="season--spring-early"`). The actual rename ships in
-> v0.7.0 — see [v0.7.0 migration plan](#v070-migration-plan) for what
-> changes and the authoring rule in the meantime.
-
 **Why `<html>` and not `<body>`.** Storybook, Tailwind v4 `dark:`, and most
 SSR frameworks already key off `<html class="...">`. Putting Mode and
 Special on the same element keeps the cascade predictable and means a
@@ -240,12 +219,6 @@ Three layers work together:
    (`bg-theme-500`, `text-theme-600`, …) compile to
    `background-color: var(--color-theme-500)`, so they participate in
    the same cascade.
-
-> The example code below uses the **canonical** `--color-theme-*` /
-> `bg-theme-*` names. The shipping code still uses the legacy
-> `--color-primary-*` / `bg-primary-*`; the rename ships in v0.7.0 (see
-> the deprecation note above). Mentally substitute the legacy name when
-> reading current source.
 
 ### Worked trace: `data-theme="season--spring-early"` → pink button
 
@@ -275,8 +248,8 @@ Three layers work together:
 ### Concretely, in this repo
 
 - [`src/core/tokens/primitives.css`](../../src/core/tokens/primitives.css) — `:root { --blue-500: oklch(...); }` (frozen primitives)
-- [`src/core/tokens/semantic.css`](../../src/core/tokens/semantic.css) — `:root { --color-theme-500: var(--blue-500); }` (default chain; legacy name: `--color-primary-500`)
-- [`src/themes/seasonal/themes.css`](../../src/themes/seasonal/themes.css) — `:root[data-theme="season--spring-early"] { --color-theme-500: oklch(...); }` (override; today shipping as `:root[data-season="spring-early"] { --color-primary-500: oklch(...); }`)
+- [`src/core/tokens/semantic.css`](../../src/core/tokens/semantic.css) — `:root { --color-theme-500: var(--blue-500); }` (default chain)
+- [`src/themes/seasonal/themes.css`](../../src/themes/seasonal/themes.css) — `:root[data-theme="season--spring-early"] { --color-theme-500: oklch(...); }` (override)
 - [`src/core/tokens/base.css`](../../src/core/tokens/base.css) — `@theme { --color-theme-500: var(--color-theme-500); }`. The self-referential look is intentional: the right-hand `var(--color-theme-500)` reads the value defined in `semantic.css`; the left-hand declaration tells Tailwind v4 "this variable is a theme token — generate utilities for it." Without `@theme`, the variable exists but `bg-theme-500` won't be a usable class.
 - Component — `<Button className="bg-theme-500" />` → Tailwind emits `.bg-theme-500 { background-color: var(--color-theme-500); }` → browser resolves the `var()` against the cascade at paint time.
 
@@ -296,24 +269,19 @@ Three layers work together:
 
 The eight seasonal palettes in [`src/themes/seasonal/themes.css`](../../src/themes/seasonal/themes.css)
 already follow the Special-axis pattern in practice: each overrides only
-the theme scale (`--color-primary-*` today; renamed to `--color-theme-*`
-in v0.7.0). The table below restates that contract in the new
-model so future authors can replicate it.
+the theme scale (`--color-theme-*`). The table below restates that contract
+so future authors can replicate it.
 
-| `data-theme` value (canonical) | Legacy `data-season` (deprecated) | Hue | Period | `allowedTokens` |
-|---|---|---|---|---|
-| `season--spring-early` | `spring-early` | 12  | 2/4 – 3/20  | `--color-theme-*` |
-| `season--spring-late`  | `spring-late`  | 138 | 3/21 – 5/5  | `--color-theme-*` |
-| `season--summer-early` | `summer-early` | 162 | 5/6 – 6/20  | `--color-theme-*` |
-| `season--summer-peak`  | `summer-peak`  | 45  | 6/21 – 8/6  | `--color-theme-*` |
-| `season--autumn-early` | `autumn-early` | 230 | 8/7 – 9/22  | `--color-theme-*` |
-| `season--autumn-late`  | `autumn-late`  | 70  | 9/23 – 11/6 | `--color-theme-*` |
-| `season--winter-early` | `winter-early` | 250 | 11/7 – 12/21 | `--color-theme-*` |
-| `season--winter-deep`  | `winter-deep`  | 0/240 | 12/22 – 2/3 | `--color-theme-*` |
-
-(In the shipping code today the `allowedTokens` is `--color-primary-*`;
-both names refer to the same slot — see the deprecation note in
-[Special owns the expressive layer](#special-owns-the-expressive-layer).)
+| `data-theme` value | Hue | Period | `allowedTokens` |
+|---|---|---|---|
+| `season--spring-early` | 12  | 2/4 – 3/20  | `--color-theme-*` |
+| `season--spring-late`  | 138 | 3/21 – 5/5  | `--color-theme-*` |
+| `season--summer-early` | 162 | 5/6 – 6/20  | `--color-theme-*` |
+| `season--summer-peak`  | 45  | 6/21 – 8/6  | `--color-theme-*` |
+| `season--autumn-early` | 230 | 8/7 – 9/22  | `--color-theme-*` |
+| `season--autumn-late`  | 70  | 9/23 – 11/6 | `--color-theme-*` |
+| `season--winter-early` | 250 | 11/7 – 12/21 | `--color-theme-*` |
+| `season--winter-deep`  | 0/240 | 12/22 – 2/3 | `--color-theme-*` |
 
 No existing seasonal theme touches surfaces, foregrounds, borders, accent,
 state colors, or info. **That is the contract** — keep it that way when
@@ -338,8 +306,7 @@ the Storybook theme global on the relevant Color / Foundation stories.
    the Theme Audit story but does not create a separate axis.
 2. **List the tokens you intend to override** as a comment at the top of
    the CSS file. Today's seasonals override the theme scale only
-   (`--color-primary-50..950` in current code; `--color-theme-50..950`
-   after the v0.7.0 rename) — match that scope unless you have a
+   (`--color-theme-50..950`) — match that scope unless you have a
    documented reason to expand.
 3. **Never override Mode-owned tokens** — surfaces, foregrounds, borders,
    inverted foregrounds, focus ring, state colors. A Special that needs to
@@ -374,39 +341,15 @@ The public API and packaging story are out of scope for this rule.
 
 ## v0.7.0 migration plan
 
-This rule prescribes canonical names (`data-theme`, `--color-theme-*`,
-`bg-theme-*`) and a value convention (`<family>--<variant>`) that are not
-yet reflected in shipping code. Four related changes close the gap in
-**v0.7.0**:
+Two follow-up changes still close the gap to the full Mode × Special
+model. Both depend on the `data-theme` / `--color-theme-*` rename that
+shipped in v0.6.x and ride on the canonical names this rule already
+prescribes:
 
 | # | Change | Files affected |
 |---|---|---|
-| 1 | `data-season` → `data-theme` with value transform `X` → `season--X` | `themes/seasonal/themes.css`, `themes/seasonal/index.ts`, `docs/Color.stories.tsx` |
-| 2 | `--color-primary-*` → `--color-theme-*` (and `bg-primary-*` → `bg-theme-*` in components) | `core/tokens/semantic.css`, `core/tokens/base.css`, `themes/default/colors.css`, `themes/seasonal/themes.css`, every component referencing `*-primary-*` |
-| 3 | Allowlist enforcement — build-time lint that fails when a Special writes a token outside its `allowedTokens` | new lint rule + per-Special manifest files |
-| 4 | 16-pattern Storybook audit story (8 Specials × 2 Modes) | new `Foundation/ThemeAudit` story |
-
-Renames #1 and #2 can ship in isolation (they're mechanical sed-style
-replacements with VRT snapshot regeneration); #3 and #4 depend on #1 and
-#2 having landed first.
-
-### Authoring rule until v0.7.0
-
-The canonical names in this rule describe the **target state**. The
-shipping code still uses the legacy names. **Until #1 and #2 land,
-write the legacy names in code** — that's what the build emits as
-Tailwind utilities today:
-
-| Write today | After v0.7.0 |
-|---|---|
-| `data-season="spring-early"` | `data-theme="season--spring-early"` |
-| `--color-primary-500` | `--color-theme-500` |
-| `bg-primary-500`, `text-primary-600`, … | `bg-theme-500`, `text-theme-600`, … |
-
-The v0.7.0 PR will mechanically rename them. Do **not** introduce *new
-patterns* the legacy names accidentally enable — e.g. don't add a `primary`
-reference that you'd want to keep meaning "fixed brand primary, ignore
-themes" after the rename; that's exactly the conflation the new name fixes.
+| 1 | Allowlist enforcement — build-time lint that fails when a Special writes a token outside its `allowedTokens` | new lint rule + per-Special manifest files |
+| 2 | 16-pattern Storybook audit story (8 Specials × 2 Modes) | new `Foundation/ThemeAudit` story |
 
 ## Quick reference
 

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -83,9 +83,9 @@ const preview: Preview = {
 
         // Apply season theme
         if (season && season !== 'none') {
-          root.setAttribute('data-season', season)
+          root.setAttribute('data-theme', `season--${season}`)
         } else {
-          root.removeAttribute('data-season')
+          root.removeAttribute('data-theme')
         }
       }, [isDark, season])
 

--- a/src/core/tokens/base.css
+++ b/src/core/tokens/base.css
@@ -189,18 +189,18 @@
   --color-purple-900: var(--purple-900);
   --color-purple-950: var(--purple-950);
 
-  /* Primary scale (from semantic.css) */
-  --color-primary-50: var(--color-primary-50);
-  --color-primary-100: var(--color-primary-100);
-  --color-primary-200: var(--color-primary-200);
-  --color-primary-300: var(--color-primary-300);
-  --color-primary-400: var(--color-primary-400);
-  --color-primary-500: var(--color-primary-500);
-  --color-primary-600: var(--color-primary-600);
-  --color-primary-700: var(--color-primary-700);
-  --color-primary-800: var(--color-primary-800);
-  --color-primary-900: var(--color-primary-900);
-  --color-primary-950: var(--color-primary-950);
+  /* Theme scale (from semantic.css) */
+  --color-theme-50: var(--color-theme-50);
+  --color-theme-100: var(--color-theme-100);
+  --color-theme-200: var(--color-theme-200);
+  --color-theme-300: var(--color-theme-300);
+  --color-theme-400: var(--color-theme-400);
+  --color-theme-500: var(--color-theme-500);
+  --color-theme-600: var(--color-theme-600);
+  --color-theme-700: var(--color-theme-700);
+  --color-theme-800: var(--color-theme-800);
+  --color-theme-900: var(--color-theme-900);
+  --color-theme-950: var(--color-theme-950);
 
   /*
    * Typography

--- a/src/core/tokens/semantic.css
+++ b/src/core/tokens/semantic.css
@@ -7,18 +7,18 @@
  */
 
 :root {
-  /* Primary - will be overridden by themes */
-  --color-primary-50: var(--blue-50);
-  --color-primary-100: var(--blue-100);
-  --color-primary-200: var(--blue-200);
-  --color-primary-300: var(--blue-300);
-  --color-primary-400: var(--blue-400);
-  --color-primary-500: var(--blue-500);
-  --color-primary-600: var(--blue-600);
-  --color-primary-700: var(--blue-700);
-  --color-primary-800: var(--blue-800);
-  --color-primary-900: var(--blue-900);
-  --color-primary-950: var(--blue-950);
+  /* Theme scale — overridden by Special themes via [data-theme] */
+  --color-theme-50: var(--blue-50);
+  --color-theme-100: var(--blue-100);
+  --color-theme-200: var(--blue-200);
+  --color-theme-300: var(--blue-300);
+  --color-theme-400: var(--blue-400);
+  --color-theme-500: var(--blue-500);
+  --color-theme-600: var(--blue-600);
+  --color-theme-700: var(--blue-700);
+  --color-theme-800: var(--blue-800);
+  --color-theme-900: var(--blue-900);
+  --color-theme-950: var(--blue-950);
 
   /* Surfaces */
   --color-background: var(--paper-warm);
@@ -61,7 +61,7 @@
 
   /*
    * Inverted foreground tiers — for text on saturated / dark-background
-   * containers (solid Toast / Callout, primary-colored fills, …).
+   * containers (solid Toast / Callout, theme-colored fills, …).
    * Each tier becomes progressively less prominent against the
    * saturated background, mirroring the foreground / -muted / -subtle
    * hierarchy.
@@ -96,7 +96,7 @@
   --color-warning-foreground: var(--paper-white);
   --color-warning-subtle: var(--amber-50);
 
-  /* Info — references blue directly so themes that retune `primary` do not affect info */
+  /* Info — references blue directly so themes that retune the theme scale do not affect info */
   --color-info: var(--blue-600);
   --color-info-hover: var(--blue-700);
   --color-info-foreground: var(--paper-white);

--- a/src/docs/Color.stories.tsx
+++ b/src/docs/Color.stories.tsx
@@ -362,24 +362,24 @@ export const Colors: Story = {
 
       <SectionTitle>Color Scales</SectionTitle>
 
-      <SubsectionTitle>Primary</SubsectionTitle>
+      <SubsectionTitle>Theme</SubsectionTitle>
       <p className="text-sm text-foreground-muted mb-3">
-        Primary color scale mapped from theme tokens. The default theme uses blue; seasonal themes
-        override this entire scale.
+        Theme color scale mapped from semantic tokens. The default theme uses blue; seasonal themes
+        override this entire scale via the <code>data-theme</code> attribute.
       </p>
       <ScaleRow
         shades={[
-          { level: '50', className: 'bg-primary-50' },
-          { level: '100', className: 'bg-primary-100' },
-          { level: '200', className: 'bg-primary-200' },
-          { level: '300', className: 'bg-primary-300' },
-          { level: '400', className: 'bg-primary-400' },
-          { level: '500', className: 'bg-primary-500' },
-          { level: '600', className: 'bg-primary-600' },
-          { level: '700', className: 'bg-primary-700' },
-          { level: '800', className: 'bg-primary-800' },
-          { level: '900', className: 'bg-primary-900' },
-          { level: '950', className: 'bg-primary-950' },
+          { level: '50', className: 'bg-theme-50' },
+          { level: '100', className: 'bg-theme-100' },
+          { level: '200', className: 'bg-theme-200' },
+          { level: '300', className: 'bg-theme-300' },
+          { level: '400', className: 'bg-theme-400' },
+          { level: '500', className: 'bg-theme-500' },
+          { level: '600', className: 'bg-theme-600' },
+          { level: '700', className: 'bg-theme-700' },
+          { level: '800', className: 'bg-theme-800' },
+          { level: '900', className: 'bg-theme-900' },
+          { level: '950', className: 'bg-theme-950' },
         ]}
       />
 
@@ -425,8 +425,7 @@ export const Colors: Story = {
 
       <SubsectionTitle>Blue</SubsectionTitle>
       <p className="text-sm text-foreground-muted mb-3">
-        Default primary color. Used as the base for the Primary scale when no seasonal theme is
-        active.
+        Default theme color. Used as the base for the Theme scale when no seasonal theme is active.
       </p>
       <ScaleRow
         shades={[
@@ -536,8 +535,9 @@ export const Colors: Story = {
       <p className="text-sm text-foreground-muted mb-4">
         Eight seasonal color themes based on the Japanese 二十四節気 (24 solar terms). Each theme
         overrides the primary color scale via the{' '}
-        <code className="text-xs bg-gray-100 px-1.5 py-0.5 rounded">data-season</code> attribute on
-        the root element.
+        <code className="text-xs bg-gray-100 px-1.5 py-0.5 rounded">data-theme</code> attribute on
+        the root element (values like{' '}
+        <code className="text-xs bg-gray-100 px-1.5 py-0.5 rounded">season--spring-early</code>).
       </p>
       <div className="flex flex-col gap-5">
         {(

--- a/src/themes/default/colors.css
+++ b/src/themes/default/colors.css
@@ -1,16 +1,16 @@
 /*
  * Default Theme
- * Uses blue as the primary color
+ * Uses blue as the theme color scale (no [data-theme] active)
  */
 
 :root {
-  --color-primary-100: var(--blue-100);
-  --color-primary-200: var(--blue-200);
-  --color-primary-300: var(--blue-300);
-  --color-primary-400: var(--blue-400);
-  --color-primary-500: var(--blue-500);
-  --color-primary-600: var(--blue-600);
-  --color-primary-700: var(--blue-700);
-  --color-primary-800: var(--blue-800);
-  --color-primary-900: var(--blue-900);
+  --color-theme-100: var(--blue-100);
+  --color-theme-200: var(--blue-200);
+  --color-theme-300: var(--blue-300);
+  --color-theme-400: var(--blue-400);
+  --color-theme-500: var(--blue-500);
+  --color-theme-600: var(--blue-600);
+  --color-theme-700: var(--blue-700);
+  --color-theme-800: var(--blue-800);
+  --color-theme-900: var(--blue-900);
 }

--- a/src/themes/seasonal/index.ts
+++ b/src/themes/seasonal/index.ts
@@ -61,11 +61,11 @@ export function getCurrentSeason(date: Date = new Date()): SeasonTheme {
 }
 
 /**
- * Get the data-season attribute object for SSR
+ * Get the data-theme attribute object for SSR
  * Use this in Astro/Next.js to set the attribute on <html>
  */
 export function getSeasonAttribute(date: Date = new Date()): Record<string, string> {
-  return { 'data-season': getCurrentSeason(date) }
+  return { 'data-theme': `season--${getCurrentSeason(date)}` }
 }
 
 /**
@@ -78,7 +78,7 @@ export function applySeasonTheme(date: Date = new Date()): SeasonTheme {
   }
 
   const season = getCurrentSeason(date)
-  document.documentElement.setAttribute('data-season', season)
+  document.documentElement.setAttribute('data-theme', `season--${season}`)
   return season
 }
 
@@ -87,5 +87,5 @@ export function applySeasonTheme(date: Date = new Date()): SeasonTheme {
  */
 export function removeSeasonTheme(): void {
   if (typeof document === 'undefined') return
-  document.documentElement.removeAttribute('data-season')
+  document.documentElement.removeAttribute('data-theme')
 }

--- a/src/themes/seasonal/themes.css
+++ b/src/themes/seasonal/themes.css
@@ -5,137 +5,137 @@
  */
 
 /* Spring Early (立春 - 春分前): 桜色・薄紅 */
-:root[data-season="spring-early"] {
-  --color-primary-50: oklch(0.98 0.02 12);
-  --color-primary-100: oklch(0.96 0.04 12);
-  --color-primary-200: oklch(0.91 0.06 12);
-  --color-primary-300: oklch(0.83 0.08 12);
-  --color-primary-400: oklch(0.74 0.09 12);
-  --color-primary-500: oklch(0.64 0.1 12);
-  --color-primary-600: oklch(0.56 0.09 12);
-  --color-primary-700: oklch(0.46 0.08 12);
-  --color-primary-800: oklch(0.36 0.06 12);
-  --color-primary-900: oklch(0.27 0.04 12);
-  --color-primary-950: oklch(0.15 0.03 12);
+:root[data-theme="season--spring-early"] {
+  --color-theme-50: oklch(0.98 0.02 12);
+  --color-theme-100: oklch(0.96 0.04 12);
+  --color-theme-200: oklch(0.91 0.06 12);
+  --color-theme-300: oklch(0.83 0.08 12);
+  --color-theme-400: oklch(0.74 0.09 12);
+  --color-theme-500: oklch(0.64 0.1 12);
+  --color-theme-600: oklch(0.56 0.09 12);
+  --color-theme-700: oklch(0.46 0.08 12);
+  --color-theme-800: oklch(0.36 0.06 12);
+  --color-theme-900: oklch(0.27 0.04 12);
+  --color-theme-950: oklch(0.15 0.03 12);
 }
 
 /* Spring Late (春分 - 立夏前): 若草色・萌黄 */
-:root[data-season="spring-late"] {
-  --color-primary-50: oklch(0.98 0.02 138);
-  --color-primary-100: oklch(0.96 0.04 138);
-  --color-primary-200: oklch(0.91 0.06 138);
-  --color-primary-300: oklch(0.83 0.08 138);
-  --color-primary-400: oklch(0.74 0.09 138);
-  --color-primary-500: oklch(0.64 0.1 138);
-  --color-primary-600: oklch(0.56 0.09 138);
-  --color-primary-700: oklch(0.46 0.08 138);
-  --color-primary-800: oklch(0.36 0.06 138);
-  --color-primary-900: oklch(0.27 0.04 138);
-  --color-primary-950: oklch(0.15 0.03 138);
+:root[data-theme="season--spring-late"] {
+  --color-theme-50: oklch(0.98 0.02 138);
+  --color-theme-100: oklch(0.96 0.04 138);
+  --color-theme-200: oklch(0.91 0.06 138);
+  --color-theme-300: oklch(0.83 0.08 138);
+  --color-theme-400: oklch(0.74 0.09 138);
+  --color-theme-500: oklch(0.64 0.1 138);
+  --color-theme-600: oklch(0.56 0.09 138);
+  --color-theme-700: oklch(0.46 0.08 138);
+  --color-theme-800: oklch(0.36 0.06 138);
+  --color-theme-900: oklch(0.27 0.04 138);
+  --color-theme-950: oklch(0.15 0.03 138);
 }
 
 /* Summer Early (立夏 - 夏至前): 萌葱色・常磐色 */
-:root[data-season="summer-early"] {
-  --color-primary-50: oklch(0.98 0.015 162);
-  --color-primary-100: oklch(0.96 0.03 162);
-  --color-primary-200: oklch(0.91 0.05 162);
-  --color-primary-300: oklch(0.83 0.07 162);
-  --color-primary-400: oklch(0.74 0.08 162);
-  --color-primary-500: oklch(0.64 0.09 162);
-  --color-primary-600: oklch(0.56 0.08 162);
-  --color-primary-700: oklch(0.46 0.07 162);
-  --color-primary-800: oklch(0.36 0.05 162);
-  --color-primary-900: oklch(0.27 0.03 162);
-  --color-primary-950: oklch(0.15 0.02 162);
+:root[data-theme="season--summer-early"] {
+  --color-theme-50: oklch(0.98 0.015 162);
+  --color-theme-100: oklch(0.96 0.03 162);
+  --color-theme-200: oklch(0.91 0.05 162);
+  --color-theme-300: oklch(0.83 0.07 162);
+  --color-theme-400: oklch(0.74 0.08 162);
+  --color-theme-500: oklch(0.64 0.09 162);
+  --color-theme-600: oklch(0.56 0.08 162);
+  --color-theme-700: oklch(0.46 0.07 162);
+  --color-theme-800: oklch(0.36 0.05 162);
+  --color-theme-900: oklch(0.27 0.03 162);
+  --color-theme-950: oklch(0.15 0.02 162);
 }
 
 /* Summer Peak (夏至 - 立秋前): 朱色・柿色 */
-:root[data-season="summer-peak"] {
-  --color-primary-50: oklch(0.98 0.02 45);
-  --color-primary-100: oklch(0.96 0.04 45);
-  --color-primary-200: oklch(0.91 0.07 45);
-  --color-primary-300: oklch(0.83 0.09 45);
-  --color-primary-400: oklch(0.74 0.1 45);
-  --color-primary-500: oklch(0.64 0.11 45);
-  --color-primary-600: oklch(0.56 0.1 45);
-  --color-primary-700: oklch(0.46 0.08 45);
-  --color-primary-800: oklch(0.36 0.06 45);
-  --color-primary-900: oklch(0.27 0.04 45);
-  --color-primary-950: oklch(0.15 0.03 45);
+:root[data-theme="season--summer-peak"] {
+  --color-theme-50: oklch(0.98 0.02 45);
+  --color-theme-100: oklch(0.96 0.04 45);
+  --color-theme-200: oklch(0.91 0.07 45);
+  --color-theme-300: oklch(0.83 0.09 45);
+  --color-theme-400: oklch(0.74 0.1 45);
+  --color-theme-500: oklch(0.64 0.11 45);
+  --color-theme-600: oklch(0.56 0.1 45);
+  --color-theme-700: oklch(0.46 0.08 45);
+  --color-theme-800: oklch(0.36 0.06 45);
+  --color-theme-900: oklch(0.27 0.04 45);
+  --color-theme-950: oklch(0.15 0.03 45);
 }
 
 /* Autumn Early (立秋 - 秋分前): 浅葱色・薄藍 */
-:root[data-season="autumn-early"] {
-  --color-primary-50: oklch(0.98 0.015 230);
-  --color-primary-100: oklch(0.96 0.03 230);
-  --color-primary-200: oklch(0.91 0.05 230);
-  --color-primary-300: oklch(0.83 0.07 230);
-  --color-primary-400: oklch(0.74 0.08 230);
-  --color-primary-500: oklch(0.64 0.085 230);
-  --color-primary-600: oklch(0.56 0.08 230);
-  --color-primary-700: oklch(0.46 0.07 230);
-  --color-primary-800: oklch(0.36 0.05 230);
-  --color-primary-900: oklch(0.27 0.03 230);
-  --color-primary-950: oklch(0.15 0.02 230);
+:root[data-theme="season--autumn-early"] {
+  --color-theme-50: oklch(0.98 0.015 230);
+  --color-theme-100: oklch(0.96 0.03 230);
+  --color-theme-200: oklch(0.91 0.05 230);
+  --color-theme-300: oklch(0.83 0.07 230);
+  --color-theme-400: oklch(0.74 0.08 230);
+  --color-theme-500: oklch(0.64 0.085 230);
+  --color-theme-600: oklch(0.56 0.08 230);
+  --color-theme-700: oklch(0.46 0.07 230);
+  --color-theme-800: oklch(0.36 0.05 230);
+  --color-theme-900: oklch(0.27 0.03 230);
+  --color-theme-950: oklch(0.15 0.02 230);
 }
 
 /* Autumn Late (秋分 - 立冬前): 山吹色・飴色 */
-:root[data-season="autumn-late"] {
-  --color-primary-50: oklch(0.98 0.02 70);
-  --color-primary-100: oklch(0.96 0.04 70);
-  --color-primary-200: oklch(0.91 0.06 70);
-  --color-primary-300: oklch(0.83 0.08 70);
-  --color-primary-400: oklch(0.74 0.09 70);
-  --color-primary-500: oklch(0.64 0.1 70);
-  --color-primary-600: oklch(0.56 0.09 70);
-  --color-primary-700: oklch(0.46 0.08 70);
-  --color-primary-800: oklch(0.36 0.06 70);
-  --color-primary-900: oklch(0.27 0.04 70);
-  --color-primary-950: oklch(0.15 0.03 70);
+:root[data-theme="season--autumn-late"] {
+  --color-theme-50: oklch(0.98 0.02 70);
+  --color-theme-100: oklch(0.96 0.04 70);
+  --color-theme-200: oklch(0.91 0.06 70);
+  --color-theme-300: oklch(0.83 0.08 70);
+  --color-theme-400: oklch(0.74 0.09 70);
+  --color-theme-500: oklch(0.64 0.1 70);
+  --color-theme-600: oklch(0.56 0.09 70);
+  --color-theme-700: oklch(0.46 0.08 70);
+  --color-theme-800: oklch(0.36 0.06 70);
+  --color-theme-900: oklch(0.27 0.04 70);
+  --color-theme-950: oklch(0.15 0.03 70);
 }
 
 /* Winter Early (立冬 - 冬至前): 銀鼠・薄墨 */
-:root[data-season="winter-early"] {
-  --color-primary-50: oklch(0.98 0.01 250);
-  --color-primary-100: oklch(0.96 0.02 250);
-  --color-primary-200: oklch(0.91 0.03 250);
-  --color-primary-300: oklch(0.83 0.04 250);
-  --color-primary-400: oklch(0.74 0.045 250);
-  --color-primary-500: oklch(0.64 0.048 250);
-  --color-primary-600: oklch(0.56 0.045 250);
-  --color-primary-700: oklch(0.46 0.04 250);
-  --color-primary-800: oklch(0.36 0.03 250);
-  --color-primary-900: oklch(0.27 0.02 250);
-  --color-primary-950: oklch(0.15 0.015 250);
+:root[data-theme="season--winter-early"] {
+  --color-theme-50: oklch(0.98 0.01 250);
+  --color-theme-100: oklch(0.96 0.02 250);
+  --color-theme-200: oklch(0.91 0.03 250);
+  --color-theme-300: oklch(0.83 0.04 250);
+  --color-theme-400: oklch(0.74 0.045 250);
+  --color-theme-500: oklch(0.64 0.048 250);
+  --color-theme-600: oklch(0.56 0.045 250);
+  --color-theme-700: oklch(0.46 0.04 250);
+  --color-theme-800: oklch(0.36 0.03 250);
+  --color-theme-900: oklch(0.27 0.02 250);
+  --color-theme-950: oklch(0.15 0.015 250);
 }
 
 /* Winter Deep (冬至 - 立春前): 藍色・濃紺 */
-:root[data-season="winter-deep"] {
-  --color-primary-50: oklch(0.98 0.015 255);
-  --color-primary-100: oklch(0.96 0.03 255);
-  --color-primary-200: oklch(0.91 0.05 255);
-  --color-primary-300: oklch(0.83 0.06 255);
-  --color-primary-400: oklch(0.74 0.07 255);
-  --color-primary-500: oklch(0.64 0.08 255);
-  --color-primary-600: oklch(0.56 0.07 255);
-  --color-primary-700: oklch(0.46 0.06 255);
-  --color-primary-800: oklch(0.36 0.05 255);
-  --color-primary-900: oklch(0.27 0.03 255);
-  --color-primary-950: oklch(0.15 0.02 255);
+:root[data-theme="season--winter-deep"] {
+  --color-theme-50: oklch(0.98 0.015 255);
+  --color-theme-100: oklch(0.96 0.03 255);
+  --color-theme-200: oklch(0.91 0.05 255);
+  --color-theme-300: oklch(0.83 0.06 255);
+  --color-theme-400: oklch(0.74 0.07 255);
+  --color-theme-500: oklch(0.64 0.08 255);
+  --color-theme-600: oklch(0.56 0.07 255);
+  --color-theme-700: oklch(0.46 0.06 255);
+  --color-theme-800: oklch(0.36 0.05 255);
+  --color-theme-900: oklch(0.27 0.03 255);
+  --color-theme-950: oklch(0.15 0.02 255);
 }
 
 /* Theme transition */
 :root {
   transition:
-    --color-primary-50 0.6s ease,
-    --color-primary-100 0.6s ease,
-    --color-primary-200 0.6s ease,
-    --color-primary-300 0.6s ease,
-    --color-primary-400 0.6s ease,
-    --color-primary-500 0.6s ease,
-    --color-primary-600 0.6s ease,
-    --color-primary-700 0.6s ease,
-    --color-primary-800 0.6s ease,
-    --color-primary-900 0.6s ease,
-    --color-primary-950 0.6s ease;
+    --color-theme-50 0.6s ease,
+    --color-theme-100 0.6s ease,
+    --color-theme-200 0.6s ease,
+    --color-theme-300 0.6s ease,
+    --color-theme-400 0.6s ease,
+    --color-theme-500 0.6s ease,
+    --color-theme-600 0.6s ease,
+    --color-theme-700 0.6s ease,
+    --color-theme-800 0.6s ease,
+    --color-theme-900 0.6s ease,
+    --color-theme-950 0.6s ease;
 }

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -51,18 +51,18 @@ export const tokens = {
     invertedForegroundMuted: 'var(--color-inverted-foreground-muted)',
     invertedForegroundSubtle: 'var(--color-inverted-foreground-subtle)',
 
-    // Primary scale (overridable per theme)
-    primary50: 'var(--color-primary-50)',
-    primary100: 'var(--color-primary-100)',
-    primary200: 'var(--color-primary-200)',
-    primary300: 'var(--color-primary-300)',
-    primary400: 'var(--color-primary-400)',
-    primary500: 'var(--color-primary-500)',
-    primary600: 'var(--color-primary-600)',
-    primary700: 'var(--color-primary-700)',
-    primary800: 'var(--color-primary-800)',
-    primary900: 'var(--color-primary-900)',
-    primary950: 'var(--color-primary-950)',
+    // Theme scale (overridable per Special theme via [data-theme])
+    theme50: 'var(--color-theme-50)',
+    theme100: 'var(--color-theme-100)',
+    theme200: 'var(--color-theme-200)',
+    theme300: 'var(--color-theme-300)',
+    theme400: 'var(--color-theme-400)',
+    theme500: 'var(--color-theme-500)',
+    theme600: 'var(--color-theme-600)',
+    theme700: 'var(--color-theme-700)',
+    theme800: 'var(--color-theme-800)',
+    theme900: 'var(--color-theme-900)',
+    theme950: 'var(--color-theme-950)',
 
     // State — error
     error: 'var(--color-error)',
@@ -82,7 +82,7 @@ export const tokens = {
     warningForeground: 'var(--color-warning-foreground)',
     warningSubtle: 'var(--color-warning-subtle)',
 
-    // State — info (pinned to blue, independent of `primary`)
+    // State — info (pinned to blue, independent of the theme scale)
     info: 'var(--color-info)',
     infoHover: 'var(--color-info-hover)',
     infoForeground: 'var(--color-info-foreground)',


### PR DESCRIPTION
## Summary

`.claude/rules/theme-architecture.md` (added in [#189](https://github.com/yasmro/schatten/pull/189)) prescribed canonical names (`data-theme`, `--color-theme-*`, `bg-theme-*`) that weren't yet reflected in shipping code. This contradiction put AI agents and contributors in an impossible position — "use `bg-theme-500` for new code" while only `bg-primary-500` existed. This PR closes the gap with the two mechanical renames the rule's v0.7.0 migration plan called out as ship-in-isolation candidates.

### Two renames, related but independent

**1. `data-season` → `data-theme` with value transform**

`data-season="X"` → `data-theme="season--X"`. Every Special theme now sets the same `data-theme` attribute; the family is encoded in the value, not in a proliferation of attribute names.

- [src/themes/seasonal/themes.css](src/themes/seasonal/themes.css) — 8 selectors
- [src/themes/seasonal/index.ts](src/themes/seasonal/index.ts) — `applySeasonTheme` / `getSeasonAttribute` / `removeSeasonTheme` keep their function names; only the attribute name + value transform change
- [.storybook/preview.tsx](.storybook/preview.tsx) — Storybook theme toolbar decorator follows the same transform
- [src/docs/Color.stories.tsx](src/docs/Color.stories.tsx) — doc text reference updated

**2. `--color-primary-*` → `--color-theme-*` (and `bg-primary-*` → `bg-theme-*`)**

The new name matches the `data-theme` attribute that drives the slot; the legacy name conflated "brand primary color" with "slot the active theme drives".

- [src/core/tokens/semantic.css](src/core/tokens/semantic.css) — default chain
- [src/core/tokens/base.css](src/core/tokens/base.css) — Tailwind v4 `@theme` registration
- [src/themes/default/colors.css](src/themes/default/colors.css) — default theme
- [src/themes/seasonal/themes.css](src/themes/seasonal/themes.css) — 88 declarations + transition list
- [src/tokens.ts](src/tokens.ts) — TS-typed `tokens.color` keys `primary50..950` → `theme50..950`
- [src/docs/Color.stories.tsx](src/docs/Color.stories.tsx) — `Primary` subsection → `Theme`, `bg-primary-*` → `bg-theme-*`

**Unaffected (intentionally)**:
- `info` remains pinned to `blue-*` directly, independent of the theme scale
- Button's `variant="primary"` is a *role* name (Pattern A action vocabulary), not a token name

### Rule updates

With the renames landed, the deprecation / "use legacy name in code" annotations are removed:

- [.claude/rules/theme-architecture.md](.claude/rules/theme-architecture.md) — two deprecation blocks deleted, the "mentally substitute the legacy name" note deleted, the legacy column in the seasonal-mapping table dropped, and the entire "Authoring rule until v0.7.0" section removed. The v0.7.0 migration plan is trimmed to just the two remaining items (allowlist enforcement, 16-pattern audit story).
- [.claude/rules/state-token-guideline.md](.claude/rules/state-token-guideline.md) — `## info independence from primary` → `## info independence from the theme scale`. The cross-link from theme-architecture.md follows the new anchor.

### Out of scope

- Allowlist enforcement (build-time lint that fails when a Special writes a token outside its `allowedTokens`) → v0.7.0
- 16-pattern Storybook audit story (8 Specials × 2 Modes) → v0.7.0

### Changesets

Two `patch` entries (per v0.6.x patch-release plan), one per rename:
- `.changeset/rename-data-season-to-data-theme.md`
- `.changeset/rename-color-primary-to-color-theme.md`

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm test -- --run` — 273 / 273 passing
- [x] `pnpm build` — bundled CSS contains only `--color-theme-*` names; seasonal output uses `data-theme="season--*"`
- [x] Repo-wide grep confirms zero remaining `data-season` / `--color-primary-` / `bg-primary-*` / `text-primary-*` / `border-primary-*` references
- [ ] VRT — no VRT spec or story references seasonal themes or `bg-primary-*` utilities, so existing baselines are unaffected. Reviewer is encouraged to spot-check the seasonal toolbar in Storybook locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)