### PR TITLE
docs(storybook): Getting Started / For Astro & For Vue (#113)

### DIFF
--- a/.changeset/storybook-getting-started-astro-vue.md
+++ b/.changeset/storybook-getting-started-astro-vue.md
@@ -1,0 +1,53 @@
+---
+'@yasmro/schatten': patch
+---
+
+docs(storybook): add `Getting Started / For Astro` and `For Vue` pages.
+
+Closes [#113](https://github.com/yasmro/schatten/issues/113).
+
+The two new MDX pages show how to wire Schatten into Astro and Vue
+projects without a React runtime — installing the package, importing
+the global stylesheet, and using `buttonVariants(...)` from
+`@yasmro/schatten/variants` to compose class strings on any element.
+Each page also documents the v0.14.0 migration path to the
+data-attribute class API (`<button class="btn" data-variant="solid">`).
+
+**What ships**
+
+- `src/docs/getting-started/ForAstro.mdx` — Astro setup, React island
+  mixing example using Pattern A Button vocabulary, tokens-only path.
+- `src/docs/getting-started/ForVue.mdx` — Vue 3 setup, `<style scoped>`
+  interaction note, `<RouterLink>` / `<NuxtLink>` integration.
+- `.storybook/main.ts` — stories glob now matches `*.mdx` as well as
+  `*.stories.*`, so the new pages mount.
+- `.storybook/preview.tsx` — storySort order picks up `Getting Started`
+  so the section appears between `Welcome` and `Foundation`.
+
+**Honesty about the v0.7.0 status**
+
+Both pages lead with a status table that distinguishes:
+
+- Tokens + CVA variant helpers — **production-ready today**.
+- Class-based component API (`.btn`, `.input`, …) — phantom in v0.7.0;
+  the selector exists in Schatten's CVA strings but the CSS bundle has
+  no declarations for it yet. Lands in v0.14.0
+  ([#58](https://github.com/yasmro/schatten/issues/58)) and stabilizes
+  in v1.0.0 per `.claude/rules/api-stability.md`.
+
+The Astro page recommends `buttonVariants({ variant: 'primary' })` as
+the today-bridge — matching the pattern README.md established in
+[#111](https://github.com/yasmro/schatten/issues/111) — rather than the
+`<button class="btn btn--primary">` form, which doesn't render today.
+
+**Button vocabulary**
+
+Both pages spell out the Pattern A (single-axis, role-based) Button
+vocabulary: `primary | secondary | tertiary | destructive | inverted |
+link`. Pattern A has no `appearance` prop; cross-references point at
+`.claude/rules/component-api-conventions.md` for the full matrix and
+the rationale.
+
+**Consumer impact**
+
+Additive. No code paths change.

--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -1,7 +1,23 @@
+import { fileURLToPath } from 'node:url'
 import type { StorybookConfig } from '@storybook/react-vite'
 
+// Workaround for storybook 10.3.x: `@storybook/addon-docs` injects an MDX
+// provider import via `import.meta.resolve(...)`, which returns a `file://`
+// URL that Vite/Rollup cannot resolve. Strip the prefix back to a regular
+// filesystem path so MDX pages build and dev-serve cleanly.
+const resolveFileUrlImports = {
+  name: 'schatten:resolve-file-url-imports',
+  enforce: 'pre' as const,
+  resolveId(source: string) {
+    if (source.startsWith('file://')) {
+      return fileURLToPath(source)
+    }
+    return null
+  },
+}
+
 const config: StorybookConfig = {
-  stories: ['../src/**/*.stories.@(js|jsx|mjs|ts|tsx)'],
+  stories: ['../src/**/*.mdx', '../src/**/*.stories.@(js|jsx|mjs|ts|tsx)'],
   addons: ['@storybook/addon-docs'],
   framework: {
     name: '@storybook/react-vite',
@@ -13,7 +29,7 @@ const config: StorybookConfig = {
   viteFinal: async (config) => {
     const tailwindcss = (await import('@tailwindcss/vite')).default
     config.plugins = config.plugins || []
-    config.plugins.push(tailwindcss())
+    config.plugins.push(resolveFileUrlImports, tailwindcss())
 
     if (process.env.STORYBOOK_BASE) {
       config.base = process.env.STORYBOOK_BASE

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -16,7 +16,7 @@ const preview: Preview = {
     layout: 'fullscreen',
     options: {
       storySort: {
-        order: ['Welcome', 'Foundation', 'Components'],
+        order: ['Welcome', 'Getting Started', 'Foundation', 'Components'],
       },
     },
   },

--- a/src/docs/getting-started/ForAstro.mdx
+++ b/src/docs/getting-started/ForAstro.mdx
@@ -1,0 +1,230 @@
+import { Meta } from '@storybook/addon-docs/blocks'
+
+<Meta title="Getting Started/For Astro" />
+
+# For Astro
+
+Schatten works in Astro without any React runtime: import the CSS bundle
+once, and either use the CVA variant helpers to compose class strings, or
+drop into a React island when you need the typed component layer.
+
+This page covers the two paths and where they meet.
+
+---
+
+## Status (v0.7.0)
+
+Schatten ships **two consumer surfaces** today. They are at different
+maturity levels in v0.7.0 — be aware which you are using:
+
+| Surface | What ships today | When it stabilizes |
+|---|---|---|
+| **Design tokens** (CSS vars: `--color-theme-600`, `--color-foreground`, …) | Production-ready | Stable from **v1.0.0** |
+| **CVA variant helpers** (`buttonVariants(...)`, `inputVariants(...)`, …) | Production-ready bridge | Stable from **v1.0.0** |
+| **Class-based component API** (`<button class="btn" data-variant="solid">`) | Phantom — the `.btn` selector is referenced internally but has no CSS rules yet | Lands in **v0.14.0**, stable from **v1.0.0** |
+
+Progress is tracked in [#58](https://github.com/yasmro/schatten/issues/58).
+Until v0.14.0 ships, the **recommended Astro bridge is `buttonVariants(...)`**
+(see "Layer A — today" below).
+
+---
+
+## Install
+
+```sh
+pnpm add @yasmro/schatten
+```
+
+`react` / `react-dom` peer deps are only required if you use React
+islands (see [React island mixing](#react-island-mixing) below). For a
+pure Astro / SSR-only setup, the CSS bundle alone has no runtime
+dependencies.
+
+---
+
+## Setup — global stylesheet
+
+Import the CSS bundle once at your app's shared layout:
+
+```astro
+---
+// src/layouts/Layout.astro
+import '@yasmro/schatten/schatten.css'
+---
+
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>My Astro site</title>
+  </head>
+  <body>
+    <slot />
+  </body>
+</html>
+```
+
+The bundle ships:
+
+- Primitive scales (`--vermillion-*`, `--green-*`, `--blue-*`, …)
+- Semantic tokens (`--color-foreground`, `--color-error`, `--color-theme-*`, …)
+- Tailwind utilities used by Schatten's CVA strings
+- Component animation keyframes (Spinner, Toast)
+
+The package declares `"sideEffects": ["**/*.css"]`, so the CSS import is
+not tree-shaken away.
+
+---
+
+## Layer A — today (CVA bridge)
+
+`buttonVariants(...)` (and its siblings) return a Tailwind class string
+that you can apply to any element — including a plain Astro `<button>`,
+an Astro `<a>`, or a `<NextLink>`-style framework link.
+
+```astro
+---
+import '@yasmro/schatten/schatten.css'
+import { buttonVariants } from '@yasmro/schatten/variants'
+---
+
+<!-- Plain button, primary -->
+<button class={buttonVariants({ variant: 'primary' })}>Save</button>
+
+<!-- An <a> styled as a secondary button -->
+<a
+  href="/docs"
+  class={buttonVariants({ variant: 'secondary', size: 'sm' })}
+>
+  Docs
+</a>
+
+<!-- Link-style action -->
+<a href="/settings" class={buttonVariants({ variant: 'link' })}>
+  Settings
+</a>
+```
+
+### Button variant vocabulary
+
+`Button` follows **Pattern A** (single-axis role-based) per
+[`component-api-conventions.md`](../../../.claude/rules/component-api-conventions.md).
+The full vocabulary:
+
+| `variant` | Use for |
+|---|---|
+| `primary` *(default)* | Main CTA. Solid brand-accent fill. |
+| `secondary` | Outlined neutral. Secondary actions. |
+| `tertiary` | Ghost (no border / no bg). Low-priority actions. |
+| `destructive` | Delete / remove. Solid vermillion fill. |
+| `inverted` | Ghost button intended for placement on a saturated surface (e.g. inside a solid Toast). |
+| `link` | Inline text-link styling. |
+
+Pattern A has **no `appearance` prop**. If you reach for one, the role
+vocabulary is what you want to extend — open an issue rather than
+inventing a second axis locally.
+
+The same approach works for the other variant functions exported from
+`@yasmro/schatten/variants`: `badgeVariants`, `inputVariants`,
+`inputWrapperVariants`, `calloutVariants`, `textVariants`,
+`textareaVariants`, `selectTriggerVariants`, and others.
+
+---
+
+## React island mixing
+
+When a piece of UI needs interactivity that's awkward to express in
+Astro alone (a dialog, a tooltip, a controlled form input), mount it as
+a React island. Schatten's React layer composes the same tokens, so the
+visual output is identical to the CVA bridge.
+
+```astro
+---
+// src/pages/index.astro
+import '@yasmro/schatten/schatten.css'
+import { Button } from '@yasmro/schatten'
+import { buttonVariants } from '@yasmro/schatten/variants'
+---
+
+<Layout>
+  {/* React island — hydrates on the client */}
+  <Button client:load variant="primary">Sign up</Button>
+
+  {/* Pure Astro — no JS shipped */}
+  <a
+    href="/learn-more"
+    class={buttonVariants({ variant: 'secondary' })}
+  >
+    Learn more
+  </a>
+</Layout>
+```
+
+Two practical notes:
+
+- **Pick the cheaper option per element.** Static-looking surfaces
+  (badges, callouts that don't dismiss, headings) cost nothing as
+  CVA-styled markup. Reach for an island only when you actually need
+  the React lifecycle (event handlers, state, Radix-driven portal
+  components like `Dialog` / `Tooltip` / `Select`).
+- **Hydration strategy is your call.** `client:load`, `client:idle`,
+  `client:visible`, `client:only="react"` all work. Schatten does not
+  prescribe one.
+
+---
+
+## Layer A — v0.14.0 onward
+
+When the data-attribute class API lands in v0.14.0
+([#58](https://github.com/yasmro/schatten/issues/58)), the same Astro
+snippet drops the JS helper entirely:
+
+```astro
+---
+import '@yasmro/schatten/schatten.css'
+---
+
+<!-- v0.14.0 onward — no buttonVariants() needed -->
+<button class="btn" data-variant="solid">Save</button>
+<a href="/docs" class="btn" data-variant="outline">Docs</a>
+```
+
+Until then, `buttonVariants(...)` is the supported bridge — the code
+above will compile and parse today, but the `.btn` rule has no
+declarations attached. Use the CVA helper for now and migrate when
+v0.14.0 ships.
+
+---
+
+## Tokens — works everywhere, today
+
+You don't need the variant helpers to consume the design tokens. Any
+Astro file can reference a CSS variable directly:
+
+```astro
+<div style="background: var(--color-error-subtle); color: var(--color-error); padding: 12px;">
+  Something went wrong.
+</div>
+```
+
+For typed pointers, the `tokens` export gives you a value map and union
+types:
+
+```astro
+---
+import { tokens } from '@yasmro/schatten/tokens'
+---
+
+<div style={`background: ${tokens.color.errorSubtle}; color: ${tokens.color.error};`}>
+  Something went wrong.
+</div>
+```
+
+---
+
+## See also
+
+- [README — Quick start](https://github.com/yasmro/schatten#quick-start)
+- [#58 — framework-agnostic CSS roadmap](https://github.com/yasmro/schatten/issues/58)
+- [`component-api-conventions.md`](../../../.claude/rules/component-api-conventions.md) — full variant matrix
+- [`api-stability.md`](../../../.claude/rules/api-stability.md) — public API contract (effective from v1.0)

--- a/src/docs/getting-started/ForVue.mdx
+++ b/src/docs/getting-started/ForVue.mdx
@@ -1,0 +1,249 @@
+import { Meta } from '@storybook/addon-docs/blocks'
+
+<Meta title="Getting Started/For Vue" />
+
+# For Vue
+
+Schatten's CSS bundle and CVA variant helpers work in Vue 3 the same way
+they work in any non-React framework: import the stylesheet once at
+app entry, then bind variant class strings into your templates with
+`:class`.
+
+This page covers the setup, the `<style scoped>` interaction, and the
+v0.14.0 migration path.
+
+---
+
+## Status (v0.7.0)
+
+The matrix is identical to [For Astro](?path=/docs/getting-started-for-astro--docs):
+
+| Surface | Today | Stable from |
+|---|---|---|
+| Design tokens (CSS vars) | Production-ready | v1.0.0 |
+| CVA variant helpers (`buttonVariants(...)`, …) | Production-ready bridge | v1.0.0 |
+| Class-based component API (`<button class="btn">`) | Phantom — selectors exist, CSS rules don't yet | v0.14.0 → v1.0.0 |
+
+Progress in [#58](https://github.com/yasmro/schatten/issues/58). Until
+v0.14.0 ships, the recommended Vue bridge is **`buttonVariants(...)`**.
+
+---
+
+## Install
+
+```sh
+pnpm add @yasmro/schatten
+```
+
+`react` / `react-dom` peer deps are **not required** for Layer A
+(`schatten.css` + `@yasmro/schatten/variants`). They are only needed if
+you separately mount React inside Vue (uncommon).
+
+---
+
+## Setup — global stylesheet
+
+Pick **one** of the entry-import strategies. Both reach every component
+in your tree because CSS custom properties cascade from `:root`.
+
+### Option A: import in `main.ts`
+
+```ts
+// src/main.ts
+import { createApp } from 'vue'
+import '@yasmro/schatten/schatten.css'
+import App from './App.vue'
+
+createApp(App).mount('#app')
+```
+
+### Option B: import in the root `<App.vue>` (unscoped)
+
+```vue
+<!-- src/App.vue -->
+<script setup lang="ts">
+import '@yasmro/schatten/schatten.css'
+</script>
+
+<template>
+  <router-view />
+</template>
+```
+
+Either works. Option A keeps Vue components free of CSS side effects;
+Option B colocates the stylesheet with the app root. Schatten doesn't
+have a preference.
+
+---
+
+## `<style scoped>` — what to expect
+
+This is the most common Vue-specific question, so it gets its own
+section.
+
+**Schatten's classes live globally.** When you import `schatten.css`,
+its rules (Tailwind utilities, base reset, animation keyframes) land
+in the global stylesheet. They don't go through Vue's `data-v-*`
+scoping pipeline.
+
+That means:
+
+- **`<style scoped>` cannot override a Schatten class.** A rule like
+  `.btn--primary { background: pink }` inside a scoped block becomes
+  `.btn--primary[data-v-abc123]`, which doesn't match the Schatten-
+  emitted element (no `data-v-abc123` attribute). Use `:deep(...)`
+  if you intentionally need to override:
+  ```vue
+  <style scoped>
+  :deep(.btn) {
+    /* applies inside this component's subtree */
+  }
+  </style>
+  ```
+- **`<style scoped>` does not conflict with Schatten either.** Your
+  component-local CSS lives in its own scope; Schatten's lives in the
+  global scope. They coexist without interfering.
+
+The general recommendation: keep Schatten styling outside of `scoped`
+blocks. Reach for `:deep()` only when you have a deliberate reason to
+retune Schatten's output in one component.
+
+---
+
+## Layer A — today (CVA bridge)
+
+`buttonVariants(...)` returns a class string. Bind it with `:class`:
+
+```vue
+<script setup lang="ts">
+import { buttonVariants } from '@yasmro/schatten/variants'
+</script>
+
+<template>
+  <!-- Primary button -->
+  <button :class="buttonVariants({ variant: 'primary' })">
+    Save
+  </button>
+
+  <!-- Anchor styled as a secondary button -->
+  <a
+    href="/docs"
+    :class="buttonVariants({ variant: 'secondary', size: 'sm' })"
+  >
+    Docs
+  </a>
+
+  <!-- Link-style action -->
+  <a href="/settings" :class="buttonVariants({ variant: 'link' })">
+    Settings
+  </a>
+</template>
+```
+
+For a `<RouterLink>` or `<NuxtLink>`, pass the variant string to its
+`:class` prop the same way:
+
+```vue
+<template>
+  <RouterLink
+    to="/dashboard"
+    :class="buttonVariants({ variant: 'primary' })"
+  >
+    Dashboard
+  </RouterLink>
+</template>
+```
+
+### Button variant vocabulary
+
+`Button` follows **Pattern A** (single-axis role-based) per
+[`component-api-conventions.md`](../../../.claude/rules/component-api-conventions.md):
+
+| `variant` | Use for |
+|---|---|
+| `primary` *(default)* | Main CTA. Solid brand-accent fill. |
+| `secondary` | Outlined neutral. Secondary actions. |
+| `tertiary` | Ghost (no border / no bg). Low-priority actions. |
+| `destructive` | Delete / remove. Solid vermillion fill. |
+| `inverted` | Ghost button on a saturated surface (e.g. inside a solid Toast). |
+| `link` | Inline text-link styling. |
+
+Pattern A has **no `appearance` prop**. If you find yourself wanting
+one for a Button, the role vocabulary is what you want to extend —
+open an issue, don't add a second axis locally.
+
+The same approach works for every variant function exported from
+`@yasmro/schatten/variants` (`badgeVariants`, `inputVariants`,
+`calloutVariants`, `textVariants`, `textareaVariants`,
+`selectTriggerVariants`, …).
+
+---
+
+## Layer A — v0.14.0 onward
+
+When the data-attribute class API lands in v0.14.0
+([#58](https://github.com/yasmro/schatten/issues/58)), the same Vue
+template drops the JS helper:
+
+```vue
+<template>
+  <!-- v0.14.0 onward — no buttonVariants() needed -->
+  <button class="btn" data-variant="solid">Save</button>
+  <a href="/docs" class="btn" data-variant="outline">Docs</a>
+</template>
+```
+
+Until then, `buttonVariants(...)` is the supported bridge. The code
+above parses today, but the `.btn` rule has no declarations attached
+in v0.7.0.
+
+---
+
+## Tokens — works everywhere, today
+
+You don't need the variant helpers to consume tokens. Any Vue template
+can reference a CSS variable directly:
+
+```vue
+<template>
+  <div
+    :style="{
+      background: 'var(--color-error-subtle)',
+      color: 'var(--color-error)',
+      padding: '12px',
+    }"
+  >
+    Something went wrong.
+  </div>
+</template>
+```
+
+For typed pointers, the `tokens` export gives you a value map and
+union types:
+
+```vue
+<script setup lang="ts">
+import { tokens } from '@yasmro/schatten/tokens'
+</script>
+
+<template>
+  <div
+    :style="{
+      background: tokens.color.errorSubtle,
+      color: tokens.color.error,
+    }"
+  >
+    Something went wrong.
+  </div>
+</template>
+```
+
+---
+
+## See also
+
+- [README — Quick start](https://github.com/yasmro/schatten#quick-start)
+- [For Astro](?path=/docs/getting-started-for-astro--docs)
+- [#58 — framework-agnostic CSS roadmap](https://github.com/yasmro/schatten/issues/58)
+- [`component-api-conventions.md`](../../../.claude/rules/component-api-conventions.md) — full variant matrix
+- [`api-stability.md`](../../../.claude/rules/api-stability.md) — public API contract (effective from v1.0)


### PR DESCRIPTION
## Summary

#113 の実装 — Storybook に `Getting Started / For Astro` と `For Vue` の MDX ページを追加。

- React 不要のフレームワーク向けに、`@yasmro/schatten/schatten.css` の import + `buttonVariants(...)` ブリッジで今日からスタイル付き要素を出す方法を提示
- v0.14.0 で着地する data-attribute class API (`<button class="btn" data-variant="solid">`) への移行経路も併記
- Button vocabulary は Pattern A (`primary | secondary | tertiary | destructive | inverted | link`) — `appearance` なしを明示
- 各ページ先頭に v0.7.0 ステータステーブル: tokens / CVA helpers は production-ready、`.btn` 等は phantom

## Status — wontfix 候補

このタスクは [#111](https://github.com/yasmro/schatten/issues/111) / [PR #209](https://github.com/yasmro/schatten/pull/209) で README に `Astro / Vue / Svelte` セクションが既に着地したことで実質的にカバー済み。Storybook MDX ページは README のスニペットを言い換えているだけで、新しい情報を提供していない。

加えて、本変更は MDX を有効化するために Storybook 10.3.6 + Vite の `file://` URL バグへの workaround plugin が必要になっており、Storybook 側が修正するまで保守が続く配管コストを抱えている。差別化要素 (e.g. seasonal themes のフレームワーク横断デモ) がないこのページのために投資する妥当性は低い。

→ Issue #113 を `not planned` で close 予定。本 PR は実装記録として残し、close する想定。

## Test plan

- [x] `pnpm lint` — clean
- [x] `pnpm typecheck` — clean
- [x] `pnpm test --run` — 17 files / 310 tests pass
- [x] `pnpm build:storybook` — succeeds、`index.json` に `getting-started-for-astro--docs` / `getting-started-for-vue--docs` が含まれる
- [x] `pnpm dev` — 起動成功

## Files

- `src/docs/getting-started/ForAstro.mdx` (新規, 230 行)
- `src/docs/getting-started/ForVue.mdx` (新規, 249 行)
- `.storybook/main.ts` — `*.mdx` glob 追加 + `file://` URL workaround plugin
- `.storybook/preview.tsx` — storySort に `'Getting Started'` を追加
- `.changeset/storybook-getting-started-astro-vue.md` — `patch`

🤖 Generated with [Claude Code](https://claude.com/claude-code)