### PR TITLE
chore(build): drop empty `./components/lv2` exports entry (closes #110)

### DIFF
--- a/.changeset/remove-empty-lv2-export.md
+++ b/.changeset/remove-empty-lv2-export.md
@@ -1,0 +1,37 @@
+---
+'@yasmro/schatten': patch
+---
+
+chore(build): drop the empty `./components/lv2` exports entry until lv2 lands.
+
+`src/components/lv2/index.ts` is still `export {}` and the matching
+`package.json#exports["./components/lv2"]` plus the `tsup` entry were
+exposing an empty surface to consumers — a signal that "an API is here but
+incomplete." Until lv2 components ship in v0.9.0, the cleaner posture is
+to not advertise the sub-path at all.
+
+Closes [#110](https://github.com/yasmro/schatten/issues/110).
+
+**Changes**
+
+- `package.json#exports["./components/lv2"]` is removed. The remaining
+  entries (`.`, `./components`, `./components/lv1`, …) are unchanged.
+- `tsup.config.ts` no longer lists `components/lv2/index` as an entry, so
+  `pnpm build` does not emit `dist/components/lv2/`.
+- `src/components/lv2/index.ts` is **kept** as `export {}` — it's the
+  placeholder that v0.9.0 will populate when the first lv2 lands. Removing
+  the file would force re-creating it (and re-wiring the tsup / exports
+  config) later for no gain today.
+
+**Restoration plan (v0.9.0)**
+
+When the first lv2 components (`FormField`, …) ship, re-add the
+`./components/lv2` exports entry and the `components/lv2/index` tsup entry
+in the same change.
+
+**Consumer impact**
+
+Effectively none — `import … from '@yasmro/schatten/components/lv2'`
+previously resolved to an empty module, so no real callsite exists. Anyone
+who somehow had that import will get a clear resolution error pointing
+back at this changeset rather than a silent empty import.

--- a/package.json
+++ b/package.json
@@ -60,14 +60,6 @@
       },
       "import": "./dist/components/lv1/index.js",
       "require": "./dist/components/lv1/index.cjs"
-    },
-    "./components/lv2": {
-      "types": {
-        "import": "./dist/components/lv2/index.d.ts",
-        "require": "./dist/components/lv2/index.d.cts"
-      },
-      "import": "./dist/components/lv2/index.js",
-      "require": "./dist/components/lv2/index.cjs"
     }
   },
   "files": [

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -33,7 +33,6 @@ export default defineConfig([
     entry: {
       'components/index': 'src/components/index.ts',
       'components/lv1/index': 'src/components/lv1/index.ts',
-      'components/lv2/index': 'src/components/lv2/index.ts',
     },
     format: ['esm', 'cjs'],
     dts: true,


### PR DESCRIPTION
## Summary

- Removes `package.json#exports["./components/lv2"]` and the matching
  `components/lv2/index` entry from `tsup.config.ts`. The build no longer
  emits `dist/components/lv2/`.
- Keeps `src/components/lv2/index.ts` (`export {}`) as the v0.9.0 placeholder.
- Adds a `patch` changeset documenting the temporary removal and the
  v0.9.0 restoration plan.

`src/components/index.ts` already stopped re-exporting lv2 in [#207](https://github.com/yasmro/schatten/pull/207) (closes [#109](https://github.com/yasmro/schatten/issues/109)), so the root entry has no transitive lv2 dependency to clean up here.

Closes [#110](https://github.com/yasmro/schatten/issues/110).

## Why

The sub-path exposed an empty surface (`export {}`) — to a consumer this
reads as "an unfinished API is here." Until lv2 components ship in
v0.9.0, the sub-path stays unannounced. When v0.9.0 lands the `FormField`
/ `ConfirmDialog` / … set, restore the exports entry and the tsup entry
in the same change.

## Test plan

- [x] `pnpm lint` — clean.
- [x] `pnpm typecheck` — clean.
- [x] `pnpm test --run` — 310 tests passing.
- [x] `pnpm build:js` — succeeds; `ls dist/components/` shows `lv1/` only, no `lv2/`.
- [x] No callsite of `@yasmro/schatten/components/lv2` exists in the repo (grep is empty).

🤖 Generated with [Claude Code](https://claude.com/claude-code)