### PR TITLE
feat(tokens): add non-interactive state tokens (disabled / readOnly) — closes #180

### DIFF
--- a/.changeset/non-interactive-state-tokens.md
+++ b/.changeset/non-interactive-state-tokens.md
@@ -1,0 +1,57 @@
+---
+'@yasmro/schatten': minor
+---
+
+feat(tokens): add non-interactive state semantic tokens (`disabled` / `readOnly`)
+
+Adds five new semantic CSS variables in
+[`semantic.css`](src/core/tokens/semantic.css) and registers them with
+Tailwind v4 via [`base.css`](src/core/tokens/base.css), so form-control
+authors can express `disabled` and `readOnly` through token names instead
+of the current cross-component `cursor-not-allowed opacity-50` pattern.
+
+The two non-interactive states have intentionally different visual
+directions:
+
+| | `disabled` | `readOnly` |
+|---|---|---|
+| Intent | This control is not usable | The value is informational, the control is static |
+| Form submission | Value is not submitted | Value is submitted |
+| Focus | Not focusable | Focusable |
+| Visual | Muted / faded (cool gray) | Subtle / static (warm tint) |
+
+Tokens added:
+
+```css
+/* disabled — surface + foreground + border */
+--color-surface-disabled
+--color-foreground-disabled
+--color-border-disabled
+
+/* readOnly — surface + border (foreground stays normal so the value stays readable) */
+--color-surface-readonly
+--color-border-readonly
+```
+
+All five are defined in both modes (`:root`, `@media (prefers-color-scheme: dark)`,
+and `.dark`). Tailwind utilities — `bg-surface-disabled`,
+`text-foreground-disabled`, `border-border-disabled`, `bg-surface-readonly`,
+`border-border-readonly` — are generated via the
+[`@theme`](src/core/tokens/base.css) registration.
+
+The tokens follow the existing 3-layer hierarchy
+([state-token-guideline.md](.claude/rules/state-token-guideline.md)): they
+sit at the semantic layer and reference primitives. They are NOT state
+semantic tokens in the `error`/`success`/… sense — there is no `hover` slot —
+so they do not follow the 4-token shape.
+
+A new "Non-Interactive States" + "Disabled vs ReadOnly (a11y audit)"
+section is added to `Foundation/Color` so designers can verify both
+modes visually.
+
+This change is additive — no component currently consumes the tokens, so
+no VRT impact. Component-side adoption (replacing `opacity-50` and
+introducing readOnly styling on Input/Textarea) lands in separate
+follow-up issues.
+
+Closes #180.

--- a/.changeset/non-interactive-state-tokens.md
+++ b/.changeset/non-interactive-state-tokens.md
@@ -54,4 +54,22 @@ no VRT impact. Component-side adoption (replacing `opacity-50` and
 introducing readOnly styling on Input/Textarea) lands in separate
 follow-up issues.
 
-Closes #180.
+Also updates two rule docs to acknowledge the new category:
+
+- [`state-token-guideline.md`](.claude/rules/state-token-guideline.md) gains
+  a "Non-interactive state tokens" section explaining the 3 / 2-slot shape,
+  why there is no `hover` slot, and why `disabled` / `readOnly` use cool
+  and warm hue families respectively.
+- [`theme-architecture.md`](.claude/rules/theme-architecture.md) pins the
+  five new tokens to the Mode axis and forbids Specials from overriding
+  them — disabled means the same thing regardless of season or brand.
+
+A new [`docs/decisions/`](docs/decisions/) directory is introduced for
+design decision logs, with
+[`2026-05-non-interactive-state-tokens.md`](docs/decisions/2026-05-non-interactive-state-tokens.md)
+as its first entry. The log captures the alternatives considered (lightness
+shifts, pattern overlays, dashed borders) and explains why hue family was
+the chosen differentiator.
+
+Closes #180. Follow-ups: #198 (designer-review step), #199 (Form States
+foundation page), #200 (semantic→primitive resolve test).

--- a/.claude/rules/state-token-guideline.md
+++ b/.claude/rules/state-token-guideline.md
@@ -2,9 +2,20 @@
 
 ## Overview
 
