### PR TITLE
feat(lint): ban primitive color classes in JSX via Biome plugin (closes #122)

### DIFF
--- a/.changeset/spicy-paws-jump.md
+++ b/.changeset/spicy-paws-jump.md
@@ -1,0 +1,10 @@
+---
+'@yasmro/schatten': patch
+---
+
+Add the `no-primitive-color` Biome GritQL linter plugin. It bans Tailwind
+primitive color utility classes (`bg-red-500`, `text-gray-700`,
+`ring-vermillion-600`, …) in component JSX, enforcing the
+state-token-guideline contract that components consume only Layer-2 semantic
+tokens. Scoped to `src/components/**/*.tsx` (stories and tests are exempt).
+Internal tooling only — no change to the published package surface.

--- a/.claude/rules/api-stability.md
+++ b/.claude/rules/api-stability.md
@@ -216,6 +216,7 @@ Ask, in order:
   roadmap (Phase 2 introduces the data-attribute class API)
 - [state-token-guideline](state-token-guideline.md) — names and shapes of state
   semantic tokens (subject to this contract from v1.0)
-- [lint-rules-guideline](lint-rules-guideline.md) — Biome rules; a future
-  custom rule will enforce "no primitive color classes in components" so the
-  public CSS-variable surface stays the only color contract
+- [lint-rules-guideline](lint-rules-guideline.md) — Biome rules and GritQL
+  plugins; the `no-primitive-color` plugin enforces "no primitive color
+  classes in components" so the public CSS-variable surface stays the only
+  color contract

--- a/.claude/rules/lint-rules-guideline.md
+++ b/.claude/rules/lint-rules-guideline.md
@@ -78,16 +78,53 @@ is combined with `asChild` (an unsupported combination), and
 `actionButton.onClick` is undefined (a footgun — clicking the action button
 becomes a silent no-op). That's a feature, not noise.
 
+## GritQL plugins
+
+Beyond the built-in rules above, Biome 2.x's GritQL plugin support lets us
+ship custom checks. Plugins are `.grit` files under
+[`biome-plugins/`](../../biome-plugins) and are loaded via `plugins` arrays
+in [`biome.json`](../../biome.json) — either globally or, where the check
+should only apply to a subset of files, inside a scoped `overrides` entry.
+
+### `no-primitive-color` — `error`
+
+Bans Tailwind *primitive* color utility classes (`bg-red-500`,
+`text-gray-700`, `ring-vermillion-600`, …) in component JSX, forcing the
+use of Layer-2 semantic tokens (`bg-error`, `text-foreground-muted`, …).
+
+**Why:** primitive color classes are exactly the kind of thing an AI
+assistant emits from training-data muscle memory. A machine check stops
+them before review does, and keeps the public CSS-variable surface (the
+semantic tokens) as the only color contract. Set to `error` so it blocks
+CI, not just editor hover.
+
+**Scope:** a scoped `overrides` entry restricts the plugin to
+`src/components/**/*.tsx`, excluding `*.stories.tsx` / `*.test.tsx` —
+stories and docs render the primitive palette intentionally.
+
+**Limitations of GritQL plugins** (worth knowing before writing more):
+
+- A plugin diagnostic cannot register a named rule category, so it is
+  suppressed with `// biome-ignore lint/plugin: <reason>`, not a
+  rule-specific name.
+- GritQL (in Biome 2.4) cannot match a JSX attribute by name; the plugin
+  matches a whole JSX element and regex-scans its attribute text. CVA
+  variant files (`src/variants/*.ts`) are therefore out of reach.
+- Multiple top-level `where` blocks in one `.grit` file fail to compile —
+  combine alternatives with `or { … } where { … }`.
+- Regex capture groups `( … )` are treated as bindings; use
+  non-capturing `(?: … )`.
+
+The contract this plugin enforces lives in
+[state-token-guideline](state-token-guideline.md#enforcement--the-no-primitive-color-lint-plugin).
+
 ## Rules deliberately **not** added
 
 - **`nursery/useSortedClasses` (Tailwind utility sort)** — under consideration
   for Phase 2. Not enabled yet because it churns existing files and the
   ergonomic win is marginal compared to the diff cost.
-- **Custom rule banning primitive color classes (`bg-red-*`, …)** — planned
-  for v0.8.0. The convention is enforced today via [state-token-guideline](state-token-guideline.md)
-  and code review; a Biome custom rule will make it mechanical.
-- **Custom rule enforcing the component API contract** — planned for v0.8.0
-  alongside the primitive-color rule above. [component-api-conventions](component-api-conventions.md)
+- **Custom rule enforcing the component API contract** — planned for v0.8.0.
+  [component-api-conventions](component-api-conventions.md)
   defines two patterns (Role-based for `Button`; Tone × Shape for
   `Badge` / `Callout` / `Toast`) and a per-component variant matrix, but
   today the contract is only enforced via TS unions and code review —

--- a/.claude/rules/state-token-guideline.md
+++ b/.claude/rules/state-token-guideline.md
@@ -36,6 +36,52 @@ Layer 3: Components (consume semantic only)
    bg-error / text-error / border-error / ring-error / bg-error-subtle ...
 ```
 
+## Enforcement — the `no-primitive-color` lint plugin
+
+The "components consume only Layer 2" rule is enforced mechanically by a
+Biome GritQL linter plugin
+([`biome-plugins/no-primitive-color.grit`](../../biome-plugins/no-primitive-color.grit),
+issue [#122](https://github.com/yasmro/schatten/issues/122)). It exists
+because primitive color classes are exactly the kind of thing an AI
+assistant writes from muscle memory (`bg-red-500`, `text-gray-700`) — a
+machine check catches them before review does.
+
+**What it flags.** Any Tailwind primitive color utility —
+`{bg,text,border,ring}-{family}-{shade}` — in component JSX. `{family}`
+covers the full Tailwind default palette *and* Schatten's own primitive
+scales (`vermillion`, `sumi`, `gray`, `blue`, `green`, `yellow`, `amber`,
+`purple`). Variant prefixes (`dark:bg-amber-500`,
+`hover:text-gray-700`) and classes inside a `cn(...)` expression are
+caught too.
+
+**What it allows.** Everything at Layer 2: state semantics (`bg-error`,
+`text-error-foreground`, `bg-success-subtle`), foreground tiers
+(`text-foreground-muted`), surfaces (`bg-surface`), and the semantic
+theme scale (`bg-theme-500` — `theme` is *not* a primitive family).
+
+**Scope.** Enabled through a scoped `overrides` entry in
+[`biome.json`](../../biome.json) that targets `src/components/**/*.tsx`
+and excludes `*.stories.tsx` / `*.test.tsx`. Stories and docs render the
+primitive palette on purpose (`Color.stories.tsx` *is* the palette
+documentation), so they are exempt by design.
+
+**Known gap.** The plugin matches JSX attributes only; it does **not**
+scan CVA variant definitions in `src/variants/*.ts` (bare class strings,
+no JSX). Primitive colors there remain a code-review concern — never
+hard-code `bg-vermillion-600` in a `cva(...)` block.
+
+**Suppressing.** A genuine exception is suppressed with the `lint/plugin`
+category — Biome plugins cannot register a named rule, so
+`lint/no-primitive-color` is *not* a valid category:
+
+```tsx
+// biome-ignore lint/plugin: <reason — why a primitive class is correct here>
+<div className="bg-vermillion-600" />
+```
+
+The plugin is exercised by [`no-primitive-color.test.ts`](../../biome-plugins/no-primitive-color.test.ts),
+which runs `biome lint` over fixture files and asserts the diagnostics.
+
 ## The 4-token shape
 
 Every state defines exactly four tokens:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,4 +80,7 @@ jobs:
       - run: pnpm install --frozen-lockfile
 
       - name: Changeset status
-        run: pnpm exec changeset status --since=origin/main
+        # Compare against the PR's base branch (develop / main), not a fixed
+        # branch — otherwise a develop-targeted PR is diffed against main and
+        # picks up unrelated already-merged changesets once the two diverge.
+        run: pnpm exec changeset status --since=origin/${{ github.base_ref }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,10 +2,10 @@ name: CI
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, develop]
     types: [opened, synchronize, reopened, labeled, unlabeled]
   push:
-    branches: [main]
+    branches: [main, develop]
 
 jobs:
   lint:

--- a/biome-plugins/no-primitive-color.grit
+++ b/biome-plugins/no-primitive-color.grit
@@ -1,0 +1,51 @@
+// no-primitive-color — Biome GritQL linter plugin
+//
+// Bans Tailwind *primitive* color utility classes (`bg-red-500`,
+// `text-gray-700`, `border-blue-300`, `ring-vermillion-600`, …) inside
+// component JSX. Components must consume Layer-2 *semantic* tokens
+// (`bg-error`, `text-foreground-muted`, `bg-surface`, …) — never the
+// Layer-1 primitive scales.
+//
+// Contract: .claude/rules/state-token-guideline.md
+//   ("Three-layer hierarchy" — components consume only Layer 2).
+// Issue: https://github.com/yasmro/schatten/issues/122
+//
+// ── Scope ───────────────────────────────────────────────────────────
+// Enabled via an `overrides` entry in biome.json that targets component
+// implementation files only (`src/components/**/*.tsx`, minus stories and
+// tests). Stories/docs legitimately render the primitive palette
+// (Color.stories.tsx) and demo color inheritance (Text.stories.tsx).
+//
+// ── How it matches ──────────────────────────────────────────────────
+// GritQL's Biome plugin support cannot match a JSX attribute by name, so
+// the pattern matches a whole JSX element and runs a regex over the text
+// of its attribute list (`$props`). Both element forms — with children
+// and self-closing — are covered. A regex hit anywhere in the attribute
+// text (a `className` string literal, or a `cn(...)` argument inside a
+// `className={...}` expression) triggers the diagnostic.
+//
+// ── Suppressing ─────────────────────────────────────────────────────
+// Biome plugin diagnostics are suppressed with the `lint/plugin`
+// category (plugins cannot register a custom rule name):
+//   // biome-ignore lint/plugin: <reason>
+//
+// ── Known gaps ──────────────────────────────────────────────────────
+// - CVA variant definitions in `src/variants/*.ts` are NOT covered:
+//   they hold bare class strings, not JSX. They are guarded by code
+//   review + the state-token-guideline contract.
+// - The diagnostic span is the whole attribute list, not the exact
+//   offending class token.
+
+language js
+
+or {
+  `<$tag $props>$...</$tag>`,
+  `<$tag $props />`
+} where {
+  $props <: r"[\s\S]*\b(?:bg|text|border|ring)-(?:red|orange|amber|yellow|lime|green|emerald|teal|cyan|sky|blue|indigo|violet|purple|fuchsia|pink|rose|slate|gray|grey|zinc|neutral|stone|sumi|vermillion)-[0-9]{2,3}\b[\s\S]*",
+  register_diagnostic(
+    span = $props,
+    message = "Primitive color utility class (e.g. `bg-red-500`, `text-gray-700`) is not allowed in component JSX. Use a semantic token instead — state: `bg-error` / `bg-success-subtle`, foreground: `text-foreground-muted`, surface: `bg-surface`. See .claude/rules/state-token-guideline.md. To keep a primitive class intentionally, add `// biome-ignore lint/plugin: <reason>`.",
+    severity = "error"
+  )
+}

--- a/biome-plugins/no-primitive-color.test.ts
+++ b/biome-plugins/no-primitive-color.test.ts
@@ -1,0 +1,123 @@
+import { execFileSync } from 'node:child_process'
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { afterAll, describe, expect, it } from 'vitest'
+
+// The `no-primitive-color` GritQL plugin has no JS API, so it is exercised
+// the way a consumer would hit it: run `biome lint` over a fixture file and
+// assert on the emitted diagnostics. Each fixture is written into a throwaway
+// temp dir with a minimal biome.json that loads the plugin by absolute path.
+
+const here = dirname(fileURLToPath(import.meta.url))
+const repoRoot = resolve(here, '..')
+const pluginPath = join(here, 'no-primitive-color.grit')
+const biomeBin = join(repoRoot, 'node_modules', '.bin', 'biome')
+
+const workdir = mkdtempSync(join(tmpdir(), 'schatten-no-primitive-color-'))
+writeFileSync(join(workdir, 'biome.json'), JSON.stringify({ plugins: [pluginPath] }))
+
+afterAll(() => rmSync(workdir, { recursive: true, force: true }))
+
+/** Lint `code` as a .tsx file and return the count of plugin diagnostics. */
+function countViolations(code: string): number {
+  const file = join(workdir, 'fixture.tsx')
+  writeFileSync(file, code)
+  let output = ''
+  try {
+    // biome prints diagnostics to stderr and exits non-zero (throwing here)
+    // whenever a violation is found.
+    execFileSync(biomeBin, ['lint', '--colors=off', file], { cwd: workdir, encoding: 'utf8' })
+  } catch (error) {
+    const { stdout, stderr } = error as { stdout?: string; stderr?: string }
+    output = `${stdout ?? ''}${stderr ?? ''}`
+  }
+  return (output.match(/Primitive color utility class/g) ?? []).length
+}
+
+describe('no-primitive-color plugin', () => {
+  describe('flags primitive color utilities in JSX', () => {
+    it('flags a bg- primitive on a self-closing element', () => {
+      expect(countViolations('export const A = () => <div className="bg-red-500" />')).toBe(1)
+    })
+
+    it('flags a text- primitive on an element with children', () => {
+      expect(
+        countViolations('export const A = () => <span className="text-gray-700">x</span>'),
+      ).toBe(1)
+    })
+
+    it('flags border- and ring- primitives', () => {
+      expect(countViolations('export const A = () => <div className="border-blue-300" />')).toBe(1)
+      expect(countViolations('export const A = () => <div className="ring-green-200" />')).toBe(1)
+    })
+
+    it('flags a primitive behind a Tailwind variant prefix', () => {
+      expect(countViolations('export const A = () => <div className="dark:bg-amber-500" />')).toBe(
+        1,
+      )
+    })
+
+    it("flags Schatten's own primitive scales (vermillion, sumi)", () => {
+      expect(countViolations('export const A = () => <div className="bg-vermillion-600" />')).toBe(
+        1,
+      )
+      expect(countViolations('export const A = () => <div className="text-sumi-800" />')).toBe(1)
+    })
+
+    it('flags a primitive class inside a cn() expression', () => {
+      expect(
+        countViolations("export const A = () => <div className={cn('flex', 'bg-pink-400')} />"),
+      ).toBe(1)
+    })
+
+    it('flags a primitive across a multi-line attribute list', () => {
+      const code = [
+        'export const A = () => (',
+        '  <div',
+        '    id="x"',
+        '    className="border-indigo-300"',
+        '  />',
+        ')',
+      ].join('\n')
+      expect(countViolations(code)).toBe(1)
+    })
+  })
+
+  describe('allows semantic tokens', () => {
+    it('does not flag state semantic tokens', () => {
+      expect(
+        countViolations(
+          'export const A = () => <div className="bg-error text-error-foreground" />',
+        ),
+      ).toBe(0)
+    })
+
+    it('does not flag foreground / surface tokens', () => {
+      expect(
+        countViolations(
+          'export const A = () => <div className="bg-surface text-foreground-muted" />',
+        ),
+      ).toBe(0)
+    })
+
+    it('does not flag the theme scale (bg-theme-500 is a semantic token)', () => {
+      expect(countViolations('export const A = () => <div className="bg-theme-500" />')).toBe(0)
+    })
+
+    it('does not flag an element without a primitive color', () => {
+      expect(countViolations('export const A = () => <div className="flex gap-2 p-4" />')).toBe(0)
+    })
+  })
+
+  describe('suppression', () => {
+    it('is silenced by a // biome-ignore lint/plugin comment', () => {
+      const code = [
+        '// biome-ignore lint/plugin: documenting the primitive palette',
+        'export const A = () => <div className="bg-red-500" />',
+      ].join('\n')
+      expect(countViolations(code)).toBe(0)
+    })
+  })
+})

--- a/biome.json
+++ b/biome.json
@@ -54,6 +54,7 @@
     "includes": [
       "src/**",
       ".storybook/**",
+      "biome-plugins/**/*.ts",
       "*.ts",
       "*.json",
       "!dist",
@@ -71,6 +72,10 @@
           "tailwindDirectives": true
         }
       }
+    },
+    {
+      "includes": ["src/components/**/*.tsx", "!**/*.stories.tsx", "!**/*.test.tsx"],
+      "plugins": ["./biome-plugins/no-primitive-color.grit"]
     }
   ]
 }

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,5 +1,5 @@
 {
   "extends": "./tsconfig.json",
-  "include": ["src/**/*", "vitest.setup.ts"],
+  "include": ["src/**/*", "biome-plugins/**/*.ts", "vitest.setup.ts"],
   "exclude": ["node_modules", "dist"]
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,6 +5,6 @@ export default defineConfig({
     environment: 'jsdom',
     globals: true,
     setupFiles: ['./vitest.setup.ts'],
-    include: ['src/**/*.test.{ts,tsx}'],
+    include: ['src/**/*.test.{ts,tsx}', 'biome-plugins/**/*.test.ts'],
   },
 })


