### PR TITLE
ci: run Storybook Preview and VRT on develop-targeted PRs

### DIFF
--- a/.changeset/storybook-vrt-develop-trigger.md
+++ b/.changeset/storybook-vrt-develop-trigger.md
@@ -1,0 +1,9 @@
+---
+---
+
+Run the Storybook Preview and VRT workflows on `develop`-targeted PRs, not
+just `main` (CI config only — no consumer-facing change, hence an empty
+changeset). `ci.yml` already triggered on `[main, develop]`; the
+`storybook-preview.yml` and `vrt.yml` workflows were left on `[main]` when the
+repo moved to a develop-based flow, so develop PRs got no Storybook preview
+and no visual-regression check.

--- a/.github/workflows/storybook-preview.yml
+++ b/.github/workflows/storybook-preview.yml
@@ -3,7 +3,7 @@ name: Storybook Preview
 on:
   pull_request:
     types: [opened, synchronize, reopened, closed]
-    branches: [main]
+    branches: [main, develop]
 
 permissions:
   contents: write

--- a/.github/workflows/vrt.yml
+++ b/.github/workflows/vrt.yml
@@ -2,7 +2,7 @@ name: VRT
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, develop]
 
 jobs:
   vrt:


### PR DESCRIPTION
## 概要

`develop` ベースの開発フロー移行時の **CI トリガー設定漏れ**を修正する。

## 問題

リポジトリは PR を `develop` 宛てに作る運用に移行した([#221](https://github.com/yasmro/schatten/pull/221))。`ci.yml`(lint / test / typecheck)は `branches: [main, develop]` に更新済みだが、以下 2 つが `branches: [main]` のまま取り残されていた:

- `storybook-preview.yml` — PR ごとの Storybook プレビューデプロイ
- `vrt.yml` — ビジュアルリグレッションテスト

`pull_request` の `branches` フィルタは **PR の base ブランチ**で判定されるため、base=`develop` の PR では両ワークフローが一切発火しない。結果、develop 宛て PR は **Storybook プレビューも VRT も得られない**状態だった。

## 修正

両ワークフローの `branches` を `[main]` → `[main, develop]` に。`ci.yml` と揃える。

| ワークフロー | Before | After |
|---|---|---|
| `ci.yml` | `[main, develop]` | (変更なし) |
| `storybook-preview.yml` | `[main]` | `[main, develop]` |
| `vrt.yml` | `[main]` | `[main, develop]` |

`deploy-storybook.yml`(本番デプロイ)は `push: [main]` のままで正しいので変更なし。

## 影響

- CI 設定のみ。公開パッケージに変更なし(空 changeset を同梱、`#221` の前例に倣う)。
- マージ後、develop 宛ての全 PR(#223 含む)で Storybook プレビュー + VRT が動くようになる。

🤖 Generated with [Claude Code](https://claude.com/claude-code)