-State semantics (`error`, `success`, `warning`, `info`) and the `destructive` action color
-follow a unified 4-token shape so that every component that needs to express "this is a state"
-has a consistent, predictable surface to draw from.
+This rule covers **two categories** of state tokens. They are deliberately
+separated because their shape and consumer story differ.
+
+| Category | Members | Shape | Consumed by |
+|---|---|---|---|
+| **Interactive state** | `error`, `success`, `warning`, `info`, plus `destructive` (action color, same primitive as `error`) | 4-token: `base` / `hover` / `foreground` / `subtle` | Form inputs (`isError`), notification surfaces (`Toast`, `Callout`, `Badge`, …) |
+| **Non-interactive state** | `disabled`, `readOnly` | Custom: `disabled` = `surface` + `foreground` + `border`; `readOnly` = `surface` + `border` (no `foreground` — the value stays readable) | Form controls when they cannot be acted on (`disabled`) or are display-only (`readOnly`) |
+
+Both categories live at the semantic layer. **Components must consume only
+the semantic layer; never reference primitive scales directly.**
+
+Each category has its own section below. The "Interactive state" section comes
+first because it is the larger surface; the "Non-interactive state" section
+comes after the interactive a11y audit.
 
 ## Three-layer hierarchy
 
@@ -98,3 +109,87 @@ fill achieves higher WCAG contrast than white-on-bright. Verify visually in `Fou
 3. Add a subsection to `src/docs/Color.stories.tsx`.
 4. Add rows to the "Filled Treatments" and "Subtle Treatments" audit sections.
 5. Add a changeset (typically `minor` — additive feature).
+
+## Non-interactive state tokens (`disabled` / `readOnly`)
+
+`disabled` and `readOnly` are a separate category of state token. They do
+**not** follow the 4-token shape and are not interchangeable with the
+interactive states above.
+
+### Semantic distinction
+
+`disabled` and `readOnly` look superficially similar — neither is editable —
+but the UX intent and the HTML semantics differ. Conflating them (e.g. by
+fading both with `opacity-50`) is an anti-pattern the token system is
+designed to prevent.
+
+| | `disabled` | `readOnly` |
+|---|---|---|
+| Meaning | The control cannot be used at all | The value is informational; the control is static |
+| Form submission | Value is **not** submitted | Value **is** submitted |
+| Focus | Not focusable | Focusable (Tab order) |
+| Visual direction | Muted / faded (cool gray) | Subtle / static (warm tint) |
+| Foreground | Muted (`--color-foreground-disabled`) | Normal (`--color-foreground` — the value must remain readable) |
+
+### Token shape (no `hover` slot)
+
+There is no `hover` slot because these states *describe non-interactivity*.
+Adding a hover token here would be semantically incoherent — by definition,
+the user is not interacting.
+
+```
+disabled  : surface + foreground + border
+readOnly  : surface + border
+```
+
+| Token | Light primitive | Dark primitive | Used as |
+|---|---|---|---|
+| `--color-surface-disabled` | `gray-100` | `gray-800` | Background of disabled controls |
+| `--color-foreground-disabled` | `gray-500` | `gray-500` | Text / icon color of disabled controls |
+| `--color-border-disabled` | `gray-200` | `gray-700` | Border of disabled controls |
+| `--color-surface-readonly` | `alabaster-100` | `alabaster-800` | Background of readOnly controls |
+| `--color-border-readonly` | `gray-200` | `gray-700` | Border of readOnly controls |
+
+`foreground-disabled` is intentionally identical in light and dark — `gray-500`
+reads as "muted but legible" against both `gray-100` and `gray-800`. The
+symmetry is by design, not an oversight. WCAG exempts disabled UI from
+contrast requirements, but Schatten still keeps ≥ ~5:1 against the
+matching surface so the value remains legible to all users (rationale in
+[docs/decisions/2026-05-non-interactive-state-tokens.md](../../docs/decisions/2026-05-non-interactive-state-tokens.md)).
+
+### Cool vs warm — why two hue families
+
+The disabled / readOnly surfaces sit at similar lightness levels (light: 0.96
+OKLCH; dark: 0.27 OKLCH). They are differentiated by **hue family**, not
+lightness: `gray-*` (saturation 0, cool by perception) for `disabled`,
+`alabaster-*` (warm tint, chroma ≈ 0.005–0.01) for `readOnly`. This encodes
+the "muted / faded" vs "subtle / static" direction at low chromatic cost.
+
+When adding a future non-interactive state (e.g. `pending`, `indeterminate`),
+preserve the principle: **express the new state through hue / chroma, not
+through lightness shifts**, so the four-way visual identity stays legible at
+matching weights.
+
+### `border-readonly` ≡ `border-disabled` ≡ `border` (today)
+
+In light mode all three resolve to `gray-200`; in dark mode `border-readonly`
+and `border-disabled` both resolve to `gray-700`. They share primitives today
+but **must continue to be referenced by their semantic name** in components,
+so future re-tuning lands at one place. This mirrors the `destructive` /
+`error` policy (same primitive, distinct semantic name).
+
+### Adding a new non-interactive state
+
+1. Decide the token shape — non-interactive states are rarely "filled"
+   surfaces, so the `subtle` and `hover` slots usually do **not** apply.
+   Default shape: `surface` + (`foreground`?) + (`border`?).
+2. Add to `semantic.css` in all three blocks (`:root`, `@media (prefers-color-scheme: dark)`,
+   `.dark`).
+3. Register in `base.css` `@theme`.
+4. Add a subsection to `src/docs/Color.stories.tsx` under "Non-Interactive
+   States" with a side-by-side preview against the existing non-interactive
+   states (`disabled` / `readOnly`).
+5. Document the rationale in [docs/decisions/](../../docs/decisions/) — what
+   the new state *means* (HTML semantics, form-submission behavior, focusability)
+   matters more than what it looks like.
+6. Add a changeset (typically `minor` — additive feature).

--- a/.claude/rules/theme-architecture.md
+++ b/.claude/rules/theme-architecture.md
@@ -59,6 +59,7 @@ once, that's a sign you want the [external Special API](#external-special-themes
 | Borders | `--color-border`, `--color-border-strong` |
 | Focus ring | `--color-ring`, `--color-ring-offset` |
 | State remapping for dark | `--color-error*`, `--color-success*`, `--color-warning*`, `--color-info*`, `--color-destructive*` (shade shift between light and dark) |
+| Non-interactive state | `--color-surface-disabled`, `--color-foreground-disabled`, `--color-border-disabled`, `--color-surface-readonly`, `--color-border-readonly` |
 
 Rule of thumb: anything that needs to flip *shade* between light and dark
 belongs to Mode.
@@ -82,6 +83,35 @@ A few tokens are pinned by intent and **must not** be moved by either axis:
   [state-token-guideline](state-token-guideline.md#info-independence-from-the-theme-scale).
 - Primitives (`--vermillion-*`, `--green-*`, `--blue-*`, …) are theme-agnostic
   by definition and live one layer below semantics.
+
+### Specials must not override non-interactive state tokens
+
+The five `disabled` / `readOnly` tokens
+(`--color-surface-disabled`, `--color-foreground-disabled`,
+`--color-border-disabled`, `--color-surface-readonly`,
+`--color-border-readonly`) are **Mode-owned, not Special-owned**, and Specials
+must not include them in their allowlist.
+
+Why this is pinned to Mode:
+
+- **Semantics over expression.** `disabled` means "this control cannot be
+  used"; `readOnly` means "this value is informational." The meaning is
+  invariant across themes. A seasonal palette that re-tints "disabled" with
+  a brand hue would communicate the wrong thing — a disabled control
+  should *recede*, not become a brand surface.
+- **A11y stability.** Each Special × Mode permutation already needs
+  visual verification (16 combinations today, see "Dark × Special" in this
+  document). Letting Specials retune disabled/readOnly would multiply the
+  audit matrix by another factor without a corresponding UX win.
+- **Consumer expectation.** Form-control authors reading
+  `bg-surface-disabled` expect the same "muted, can't use" surface
+  regardless of which Special is active. Theme-driven drift would break
+  that contract silently.
+
+If a future product use case genuinely needs theme-aware disabled coloring
+(e.g. a brand-tinted "ghost" state), revisit this rule with a concrete
+example — do not work around it by adding the tokens to a Special
+allowlist informally.
 
 ## Cascade
 

--- a/docs/decisions/2026-05-non-interactive-state-tokens.md
+++ b/docs/decisions/2026-05-non-interactive-state-tokens.md
@@ -1,0 +1,200 @@
+# Non-Interactive State Tokens — Design Decision Log
+
+| | |
+|---|---|
+| Date | 2026-05-16 |
+| Status | Accepted |
+| Related issue | [#180](https://github.com/yasmro/schatten/issues/180) |
+| Related PR | [#197](https://github.com/yasmro/schatten/pull/197) |
+| Related rules | [state-token-guideline.md](../../.claude/rules/state-token-guideline.md), [theme-architecture.md](../../.claude/rules/theme-architecture.md) |
+| Tokens affected | `--color-surface-disabled`, `--color-foreground-disabled`, `--color-border-disabled`, `--color-surface-readonly`, `--color-border-readonly` |
+
+This is the first entry in `docs/decisions/`. The directory exists to capture
+design-time *reasoning* that would otherwise be lost — the choices that
+codebase, rules, and tests do not preserve. Future entries should follow the
+same structure.
+
+## Context
+
+Schatten's form-control lv1s (`Input`, `Textarea`, `Select`, `Radio`,
+`Checkbox`, `Switch`) had been using `cursor-not-allowed opacity-50` for
+`disabled` and inheriting HTML default behaviour for `readOnly`. Two
+problems followed:
+
+1. **`opacity-50` conflates two distinct UX states.** Disabled controls and
+   readOnly controls look identical, but they communicate different
+   things: "you cannot use this" vs "this is a value, not an input."
+2. **No token surface to consume.** Component authors had no semantic
+   name for either state, so retuning required edits across N components.
+
+This log records *why* the chosen tokens look the way they do, so future
+contributors (human or AI) can extend the pattern without re-litigating the
+same questions.
+
+## Decision
+
+Add five semantic tokens at the `semantic.css` layer:
+
+| Token | Light | Dark | Slot |
+|---|---|---|---|
+| `--color-surface-disabled` | `gray-100` | `gray-800` | surface |
+| `--color-foreground-disabled` | `gray-500` | `gray-500` | foreground |
+| `--color-border-disabled` | `gray-200` | `gray-700` | border |
+| `--color-surface-readonly` | `alabaster-100` | `alabaster-800` | surface |
+| `--color-border-readonly` | `gray-200` | `gray-700` | border |
+
+**Shape**: `disabled` has 3 slots, `readOnly` has 2. No `hover` slot, no
+`subtle` slot. (See "Why not the 4-token shape" below.)
+
+**Axis**: Mode-owned. Special themes must not override these. (See
+[theme-architecture.md](../../.claude/rules/theme-architecture.md#specials-must-not-override-non-interactive-state-tokens).)
+
+## Rationale
+
+### 1. Cool gray (disabled) vs warm alabaster (readOnly)
+
+The two states sit at the same OKLCH lightness levels (`0.96` in light,
+`0.27` in dark). They are differentiated by **hue family**:
+
+- `gray-*` (chroma 0, perceptually cool) → "muted / faded / dead"
+- `alabaster-*` (chroma ≈ 0.005–0.01, warm-tinted) → "static / informational"
+
+This encodes a UX distinction at minimal chromatic cost. Designers can read
+the two surfaces apart at a glance when placed side by side, while neither
+state is loud enough to compete with the active controls around it.
+
+#### Alternatives considered
+
+| Alternative | Why rejected |
+|---|---|
+| Both states cool, differentiated by **lightness** (e.g. disabled at gray-100, readOnly at gray-50) | Lightness is already heavily used (surface tiers, hover, foreground tiers). Stacking another lightness step would compress the perceptual ladder. Hue is the cheaper channel. |
+| Pattern (diagonal lines / dots) on disabled surface | Strong signal but breaks token-only composition — component CSS would need pseudo-elements. Not implementable purely at the token layer. Could be revisited as a *component-level* enhancement. |
+| Border-style (dashed for readOnly, solid for disabled) | Same problem — border-style is not a `--color-*` value. Adds a second axis (color + style) that the token system cannot express. |
+| Stronger color cue (e.g. warm tan for readOnly) | Risks bleeding into "warning" territory. The whole point of these states is to *recede*, not announce themselves. |
+| Use `opacity` at the token layer (e.g. `oklch(...)` with alpha) | Compounds with parent backgrounds unpredictably; reduces contrast control. Better to compose surface + foreground explicitly. |
+
+### 2. Why `foreground-disabled` does not shift between light and dark
+
+Every other state token in the system shifts shade between light/dark
+(`error-600` → `error-500`, etc.). `foreground-disabled` is pinned at
+`gray-500` in both.
+
+**Why**: `gray-500` (OKLCH lightness ≈ 0.58) is the perceptual mid-point.
+Against `gray-100` (light surface, lightness ≈ 0.96) it yields ~5:1
+contrast — muted but legible. Against `gray-800` (dark surface, lightness
+≈ 0.27) it yields ~4:1 — also legible. A symmetric mid-gray solves both
+modes with one declaration.
+
+WCAG 2.1 exempts disabled UI from contrast requirements (SC 1.4.3 Note 1),
+but Schatten deliberately exceeds the exemption: low-vision and aging users
+benefit when a disabled value is still readable, even if it is clearly
+inactive.
+
+#### Alternatives considered
+
+| Alternative | Why rejected |
+|---|---|
+| `gray-400` light / `gray-600` dark (asymmetric shift like other states) | Higher fade ratio but worse legibility at smaller font sizes; the symmetric `gray-500` is the better trade-off given WCAG generosity. |
+| `foreground-muted` (existing token) | Semantically wrong — `foreground-muted` is "secondary helper text" (still fully usable). Disabled foreground should communicate "this control is not in play." |
+
+### 3. Why not the 4-token shape (`base` / `hover` / `foreground` / `subtle`)
+
+The interactive state category (`error`, `success`, `warning`, `info`,
+`destructive`) uses a 4-slot shape because each state has both a **filled**
+treatment (`bg-{state}` + `text-{state}-foreground`) and a **soft**
+treatment (`bg-{state}-subtle` + `text-{state}`), and most also have
+hover affordances.
+
+Non-interactive states have neither:
+
+- **No `hover`** — by definition the user cannot interact. Adding a hover
+  slot would be semantically incoherent.
+- **No `subtle`** — disabled/readOnly *are* the subtle treatment. There is
+  no "louder" filled variant that demands a "softer" sibling.
+- **No `foreground` on `readOnly`** — the value must remain readable using
+  the normal `--color-foreground`. Adding a separate readonly foreground
+  would invite designers to fade readOnly text, which contradicts the
+  state's meaning.
+
+Forcing the 4-token shape onto these states would create 3 unused tokens
+per state (10 dead tokens overall) and tempt future contributors to
+"fill them in" with values that contradict the UX intent.
+
+### 4. Why `border-readonly`, `border-disabled`, and `border` resolve to the same primitive today
+
+In light mode, all three resolve to `gray-200`. In dark mode,
+`border-readonly` and `border-disabled` both resolve to `gray-700` (same
+as `border`). They are aliases by value, distinct by name.
+
+**Why keep them separate**: the semantic name is the contract. Components
+that reference `border-border-readonly` will pick up future re-tuning
+automatically; components that hard-code `border-border` will not. This
+mirrors the existing `destructive` / `error` policy (same primitive,
+distinct name, future-flexible).
+
+The trade-off is dead-code risk if the values never diverge. We accept that
+because the renaming cost (post-1.0, per [api-stability.md](../../.claude/rules/api-stability.md))
+of *adding* the semantic name later would be a `major` bump. Keeping the
+name available now is cheap insurance.
+
+### 5. Why Mode-owned, not Special-owned
+
+Special themes own `--color-theme-*` and (optionally) `accent`. They must
+not touch the new non-interactive tokens. Reasoning is captured in
+[theme-architecture.md](../../.claude/rules/theme-architecture.md#specials-must-not-override-non-interactive-state-tokens);
+the short version:
+
+- Disabled "means" the same thing regardless of season or brand.
+- Letting Specials retune disabled multiplies the audit matrix.
+- Form-control consumers expect a stable disabled surface.
+
+If a future Special truly needs theme-tinted disabled, revisit this rule
+with a concrete example — do not bypass it.
+
+## Consequences
+
+### Positive
+
+- Form-control authors can express `disabled` and `readOnly` via Tailwind
+  utilities (`bg-surface-disabled`, `text-foreground-disabled`,
+  `border-border-readonly`, etc.) without inventing component-local CSS.
+- The two states are visually distinguishable at a glance, fixing the
+  `opacity-50` conflation.
+- Token layer remains framework-agnostic — the same tokens can be consumed
+  by the CSS-only build (issue #58 Phase 2).
+
+### Negative
+
+- Two more "alias" tokens in light mode (`border-readonly` ≡
+  `border-disabled` ≡ `border`). Manageable, but worth flagging in an API
+  audit before v1.0.
+- The cool/warm distinction is subtle on uncalibrated displays. Designers
+  should verify both modes on at least one calibrated reference display
+  during component-side adoption (see #182 / #183 review process).
+- One more drift surface between the `@media (prefers-color-scheme: dark)`
+  and `.dark` blocks in `semantic.css`. Will be addressed when the
+  duplicate-block consolidation lands.
+
+## Adoption path
+
+This PR is tokens-only. Component-side adoption is split across follow-ups:
+
+- **#182** — `opacity-50` system-wide sweep across form lv1s
+- **#183** — Input/Textarea readOnly visual styling
+- Designer review is required before merging either, per
+  [#TBD](#) (issue to be opened in this PR's wake)
+
+## Review history
+
+| Date | Reviewer | Notes |
+|---|---|---|
+| 2026-05-16 | Yu Ohno (engineering) | Initial implementation and review |
+| _pending_ | _design_ | Side-by-side verification on calibrated display, both Modes, with multiple Specials active |
+
+## References
+
+- Issue [#180](https://github.com/yasmro/schatten/issues/180) — feature request
+- PR [#197](https://github.com/yasmro/schatten/pull/197) — implementation
+- [state-token-guideline.md](../../.claude/rules/state-token-guideline.md) — codified rule
+- [theme-architecture.md](../../.claude/rules/theme-architecture.md) — axis ownership
+- WCAG 2.1 SC 1.4.3 Note 1 (disabled UI exemption from contrast)

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -1,0 +1,55 @@
+# Design Decision Log
+
+Schatten's `.claude/rules/` codifies *what is true*. This directory captures
+*why we chose it* — the trade-off analysis, the alternatives considered, the
+context that the codebase and git history alone do not preserve.
+
+## When to add an entry
+
+Add a decision log when a change involves a non-obvious choice that future
+contributors (or your future self) might reasonably want to re-litigate:
+
+- New semantic token shapes or naming patterns
+- New variant patterns that diverge from existing components
+- API choices where multiple defensible options were on the table
+- Accessibility / contrast trade-offs that go beyond WCAG minimums
+- Theme / Mode / Special partitioning decisions
+- "We considered X but rejected it because Y" — capture both X and Y
+
+Skip an entry when:
+
+- The decision is fully captured by the corresponding `.claude/rules/` file
+- It's a bug fix or a mechanical refactor with no real alternatives
+- It's already documented in the changeset or PR description in enough
+  depth that re-deriving the reasoning is cheap
+
+## Format
+
+```
+docs/decisions/YYYY-MM-<kebab-slug>.md
+```
+
+Each entry should include, at minimum:
+
+- Status (Proposed / Accepted / Superseded)
+- Related issue / PR / rules
+- Context — what problem prompted the decision
+- Decision — what was chosen
+- Rationale — including alternatives considered and rejected
+- Consequences — positive and negative
+- Review history — who signed off and when
+
+See [`2026-05-non-interactive-state-tokens.md`](2026-05-non-interactive-state-tokens.md)
+for the canonical template.
+
+## Relationship to `.claude/rules/`
+
+| Surface | Audience | Content |
+|---|---|---|
+| `.claude/rules/*.md` | Future contributors writing code | *What* the convention is — terse, prescriptive |
+| `docs/decisions/*.md` | Future contributors questioning the convention | *Why* the convention is — narrative, trade-off-aware |
+
+When updating a rule, link back to the decision log that produced it.
+When writing a decision log, link forward to the rule it codifies. The two
+surfaces are intentionally coupled but separate — confusing them produces
+either over-explained rules or under-explained narratives.

--- a/src/core/tokens/base.css
+++ b/src/core/tokens/base.css
@@ -83,6 +83,14 @@
   --color-info-foreground: var(--color-info-foreground);
   --color-info-subtle: var(--color-info-subtle);
 
+  /* Non-interactive state — disabled / readOnly */
+  --color-surface-disabled: var(--color-surface-disabled);
+  --color-foreground-disabled: var(--color-foreground-disabled);
+  --color-border-disabled: var(--color-border-disabled);
+
+  --color-surface-readonly: var(--color-surface-readonly);
+  --color-border-readonly: var(--color-border-readonly);
+
   /* ===== Primitive Scales (for theme authoring & docs) ===== */
 
   /* Sumi scale */