### PR DESCRIPTION
## 概要

Closes #122.

`bg-red-500` / `text-gray-700` のような Tailwind primitive 色 utility を JSX で使うことを Biome の GritQL plugin で機械的に禁止します。AI が学習データから無意識に書きがちな違反を CI で止め、semantic token (`bg-error`, `text-foreground-muted` 等) の使用を強制します。

## 実装方針 — Biome GritQL plugin

issue では「Biome plugin (or ESLint で代替)」とありました。Biome 2.4 の GritQL plugin で実装できることを実機確認できたため、ESLint を併存させずに Biome 単体で完結させています(プロジェクトの「Biome single binary」方針を維持)。

検証で判明した GritQL plugin の制約と対応:

| 制約 | 対応 |
|---|---|
| JSX 属性を名前で直接マッチできない | JSX 要素全体をマッチし、属性テキストを正規表現で走査 |
| 複数の top-level `where` ブロックはコンパイル不可 | `or { … } where { … }` で要素2形態(子あり / 自己終了)を統合 |
| 正規表現のキャプチャグループは束縛変数として扱われる | 非キャプチャ `(?: … )` を使用 |
| plugin diagnostic は独自ルール名を登録できない | 抑制は `// biome-ignore lint/plugin: <reason>`(`lint/no-primitive-color` は不可) |

