### PR TITLE
refactor(build): extract CSS asset copy into standalone script (closes #121)

### DIFF
--- a/.changeset/copy-css-assets-script.md
+++ b/.changeset/copy-css-assets-script.md
@@ -1,0 +1,7 @@
+---
+---
+
+Extract the `dist/` CSS asset copy out of tsup's `onSuccess` hook into a
+standalone `build:copy-css` step (`scripts/copy-css-assets.mjs`). Build-pipeline
+refactor only — the `dist/` output is unchanged, so this is an empty changeset
+with no consumer-facing release.

--- a/package.json
+++ b/package.json
@@ -71,10 +71,11 @@
   ],
   "scripts": {
     "dev": "storybook dev -p 6006",
-    "build": "pnpm clean:dist && pnpm build:js && pnpm build:css",
+    "build": "pnpm clean:dist && pnpm build:js && pnpm build:css && pnpm build:copy-css",
     "clean:dist": "rm -rf dist",
     "build:js": "tsup",
     "build:css": "lightningcss src/schatten.css -o dist/schatten.css --minify --bundle",
+    "build:copy-css": "node scripts/copy-css-assets.mjs",
     "build:storybook": "storybook build",
     "test": "vitest",
     "test:ui": "vitest --ui",

--- a/scripts/copy-css-assets.mjs
+++ b/scripts/copy-css-assets.mjs
@@ -1,0 +1,62 @@
+#!/usr/bin/env node
+// Copy the framework-agnostic CSS assets into `dist/`.
+//
+// These `.css` files (token layers + theme palettes) are consumed directly
+// by the `./core/tokens`, `./themes/default`, and `./themes/seasonal/themes.css`
+// entries in package.json's `exports` map. tsup compiles the JS/DTS but never
+// touches `.css`, so this step copies them verbatim.
+//
+// Why a standalone script instead of tsup's `onSuccess`: `onSuccess` only runs
+// for the build group it is attached to. Hanging the copy off the third group
+// (`themes/seasonal/index`) meant a reordering of the config array would
+// silently drop the CSS from `dist/`. Running this as its own `build:copy-css`
+// step makes the copy independent of tsup's build result and entry order.
+//
+// See issue #121.
+
+import { copyFileSync, existsSync, mkdirSync, readdirSync } from 'node:fs'
+import { join } from 'node:path'
+
+// Source/dest directory pairs are derived from these — `src/<dir>` → `dist/<dir>`.
+// Keep in sync with the matching entries in package.json's `exports`.
+const dirs = ['core/tokens', 'themes/default', 'themes/seasonal']
+
+function copyCssAssets() {
+  let copied = 0
+
+  for (const dir of dirs) {
+    const srcDir = `src/${dir}`
+    const destDir = `dist/${dir}`
+
+    if (!existsSync(srcDir)) {
+      throw new Error(
+        `copy-css-assets: source directory "${srcDir}" not found. ` +
+          'Expected one of the CSS asset directories listed in scripts/copy-css-assets.mjs.',
+      )
+    }
+
+    const cssFiles = readdirSync(srcDir).filter((file) => file.endsWith('.css'))
+
+    if (cssFiles.length === 0) {
+      throw new Error(
+        `copy-css-assets: no .css files found in "${srcDir}". ` +
+          'This directory is expected to ship CSS assets — verify the source tree.',
+      )
+    }
+
+    mkdirSync(destDir, { recursive: true })
+    for (const file of cssFiles) {
+      copyFileSync(join(srcDir, file), join(destDir, file))
+      copied++
+    }
+  }
+
+  console.log(`✓ CSS assets copied (${copied} files)`)
+}
+
+try {
+  copyCssAssets()
+} catch (error) {
+  console.error(error instanceof Error ? error.message : error)
+  process.exit(1)
+}

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -1,18 +1,10 @@
-import { copyFileSync, mkdirSync, readdirSync } from 'node:fs'
 import { defineConfig } from 'tsup'
 
-function copyCssAssets() {
-  const dirs = ['core/tokens', 'themes/default', 'themes/seasonal']
-  for (const dir of dirs) {
-    mkdirSync(`dist/${dir}`, { recursive: true })
-    for (const file of readdirSync(`src/${dir}`)) {
-      if (file.endsWith('.css')) {
-        copyFileSync(`src/${dir}/${file}`, `dist/${dir}/${file}`)
-      }
-    }
-  }
-}
-
+// CSS assets are copied into `dist/` by the standalone `build:copy-css` step
+// (scripts/copy-css-assets.mjs), not by a tsup `onSuccess` hook. See issue #121:
+// hanging the copy off a single build group made it silently dependent on the
+// config-array order.
+//
 // `clean` lives in the build script (rimraf via `pnpm clean:dist`) instead of
 // in a single config block — tsup runs all configs in parallel, so a per-config
 // `clean: true` can race with the other configs' DTS emit and silently wipe
@@ -41,7 +33,7 @@ export default defineConfig([
       options.jsx = 'automatic'
     },
   },
-  // Seasonal theme utilities + CSS asset copy
+  // Seasonal theme utilities
   {
     entry: {
       'themes/seasonal/index': 'src/themes/seasonal/index.ts',
@@ -49,6 +41,5 @@ export default defineConfig([
     format: ['esm', 'cjs'],
     dts: true,
     external: ['react', 'react-dom'],
-    onSuccess: copyCssAssets,
   },
 ])


### PR DESCRIPTION
## 概要

[#121](https://github.com/yasmro/schatten/issues/121) — tsup の CSS 複製を `onSuccess` フックから独立スクリプトへ切り出す。

`onSuccess` は紐付いた build group (`themes/seasonal/index` — 3 番目) の成功時にしか走らないため、`tsup.config.ts` の config 配列の順序を変えると CSS 複製がサイレントに崩れる脆弱性があった。tsup の build 結果に依存しない独立スクリプトへ切り出す。

## 変更内容

- **`scripts/copy-css-assets.mjs` 新規作成** — `src/{core/tokens,themes/default,themes/seasonal}/*.css` を `dist/` へ複製。複製対象ディレクトリは従来どおり変更なし。
  - エラーハンドリング: source ディレクトリが見つからない / CSS ファイルが 0 件の場合は明確なメッセージで `exit 1`。
  - glob 依存なし — `readdirSync` + filter のみ。
- **`package.json`** — `build:copy-css` script を追加し、`build` を `clean:dist → build:js → build:css → build:copy-css` の chain に。
- **`tsup.config.ts`** — `onSuccess: copyCssAssets` とローカルの `copyCssAssets` 関数を削除。

コンポーネント単位の CSS (`Toast.css` / `Spinner.css`) は引き続き `schatten.css` 経由でのみ配布（issue の案 B = 現状維持）。`dist/components/**` の出力に変更なし。

## 確認

- `pnpm build` がクリーン状態から end-to-end で成功 (exit 0)。
- `dist/core/tokens`, `dist/themes/default`, `dist/themes/seasonal` に `.css` が 11 ファイル含まれることを確認。dist 出力は従来と同等。
- `pnpm lint` / `typecheck` (pre-commit hook) パス。

## DoD

- [x] `scripts/copy-css-assets.mjs` 作成
- [x] `package.json` の `build` スクリプトを更新 (3 ステップ chain → 4 ステップ)
- [x] `tsup.config.ts` から `onSuccess: copyCssAssets` 削除
- [x] `pnpm build` で全 dist 出力が以前と同等であることを確認
- [x] `dist/core/tokens`, `dist/themes/default`, `dist/themes/seasonal` に `.css` が含まれることを確認

Closes #121

🤖 Generated with [Claude Code](https://claude.com/claude-code)