### PR TITLE
chore(changeset): track develop as the base branch

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -8,7 +8,7 @@
   "fixed": [],
   "linked": [],
   "access": "public",
-  "baseBranch": "main",
+  "baseBranch": "develop",
   "updateInternalDependencies": "patch",
   "ignore": []
 }

--- a/.changeset/quiet-laws-develop.md
+++ b/.changeset/quiet-laws-develop.md
@@ -1,0 +1,5 @@
+---
+---
+
+Point the Changesets `baseBranch` at `develop` (release-tooling config only —
+no consumer-facing change, hence an empty changeset).


### PR DESCRIPTION
## 概要

リポジトリのデフォルト/統合ブランチが `develop` に変わったため、Changesets の `baseBranch` をそれに追従させます。

`.changeset/config.json`:

```diff
-  "baseBranch": "main",
+  "baseBranch": "develop",
```

## なぜ

`baseBranch` は `changeset version` と、`--since` を付けない `changeset status` の比較基準になります。`main` のままだと develop と main が乖離した時点で誤ったブランチと差分を取ります。

CI の `changeset` ジョブ側は別途 [#220](https://github.com/yasmro/schatten/pull/220) で `--since=origin/${{ github.base_ref }}` に修正済みで、こちらはローカル/リリース時の挙動を揃えるものです。

## changeset

リリースツーリングの設定変更のみで consumer 影響はないため、空の changeset を同梱しています。

🤖 Generated with [Claude Code](https://claude.com/claude-code)