## 変更内容

- **`biome-plugins/no-primitive-color.grit`** — plugin 本体。`{bg,text,border,ring}-{family}-{shade}` を検出。`family` は Tailwind デフォルトパレット全体に加え Schatten 独自の primitive scale(`vermillion` / `sumi` / `gray` / `blue` / `green` / `yellow` / `amber` / `purple`)もカバー。`dark:bg-amber-500` のような variant prefix や `cn(...)` 式内の文字列も検出。`bg-theme-500`(semantic な theme scale)は許可。
- **`biome.json`** — scoped `overrides` で plugin を `src/components/**/*.tsx` のみに適用(`*.stories.tsx` / `*.test.tsx` は除外)。`Color.stories.tsx` は primitive パレットそのものの documentation なので対象外が正。
- **`biome-plugins/no-primitive-color.test.ts`** — fixture に対し `biome lint` を実行して diagnostics を検証する vitest テスト(12 ケース)。`vitest.config.ts` / `tsconfig.test.json` に discovery を追加。
- **ドキュメント** — `state-token-guideline.md` に "Enforcement" セクション、`lint-rules-guideline.md` に "GritQL plugins" セクションを追加。`api-stability.md` の参照も更新。
- **`.github/workflows/ci.yml`** — `develop` ブランチでも CI が発火するよう trigger を追加(本 PR が `develop` 向けのため)。

### 禁止対象外(CVA 定義)

GritQL plugin は JSX 属性のみを対象とし、`src/variants/*.ts` の CVA 定義(JSX を含まない素の class 文字列)は走査できません。issue の「考慮ポイント」通り variants/ は対象外とし、code review + state-token-guideline で担保します。plugin 内および両ドキュメントに既知の gap として明記済み。

## DoD

- [x] Biome custom rule 実装(GritQL plugin)
- [x] `biome.json` で有効化(component 実装ファイルに scoped)
- [x] 既存違反 0 件 — component 実装 `.tsx` には primitive 色クラスなし(stories のみ、これは対象外)
- [x] `pnpm lint` パス
- [x] エラーメッセージで semantic 代替を案内
- [x] rule の使い方を `state-token-guideline.md` に追記
- [x] rule 自体に対する vitest テスト併設(`biome-plugins/no-primitive-color.test.ts`)

## 検証

- `pnpm lint` ✅(149 files, 0 errors)
- `pnpm typecheck` ✅
- `pnpm vitest run` ✅(19 files / 326 tests、うち plugin テスト 12)

🤖 Generated with [Claude Code](https://claude.com/claude-code)