### PR TITLE
feat(hook): add .claude/settings.json hooks for lv1 edit-time checks (closes #107)

### DIFF
--- a/.changeset/lv1-edit-hooks.md
+++ b/.changeset/lv1-edit-hooks.md
@@ -1,0 +1,27 @@
+---
+'@yasmro/schatten': patch
+---
+
+chore(hook): add `.claude/settings.json` hooks for lv1 edit-time checks
+
+Adds two non-blocking Claude Code hooks so test/vrt-less `lv1` additions
+get caught at edit time (AI or human), without relying on post-hoc CI.
+
+- **PostToolUse(Edit|Write|MultiEdit)** → [`scripts/check-lv1-companions.mjs`](scripts/check-lv1-companions.mjs).
+  When the edit lands on `src/components/lv1/{X}/{X}.tsx`, verifies that
+  `{X}.test.tsx` and `{X}.vrt.spec.ts` exist as siblings; surfaces a
+  system-reminder via `hookSpecificOutput.additionalContext` if missing.
+- **Stop** → [`scripts/check-lv1-export-integrity.mjs`](scripts/check-lv1-export-integrity.mjs).
+  Diffs `lv1` component directories against the `from './...'` re-exports
+  in `src/components/lv1/index.ts` (both directions, so orphan exports
+  are flagged too).
+
+Both scripts read the Claude Code stdin JSON contract
+(`tool_input.file_path`, `$CLAUDE_PROJECT_DIR`), exit `0` always, and
+emit messages via `additionalContext` so they reach Claude as a
+system-reminder. node-only, no shell dependencies — works on Windows.
+Complements (does not replace) the existing lefthook pre-commit step.
+
+Repo-tooling change only — no source, no published artifact change.
+
+Closes #107.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node $CLAUDE_PROJECT_DIR/scripts/check-lv1-companions.mjs"
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node $CLAUDE_PROJECT_DIR/scripts/check-lv1-export-integrity.mjs"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,3 +39,12 @@ When adding or modifying components, follow shadcn/ui conventions (Radix UI + CV
 - See [.claude/rules/lint-rules-guideline.md](.claude/rules/lint-rules-guideline.md) for the Biome rules added on top of `recommended` and the rationale for each
 - See [.claude/rules/api-stability.md](.claude/rules/api-stability.md) for the public API stability contract (effective from v1.0.0) — what counts as public API across React props, CSS classes, CSS variables, and CVA output, and the breaking-change policy
 - See [.claude/rules/component-testid-guideline.md](.claude/rules/component-testid-guideline.md) for the `data-testid` pass-through policy and the no-auto-testid rule
+
+## Claude Code hooks
+
+`.claude/settings.json` registers two project-level hooks (team-shared, checked into git — distinct from the per-user `.claude/settings.local.json`):
+
+- **PostToolUse(Edit|Write|MultiEdit)** → [scripts/check-lv1-companions.mjs](scripts/check-lv1-companions.mjs). When an edit lands on `src/components/lv1/{X}/{X}.tsx`, verifies that `{X}.test.tsx` and `{X}.vrt.spec.ts` exist as siblings. Missing files produce a non-blocking system-reminder so test/vrt-less lv1 additions get caught immediately.
+- **Stop** → [scripts/check-lv1-export-integrity.mjs](scripts/check-lv1-export-integrity.mjs). At session end, diffs the lv1 component directories against the `from './...'` re-exports in [src/components/lv1/index.ts](src/components/lv1/index.ts). Mismatches surface as a non-blocking system-reminder.
+
+Both hooks are **non-blocking** — they print to `hookSpecificOutput.additionalContext` and always exit 0. They complement (do not replace) the lefthook pre-commit step.

--- a/scripts/check-lv1-companions.mjs
+++ b/scripts/check-lv1-companions.mjs
@@ -1,0 +1,83 @@
+#!/usr/bin/env node
+// PostToolUse hook: when Claude Code edits src/components/lv1/{X}/{X}.tsx,
+// verify that the sibling unit test (`{X}.test.tsx`) and VRT spec
+// (`{X}.vrt.spec.ts`) exist. Emits a non-blocking system-reminder so that
+// "test/vrt-less" lv1 additions get caught at edit time.
+//
+// Contract with Claude Code:
+//  - Reads a JSON payload from stdin containing { tool_name, tool_input, ... }.
+//  - Exits 0 always (this hook never blocks the edit).
+//  - When a problem is found, prints a JSON response with
+//    hookSpecificOutput.additionalContext so the message reaches Claude.
+
+import { existsSync, readFileSync } from 'node:fs'
+import path from 'node:path'
+
+const LV1_TSX_RE = /(?:^|\/)src\/components\/lv1\/([^/]+)\/\1\.tsx$/
+
+function readStdin() {
+  try {
+    return readFileSync(0, 'utf8')
+  } catch {
+    return ''
+  }
+}
+
+function extractFilePath(payload) {
+  if (!payload) return null
+  let parsed
+  try {
+    parsed = JSON.parse(payload)
+  } catch {
+    return null
+  }
+  const input = parsed?.tool_input
+  if (!input) return null
+  // Edit / Write: { file_path }
+  if (typeof input.file_path === 'string') return input.file_path
+  // MultiEdit: { file_path } too (single path)
+  return null
+}
+
+function emit(additionalContext) {
+  const response = {
+    hookSpecificOutput: {
+      hookEventName: 'PostToolUse',
+      additionalContext,
+    },
+  }
+  process.stdout.write(JSON.stringify(response))
+}
+
+function main() {
+  const raw = readStdin()
+  const filePath = extractFilePath(raw)
+  if (!filePath) return
+
+  const projectDir = process.env.CLAUDE_PROJECT_DIR ?? process.cwd()
+  const relative = path.relative(projectDir, path.resolve(projectDir, filePath))
+  if (relative.startsWith('..')) return
+
+  const match = relative.match(LV1_TSX_RE)
+  if (!match) return
+
+  const componentName = match[1]
+  const dir = path.join(projectDir, 'src/components/lv1', componentName)
+  const testFile = path.join(dir, `${componentName}.test.tsx`)
+  const vrtFile = path.join(dir, `${componentName}.vrt.spec.ts`)
+
+  const missing = []
+  if (!existsSync(testFile)) missing.push(`${componentName}.test.tsx`)
+  if (!existsSync(vrtFile)) missing.push(`${componentName}.vrt.spec.ts`)
+  if (missing.length === 0) return
+
+  const lines = [
+    `[lv1 companion check] ${componentName} is missing companion file(s): ${missing.join(', ')}.`,
+    `Every lv1 component must ship with a sibling unit test and VRT spec in the same directory.`,
+    `See .claude/rules/testing-guideline.md (Required test cases) and .claude/rules/vrt-spec-guideline.md.`,
+    `Create the missing file(s) in src/components/lv1/${componentName}/ before completing this change.`,
+  ]
+  emit(lines.join('\n'))
+}
+
+main()

--- a/scripts/check-lv1-export-integrity.mjs
+++ b/scripts/check-lv1-export-integrity.mjs
@@ -1,0 +1,88 @@
+#!/usr/bin/env node
+// Stop hook: verify src/components/lv1/index.ts re-exports every lv1
+// component directory. Catches the "added a component but forgot to wire
+// up the barrel" failure mode at session end.
+//
+// Heuristic:
+//  - List subdirectories of src/components/lv1/.
+//  - Parse src/components/lv1/index.ts and collect every `from './<name>'`.
+//  - Diff the two sets and report directories that are missing from the
+//    barrel (and exports that don't have a matching directory).
+//
+// Exits 0 always — this hook reports, it does not block. When a problem
+// is found, the message is emitted via JSON
+// (hookSpecificOutput.additionalContext) so Claude sees it.
+
+import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs'
+import path from 'node:path'
+
+const LV1_DIR_REL = 'src/components/lv1'
+const INDEX_FILE_REL = 'src/components/lv1/index.ts'
+const FROM_RE = /from\s+['"]\.\/([^'"/.]+)['"]/g
+
+function listComponentDirs(lv1Dir) {
+  if (!existsSync(lv1Dir)) return []
+  return readdirSync(lv1Dir)
+    .filter((entry) => {
+      const full = path.join(lv1Dir, entry)
+      try {
+        return statSync(full).isDirectory()
+      } catch {
+        return false
+      }
+    })
+    .sort()
+}
+
+function parseExportedNames(indexPath) {
+  if (!existsSync(indexPath)) return new Set()
+  const source = readFileSync(indexPath, 'utf8')
+  const names = new Set()
+  let m
+  while ((m = FROM_RE.exec(source)) !== null) names.add(m[1])
+  return names
+}
+
+function emit(additionalContext) {
+  const response = {
+    hookSpecificOutput: {
+      hookEventName: 'Stop',
+      additionalContext,
+    },
+  }
+  process.stdout.write(JSON.stringify(response))
+}
+
+function main() {
+  const projectDir = process.env.CLAUDE_PROJECT_DIR ?? process.cwd()
+  const lv1Dir = path.join(projectDir, LV1_DIR_REL)
+  const indexPath = path.join(projectDir, INDEX_FILE_REL)
+
+  const dirs = listComponentDirs(lv1Dir)
+  if (dirs.length === 0) return
+
+  const exported = parseExportedNames(indexPath)
+
+  const missingFromIndex = dirs.filter((d) => !exported.has(d))
+  const orphanedExports = [...exported].filter((name) => !dirs.includes(name)).sort()
+
+  if (missingFromIndex.length === 0 && orphanedExports.length === 0) return
+
+  const lines = [`[lv1 export integrity] mismatch between ${LV1_DIR_REL}/ and ${INDEX_FILE_REL}:`]
+  if (missingFromIndex.length > 0) {
+    lines.push(
+      `- Directories without a corresponding export in index.ts: ${missingFromIndex.join(', ')}`,
+    )
+  }
+  if (orphanedExports.length > 0) {
+    lines.push(
+      `- Exports in index.ts without a matching component directory: ${orphanedExports.join(', ')}`,
+    )
+  }
+  lines.push(
+    'Update src/components/lv1/index.ts so every lv1 component dir is re-exported exactly once.',
+  )
+  emit(lines.join('\n'))
+}
+
+main()


### PR DESCRIPTION
## Summary

- Add `.claude/settings.json` (team-shared, distinct from per-user `.claude/settings.local.json`) with two non-blocking Claude Code hooks so test/vrt-less lv1 additions get caught at edit time, by AI or human alike.
- **PostToolUse(Edit|Write|MultiEdit)** → [`scripts/check-lv1-companions.mjs`](scripts/check-lv1-companions.mjs): when the edit lands on `src/components/lv1/{X}/{X}.tsx`, verifies `{X}.test.tsx` and `{X}.vrt.spec.ts` exist as siblings.
- **Stop** → [`scripts/check-lv1-export-integrity.mjs`](scripts/check-lv1-export-integrity.mjs): diffs lv1 component directories against the `from './...'` re-exports in `src/components/lv1/index.ts` (both directions — orphan exports are flagged too).
- Document the hooks in [CLAUDE.md](CLAUDE.md).

Closes #107.

## Design notes

- **Hook protocol** — both scripts read the Claude Code stdin JSON contract (`tool_input.file_path`, `$CLAUDE_PROJECT_DIR`) rather than the `$CLAUDE_HOOK_FILE_PATH` sketch in the issue. That sketch isn't part of the actual Claude Code hook contract; the JSON-over-stdin path is.
- **Non-blocking by design** — both exit `0` and surface messages via `hookSpecificOutput.additionalContext`, so AI/human can proceed deliberately. Matches the issue's "警告のみ (block しない)" requirement.
- **node-only, no shell dependencies** — works on Windows; no `bash`, no `find`, no `grep` shell-outs.
- **Layering with lefthook** — the existing lefthook pre-commit step is unchanged. These hooks fire on every Claude Code edit/stop, so the failure mode is caught earlier in the loop without losing the pre-commit safety net.

## Manual verification

| # | Scenario | Expected | Result |
|---|---|---|---|
| 1 | PostToolUse on existing `Button.tsx` | silent | ✓ |
| 2 | PostToolUse on non-lv1 path (`src/lib/utils.ts`) | silent | ✓ |
| 3 | PostToolUse on new `NewWidget.tsx` (both companions missing) | warns with both filenames | ✓ |
| 4 | PostToolUse with only test missing | warns about test only | ✓ |
| 5 | PostToolUse with both companions present | silent | ✓ |
| 6 | PostToolUse on `Button.test.tsx` itself (not the `{X}.tsx`) | silent | ✓ |
| 7 | Stop on real repo (17 dirs ↔ 17 exports) | silent | ✓ |
| 8 | Stop with phantom dir (no matching export) | flags `Phantom` | ✓ |
| 9 | Stop with orphan export (export but no dir) | flags both `Phantom` + `Toast` | ✓ |

`pnpm lint` and `pnpm typecheck` pass.

## Test plan

- [ ] Reviewer: in a clean Claude Code session in this repo, edit any existing lv1 `.tsx` — no hook output expected (companions present).
- [ ] Reviewer: create a temporary `src/components/lv1/Foo/Foo.tsx` and edit it; expect a system-reminder pointing to the missing test/vrt files.
- [ ] Reviewer: at session end, the Stop hook is silent when `index.ts` and the dir set agree.
- [ ] Confirm both hook scripts run under Node (no shell-isms) and exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)