### PR TITLE
chore(ci): publish per-PR preview builds via pkg.pr.new

### DIFF
--- a/.github/workflows/preview-release.yml
+++ b/.github/workflows/preview-release.yml
@@ -1,0 +1,37 @@
+name: Preview Release
+
+# Publishes a per-commit preview build to pkg.pr.new on every PR, so the
+# package can be installed and verified (e.g. SSR-tested in CodeSandbox /
+# StackBlitz) before merge. pkg.pr.new serves the build from its own CDN —
+# nothing is published to the npm registry.
+#
+# Requires the pkg.pr.new GitHub App to be installed on this repository:
+#   https://github.com/apps/pkg-pr-new
+# The App requests repository-level permissions only (no org-level access);
+# scoping the install to this repo keeps it fully contained. No npm token or
+# repository secret is needed.
+
+on:
+  pull_request:
+    branches: [main, develop]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: pnpm/action-setup@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Build package
+        run: pnpm build
+
+      - name: Publish preview to pkg.pr.new
+        run: pnpm dlx pkg-pr-new publish --pnpm

--- a/package.json
+++ b/package.json
@@ -153,7 +153,10 @@
   "pnpm": {
     "overrides": {
       "postcss@<8.5.10": ">=8.5.10"
-    }
+    },
+    "onlyBuiltDependencies": [
+      "lightningcss-cli"
+    ]
   },
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## 概要

PR ごとにパッケージをビルドして [pkg.pr.new](https://github.com/stackblitz-labs/pkg.pr.new) にアップロードする `Preview Release` ワークフローを追加します。pkg.pr.new が PR にインストール用 URL をコメントで返すため、**マージ前に PR のビルド成果物を実際の利用者環境で検証**できるようになります（例: CodeSandbox / StackBlitz での Next.js App Router SSR ビルド確認 → #116 の DoD 検証）。

## 仕組み

1. `main` / `develop` 宛ての PR で CI が `pnpm build`
2. `pkg-pr-new publish` が成果物を pkg.pr.new の CDN にアップロード（**npm レジストリには publish しない**）
3. bot が PR に `pnpm add https://pkg.pr.new/yasmro/schatten@<PR番号>` 形式の URL をコメント

トークン・シークレット登録は不要です。

## ⚠️ マージ前の前提作業（リポジトリ管理者）

`pkg-pr-new publish` ステップは **pkg.pr.new GitHub App が未インストールだと失敗**します。マージ前に以下を実施してください:

- https://github.com/apps/pkg-pr-new から `yasmro/schatten` リポジトリにインストール
- インストール範囲は **"Only select repositories" → `schatten` のみ** を推奨

### セキュリティ（権限）

pkg.pr.new が要求するのは **repository-level 権限のみ**で、organization-level 権限は一切ありません。リポジトリを限定すれば影響は `schatten` 内に完全に閉じます。

| 権限 | レベル | 内容 |
|---|---|---|
| Metadata | repo | 読み取り |
| Contents | repo | 読み取りのみ |
| Pull Requests | repo | 読み書き（install URL のコメント投稿） |
| Checks | repo | 読み書き |
| Commit Status | repo | 読み書き |

## 関連

- #116（SSR 対応）の実機検証手段として整備

🤖 Generated with [Claude Code](https://claude.com/claude-code)