--- a/src/core/tokens/semantic.css
+++ b/src/core/tokens/semantic.css
@@ -101,6 +101,29 @@
   --color-info-hover: var(--blue-700);
   --color-info-foreground: var(--paper-white);
   --color-info-subtle: var(--blue-50);
+
+  /*
+   * Non-interactive state tokens — for `disabled` and `readOnly` form controls.
+   * These describe a control that cannot be acted on (disabled) or whose value
+   * is displayed but not editable (readOnly). They are NOT state semantic
+   * tokens in the `error`/`success`/… sense (no `hover` slot), so they do
+   * not follow the 4-token shape.
+   *
+   * Visual direction
+   *   disabled  — muted / faded (cool gray). "this is not usable"
+   *   readOnly  — subtle / static (warm tint). "this is informational"
+   *
+   * Token shape
+   *   disabled  : surface + foreground + border
+   *   readOnly  : surface + border (foreground stays normal — the value
+   *               must remain readable)
+   */
+  --color-surface-disabled: var(--gray-100);
+  --color-foreground-disabled: var(--gray-500);
+  --color-border-disabled: var(--gray-200);
+
+  --color-surface-readonly: var(--alabaster-100);
+  --color-border-readonly: var(--gray-200);
 }
 
 /* Dark mode - System preference fallback */
@@ -158,6 +181,14 @@
     --color-info-hover: var(--blue-400);
     --color-info-foreground: var(--paper-white-inverted);
     --color-info-subtle: var(--blue-900);
+
+    /* Non-interactive state tokens — dark mode mappings */
+    --color-surface-disabled: var(--gray-800);
+    --color-foreground-disabled: var(--gray-500);
+    --color-border-disabled: var(--gray-700);
+
+    --color-surface-readonly: var(--alabaster-800);
+    --color-border-readonly: var(--gray-700);
   }
 }
 
@@ -215,4 +246,12 @@
   --color-info-hover: var(--blue-400);
   --color-info-foreground: var(--paper-white-inverted);
   --color-info-subtle: var(--blue-900);
+
+  /* Non-interactive state tokens — dark mode mappings */
+  --color-surface-disabled: var(--gray-800);
+  --color-foreground-disabled: var(--gray-500);
+  --color-border-disabled: var(--gray-700);
+
+  --color-surface-readonly: var(--alabaster-800);
+  --color-border-readonly: var(--gray-700);
 }

--- a/src/docs/Color.stories.tsx
+++ b/src/docs/Color.stories.tsx
@@ -258,6 +258,57 @@ export const Colors: Story = {
         />
       </div>
 
+      <SubsectionTitle>Non-Interactive States</SubsectionTitle>
+      <p className="text-sm text-foreground-muted mb-3">
+        Form controls that cannot be acted on (<code>disabled</code>) or are display-only (
+        <code>readOnly</code>) consume these tokens. They are not state tokens in the{' '}
+        <code>error</code>/<code>success</code>/… sense — there is no <code>hover</code> slot.
+      </p>
+      <div className="border border-border rounded-xl px-5">
+        <ColorRow
+          name="surface-disabled"
+          description="Background for disabled controls — cool, muted"
+          className="bg-surface-disabled border border-border"
+        />
+        <ColorRow
+          name="foreground-disabled"
+          description="Text/icon color for disabled controls"
+          className="bg-foreground-disabled"
+        />
+        <ColorRow
+          name="border-disabled"
+          description="Border for disabled controls"
+          className="bg-border-disabled"
+        />
+        <ColorRow
+          name="surface-readonly"
+          description="Background for readOnly controls — warm, static"
+          className="bg-surface-readonly border border-border"
+        />
+        <ColorRow
+          name="border-readonly"
+          description="Border for readOnly controls"
+          className="bg-border-readonly"
+        />
+      </div>
+
+      <SubsectionTitle>Disabled vs ReadOnly (a11y audit)</SubsectionTitle>
+      <p className="text-sm text-foreground-muted mb-3">
+        Side-by-side preview of how the two non-interactive treatments look. <code>disabled</code>{' '}
+        uses a cool muted palette to convey "not usable"; <code>readOnly</code> uses a warm subtle
+        palette to convey "value is informational, but the control is static". Verify both modes.
+      </p>
+      <div className="flex flex-col gap-2">
+        <div className="flex items-center gap-3 rounded-lg border border-border-disabled bg-surface-disabled px-4 py-3 text-foreground-disabled">
+          <span className="font-mono text-xs opacity-70">disabled</span>
+          <span className="text-sm font-medium">The quick brown fox jumps over the lazy dog</span>
+        </div>
+        <div className="flex items-center gap-3 rounded-lg border border-border-readonly bg-surface-readonly px-4 py-3 text-foreground">
+          <span className="font-mono text-xs opacity-70">readOnly</span>
+          <span className="text-sm font-medium">The quick brown fox jumps over the lazy dog</span>
+        </div>
+      </div>
+
       <SubsectionTitle>Filled Treatments (a11y audit)</SubsectionTitle>
       <p className="text-sm text-foreground-muted mb-3">
         Each row shows a state's <code>bg-X</code> with <code>text-X-foreground</code> applied — the


### PR DESCRIPTION
## Summary

Adds five semantic CSS variables for non-interactive form-control states (`disabled` / `readOnly`), updates the codified rules to acknowledge the new category, and introduces a `docs/decisions/` surface for design trade-off narratives. Closes #180.

The two non-interactive states have intentionally different visual directions:

| | `disabled` | `readOnly` |
|---|---|---|
| Intent | Control is not usable | Value is informational; control is static |
| Form submission | Value not submitted | Value submitted |
| Focus | Not focusable | Focusable |
| Visual | Muted / faded (cool gray) | Subtle / static (warm tint) |

## Token surface added

```css
/* disabled — surface + foreground + border */
--color-surface-disabled       (light: gray-100     / dark: gray-800)
--color-foreground-disabled    (light: gray-500     / dark: gray-500)
--color-border-disabled        (light: gray-200     / dark: gray-700)

/* readOnly — surface + border (foreground stays normal so the value stays readable) */
--color-surface-readonly       (light: alabaster-100 / dark: alabaster-800)
--color-border-readonly        (light: gray-200      / dark: gray-700)
```

These are NOT state tokens in the `error`/`success`/… sense — there is no `hover` slot, no `subtle` slot — so they don't follow the 4-token shape. Shape is custom: 3 tokens for `disabled`, 2 for `readOnly` (foreground stays normal).

## Design + architecture rules updated

- [state-token-guideline.md](.claude/rules/state-token-guideline.md) — adds a "Non-interactive state tokens" section explaining the 3 / 2-slot shape, the cool-vs-warm hue rationale, why `foreground-disabled` is symmetric across light/dark, and the procedure for adding future non-interactive states.
- [theme-architecture.md](.claude/rules/theme-architecture.md) — pins the 5 new tokens to the Mode axis under "Tokens neither axis touches → Specials must not override non-interactive state tokens". A seasonal palette retinting "disabled" would break the meaning of the state.

## Design decision log

Introduces [`docs/decisions/`](docs/decisions/) as the new canonical surface for design trade-off narratives:

- [docs/decisions/README.md](docs/decisions/README.md) — explains the convention (rules say *what*, decisions say *why*) and the entry format.
- [docs/decisions/2026-05-non-interactive-state-tokens.md](docs/decisions/2026-05-non-interactive-state-tokens.md) — captures the alternatives considered (lightness shifts, pattern overlays, dashed borders, opacity-at-token-layer) and why hue family was the chosen differentiator. Includes a "Review history" section to be signed by designers during component-side adoption.

## Acceptance criteria (issue DoD)

- [x] `--color-surface-disabled`, `--color-foreground-disabled`, `--color-border-disabled` added to `semantic.css`
- [x] `--color-surface-readonly`, `--color-border-readonly` added to `semantic.css`
- [x] Dark mode values defined for both `@media (prefers-color-scheme: dark)` and `.dark`
- [x] Registered in `base.css` `@theme`
- [x] New tokens added to [Color.stories.tsx](src/docs/Color.stories.tsx) with "Non-Interactive States" + "Disabled vs ReadOnly (a11y audit)" subsections
- [x] **(extra)** Rule docs updated to reflect the new category
- [x] **(extra)** Design decision log captures the alternatives considered

## Follow-up work (out of scope, tracked)

- [#198](https://github.com/yasmro/schatten/issues/198) — formalise designer-review step for #182 / #183 component-side adoption
- [#199](https://github.com/yasmro/schatten/issues/199) — standalone `Foundation/Form States` Storybook page (v0.7.0)
- [#200](https://github.com/yasmro/schatten/issues/200) — semantic→primitive resolve test, riding on the v0.7.0 allowlist work (#114)
- #182 — `opacity-50` system-wide sweep across form lv1s
- #183 — Input/Textarea readOnly visual styling

## Test plan

- [x] `pnpm lint` — pass
- [x] `pnpm typecheck` — pass
- [x] `pnpm exec vitest --run` — 273 / 273 pass (no component currently consumes the tokens, so no test changes)
- [x] `pnpm build` — pass; all five tokens (including dark-mode mappings) confirmed in minified `dist/schatten.css`
- [ ] Storybook: open `Foundation/Color → Non-Interactive States` and `Disabled vs ReadOnly (a11y audit)`, toggle light/dark, verify both modes
- [x] No VRT impact (no component consumes the tokens yet)

🤖 Generated with [Claude Code](https://claude.com/claude-code)