### PR TITLE
perf(build): make lv1 barrel tree-shakeable via per-component entries

### DIFF
--- a/.changeset/lv1-barrel-tree-shaking.md
+++ b/.changeset/lv1-barrel-tree-shaking.md
@@ -1,0 +1,14 @@
+---
+'@yasmro/schatten': patch
+---
+
+Make the `components/lv1` barrel tree-shakeable. `tsup` now builds each lv1
+component as its own ESM entry with code splitting, instead of bundling all 17
+components into one shared chunk. A consumer importing a single component drops
+~81 % — `import { Button }` goes from ~48 KB to ~9.7 KB (minified + brotlied).
+
+No public API change: the `package.json#exports` map is unchanged (same `.`
+and `./components/lv1` entry points), and consumers write imports exactly as
+before. CJS keeps the single-barrel build (`require()` does not tree-shake).
+See `docs/decisions/2026-05-lv1-barrel-tree-shaking.md` for the root-cause
+analysis and the alternatives that were rejected.

--- a/.size-limit.json
+++ b/.size-limit.json
@@ -8,7 +8,7 @@
     "name": "components/lv1 (Button only, tree-shaken)",
     "path": "dist/components/lv1/index.js",
     "import": "{ Button }",
-    "limit": "55 KB"
+    "limit": "12 KB"
   },
   {
     "name": "variants",

--- a/docs/decisions/2026-05-lv1-barrel-tree-shaking.md
+++ b/docs/decisions/2026-05-lv1-barrel-tree-shaking.md
@@ -1,0 +1,167 @@
+# lv1 Barrel Tree-Shaking — Design Decision Log
+
+| | |
+|---|---|
+| Date | 2026-05-18 |
+| Status | Accepted |
+| Related issue | [#119](https://github.com/yasmro/schatten/issues/119) |
+| Related PR | [#226](https://github.com/yasmro/schatten/pull/226) (size-limit CI — predecessor) |
+| Related rules | [api-stability.md](../../.claude/rules/api-stability.md) |
+| Files affected | `tsup.config.ts`, `.size-limit.json` |
+
+## Context
+
+The `@yasmro/schatten/components/lv1` barrel did not tree-shake. A consumer
+importing a single component pulled in the entire library.
+
+The evidence came from the `.size-limit.json` added in PR #226: the
+`components/lv1 (Button only, tree-shaken)` entry — which imports `{ Button }`
+from `dist/components/lv1/index.js` — measured **48.31 KB**, essentially
+identical to the `components/lv1 (all)` entry at **48.46 KB** (both minified +
+brotlied, peer deps excluded). Importing one component cost the same as
+importing all 17.
+
+### Root cause
+
+`tsup.config.ts` built `src/components/lv1/index.ts` as a **single bundled
+entry**. That produced:
+
+- `dist/components/lv1/index.js` — a ~1 KB barrel that only re-exports.
+- `dist/chunk-*.js` — one ~142 KB raw chunk containing **all 17 components
+  plus all of their bundled Radix dependencies**, concatenated into a single
+  module scope.
+
+A consumer's bundler, when it sees `import { Button }` resolve into that
+shared chunk, can only tree-shake a top-level declaration if the declaration's
+initializer is provably side-effect-free. esbuild emits `var Button =
+forwardRef(...)`, `var Dialog = forwardRef(...)`, etc. **without** a
+`/* @__PURE__ */` annotation, and emits the bundled Radix internals the same
+way. With no annotation, a call expression is assumed to have side effects, so
+every component declaration — and everything it transitively references — is
+retained. One unshakeable chunk.
+
+## Decision
+
+Build each lv1 component as **its own tsup ESM entry**, with code splitting
+enabled. `src/components/lv1/index.ts` and `src/components/index.ts` remain
+entries too; esbuild rewrites the barrels to re-export from the per-component
+entry files. Shared code (`cn`, CVA variant tables, Radix primitives) is
+deduplicated into shared chunks that load only when a component that needs
+them is imported.
+
+CJS is **not** split — the two barrels (`components/index`,
+`components/lv1/index`) are still bundled whole for `require()` consumers.
+
+The `package.json#exports` map is unchanged: the same two public entry points
+(`.` and `./components/lv1`) are published. No per-component subpath exports
+were added — the barrel itself now tree-shakes, so subpaths would add public
+API surface without adding capability.
+
+`.size-limit.json`'s `Button only` budget is lowered from **55 KB to 12 KB**.
+
+## Rationale — alternatives considered
+
+Three fixes were evaluated empirically (esbuild re-bundle, minified, brotli,
+peer deps external):
+
+| Approach | `import { Button }` | Verdict |
+|---|---|---|
+| **Current** — single bundled chunk | 49.5 KB | baseline |
+| **Maximal `/* @__PURE__ */` annotation** — every component declaration + every `cva()` + every `createContext()` in the chunk annotated | **48.3 KB** | **rejected — 0 % improvement** |
+| **Per-component ESM entries + splitting** | **9.5 KB (−81 %)** | **chosen** |
+
+### Why pure annotations were rejected
+
+Annotating *our own* `forwardRef` / `cva` calls is necessary-but-insufficient.
+The single chunk's weight is dominated by **Radix internals** —
+`React.forwardRef(...)`, `createContext(...)`, IIFEs, prototype mutations —
+which live in `node_modules` and which we cannot annotate. A patched build
+that annotated every declaration we *could* reach still measured 48.3 KB for
+`{ Button }`: no improvement. Pre-bundling third-party code into one module
+scope is fundamentally hostile to consumer-side tree-shaking, and no amount of
+annotation on the slice we control changes that.
+
+### Why the `treeshake` tsup option was rejected
+
+`treeshake` removes code that is dead *from the bundle's own entry's
+perspective*. The barrel deliberately re-exports all 17 components, so nothing
+is dead — the problem is entirely consumer-side. The option is irrelevant
+here.
+
+### Why per-component subpath exports were not added
+
+A per-component subpath (`./components/lv1/Button`) measured an identical
+9.5 KB to importing `{ Button }` from the tree-shaken barrel — it adds no
+capability. It *would* add public API surface (every subpath becomes a
+contract under [api-stability.md](../../.claude/rules/api-stability.md)) and
+would require per-component CJS targets, duplicating bundled Radix across 17
+standalone files and bloating the published package. Subpaths remain a
+possible future addition — doing so later is additive and non-breaking.
+
+### Why CJS is not split
+
+`require()` consumers do not benefit from tree-shaking, and per-component CJS
+files would duplicate the bundled Radix code across 17 standalone bundles,
+inflating the npm package for no consumer gain. CJS keeps the single-barrel
+build.
+
+## Consequences
+
+**Positive**
+
+- A single-component import drops ~81 % (`{ Button }`: 49.5 KB → 9.5 KB;
+  `{ Dialog }`: 19.9 KB). The barrel tree-shakes with no change to how
+  consumers write imports.
+- Both public entry points (`.` and `./components/lv1`) benefit — the root
+  entry re-exports the lv1 barrel and shakes the same way.
+- New lv1 components are picked up automatically: `tsup.config.ts` enumerates
+  `src/components/lv1/*/index.ts`, so adding a component needs no build-config
+  edit.
+
+**Negative / trade-offs**
+
+- `dist/` gains 17 per-component ESM files and per-component CSS files
+  (`Dialog/index.css`, etc.) instead of one `index.css`. None are in the
+  `exports` map, so per [api-stability.md](../../.claude/rules/api-stability.md)
+  they are not public API and may change freely. The published package is
+  marginally larger in raw file count; the shared-chunk dedup keeps total
+  bytes essentially flat.
+- CJS consumers still get the whole library on any import. Accepted: `require`
+  does not tree-shake regardless.
+- ESM and CJS now build in separate tsup config blocks (splitting is
+  ESM-only), and a third block emits the barrels' `.d.ts` / `.d.cts`. More
+  config blocks, but each has a single clear responsibility.
+
+## Verification
+
+Built with the new config and measured with `size-limit`
+(`@size-limit/preset-small-lib`, esbuild + brotli, peer deps excluded):
+
+| size-limit entry | Before | After | Budget |
+|---|---|---|---|
+| `components/lv1 (Button only, tree-shaken)` | ~48.3 KB | **9.67 KB** | 12 KB |
+| `components/lv1 (all)` | ~48.5 KB | 48.65 KB | 60 KB |
+
+The `Button only` budget is set to 12 KB — comfortably above the 9.67 KB
+measured, well under the ~20 KB [#119](https://github.com/yasmro/schatten/issues/119)
+originally targeted, leaving headroom for Button to grow before the budget
+needs revisiting.
+
+> **Note on `.size-limit.json`.** The size-limit *tooling* (the `size-limit`
+> devDependencies, the `size` / `size:why` scripts, the CI job) is introduced
+> by PR #226. This change carries only `.size-limit.json` with the lowered
+> budget; it assumes #226 lands first. If the two are reconciled, keep the
+> 12 KB `Button only` limit.
+
+## Review history
+
+| Date | Reviewer | Notes |
+|---|---|---|
+| 2026-05-18 | Yu Ohno (engineering) | Investigation, measurement, and implementation |
+
+## References
+
+- Issue [#119](https://github.com/yasmro/schatten/issues/119) — bundle-size monitoring + tree-shaking target
+- PR [#226](https://github.com/yasmro/schatten/pull/226) — size-limit CI (predecessor)
+- [api-stability.md](../../.claude/rules/api-stability.md) — what counts as public API (the `exports` map)
+- [esbuild — `/* @__PURE__ */` annotations](https://esbuild.github.io/api/#pure)

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -14,6 +14,8 @@ contributors (or your future self) might reasonably want to re-litigate:
 - API choices where multiple defensible options were on the table
 - Accessibility / contrast trade-offs that go beyond WCAG minimums
 - Theme / Mode / Special partitioning decisions
+- Build / bundling / packaging trade-offs — output layout, tree-shaking,
+  entry points, `exports`-map shape
 - "We considered X but rejected it because Y" — capture both X and Y
 
 Skip an entry when:

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -1,3 +1,4 @@
+import { existsSync, readdirSync } from 'node:fs'
 import { defineConfig } from 'tsup'
 
 // CSS assets are copied into `dist/` by the standalone `build:copy-css` step
@@ -9,6 +10,28 @@ import { defineConfig } from 'tsup'
 // in a single config block — tsup runs all configs in parallel, so a per-config
 // `clean: true` can race with the other configs' DTS emit and silently wipe
 // already-written outputs (this was hitting `dist/themes/seasonal/index.d.ts`).
+
+// One ESM entry per lv1 component directory. Building each component as its
+// own entry (instead of a single bundled barrel) is what makes the public
+// `components/lv1` barrel tree-shakeable: a consumer importing `{ Button }`
+// pulls in only Button's module + its shared chunks, not all 17 components.
+// A single pre-bundled barrel chunk cannot be shaken — its weight is dominated
+// by Radix internals that carry no `/* @__PURE__ */` annotations, so a
+// consumer bundler has to retain the whole chunk. See
+// docs/decisions/2026-05-lv1-barrel-tree-shaking.md.
+const LV1_DIR = 'src/components/lv1'
+const lv1ComponentEntries = Object.fromEntries(
+  readdirSync(LV1_DIR, { withFileTypes: true })
+    .filter((d) => d.isDirectory() && existsSync(`${LV1_DIR}/${d.name}/index.ts`))
+    .map((d) => [`components/lv1/${d.name}/index`, `${LV1_DIR}/${d.name}/index.ts`]),
+)
+
+// The two barrel entries that `package.json#exports` actually publishes.
+const componentBarrelEntries = {
+  'components/index': 'src/components/index.ts',
+  'components/lv1/index': 'src/components/lv1/index.ts',
+}
+
 export default defineConfig([
   // Variants & tokens (no React, for Astro / non-React consumers)
   {
@@ -20,18 +43,43 @@ export default defineConfig([
     dts: true,
     external: ['react', 'react-dom', 'lucide-react'],
   },
-  // Components (React)
+  // Components — ESM. Per-component entries + code splitting: each component
+  // becomes its own module, shared code (`cn`, variants, Radix) lands in
+  // chunks. The barrel re-exports from those entries, so `import { Button }`
+  // tree-shakes down to Button + its chunks only.
   {
     entry: {
-      'components/index': 'src/components/index.ts',
-      'components/lv1/index': 'src/components/lv1/index.ts',
+      ...componentBarrelEntries,
+      ...lv1ComponentEntries,
     },
-    format: ['esm', 'cjs'],
-    dts: true,
+    format: ['esm'],
+    dts: false,
+    splitting: true,
     external: ['react', 'react-dom', 'lucide-react'],
     esbuildOptions(options) {
       options.jsx = 'automatic'
     },
+  },
+  // Components — CJS. Barrels only: `require()` consumers do not tree-shake,
+  // and emitting per-component CJS files would duplicate the bundled Radix
+  // code across 17 standalone bundles and bloat the published package.
+  {
+    entry: componentBarrelEntries,
+    format: ['cjs'],
+    dts: false,
+    external: ['react', 'react-dom', 'lucide-react'],
+    esbuildOptions(options) {
+      options.jsx = 'automatic'
+    },
+  },
+  // Components — type declarations. Only the two published barrel entries
+  // need `.d.ts` / `.d.cts`; the per-component ESM entries are an internal
+  // build detail and are not part of `package.json#exports`.
+  {
+    entry: componentBarrelEntries,
+    format: ['esm', 'cjs'],
+    dts: { only: true },
+    external: ['react', 'react-dom', 'lucide-react'],
   },
   // Seasonal theme utilities
   {


### PR DESCRIPTION
## What

Makes the `@yasmro/schatten/components/lv1` barrel **tree-shakeable**. A consumer importing a single component now drops ~81 % — `import { Button }` goes from ~48 KB to **9.67 KB** (minified + brotlied).

## Why

The barrel did not tree-shake: importing one component cost the same as importing all 17.

`tsup` built `src/components/lv1/index.ts` as a **single bundled entry**, producing one ~142 KB chunk that holds all 17 components plus their bundled Radix dependencies in one module scope. A consumer's bundler cannot shake it: esbuild emits `var Button = forwardRef(...)` — and every Radix internal — **without a `/* @__PURE__ */` annotation**, so the call is assumed side-effecting and the whole chunk is retained.

## Approach — alternatives evaluated

Measured empirically (esbuild re-bundle, minified, brotli, peer deps external):

| Approach | `import { Button }` | Verdict |
|---|---|---|
| Current — single chunk | 49.5 KB | baseline |
| Maximal `/* @__PURE__ */` (every decl + `cva` + `createContext` annotated) | 48.3 KB | **rejected — 0 % gain** |
| **Per-component ESM entries + `splitting`** | **9.5 KB (−81 %)** | **chosen** |

- **Pure annotations** are necessary-but-insufficient — the chunk's weight is Radix internals in `node_modules` that we cannot annotate.
- **`treeshake` tsup option** is irrelevant — the barrel has no dead code from its own perspective; the problem is consumer-side.
- **Per-component subpath exports** measured identical to the shaken barrel — no capability gain, adds public API surface, needs CJS targets — not added.

Full root-cause analysis and rejected alternatives: [`docs/decisions/2026-05-lv1-barrel-tree-shaking.md`](docs/decisions/2026-05-lv1-barrel-tree-shaking.md).

## Changes

- **`tsup.config.ts`** — components build in 3 blocks: ESM per-component entries (auto-enumerated from `src/components/lv1/*/index.ts`, so new components need no config edit) + `splitting`; CJS barrels-only (avoids duplicating Radix across 17 standalone files); a dts-only block for the two published barrels.
- **`.size-limit.json`** — `Button only` budget lowered **55 KB → 12 KB** (9.67 KB measured + headroom).
- Decision doc + changeset (`patch`).

## Not a public API change

The `package.json#exports` map is unchanged — same `.` and `./components/lv1` entry points, consumers write imports exactly as before. New per-component files in `dist/` are not in the `exports` map, so per [api-stability.md](.claude/rules/api-stability.md) they are not public API. CJS keeps the single-barrel build (`require()` does not tree-shake).

## Verification

- `size-limit` on the rebuilt dist: **Button only = 9.67 KB** (budget 12 KB ✓), all = 48.65 KB ✓.
- `pnpm build:js`, `biome ci`, `publint`, `pnpm typecheck` pass; ESM barrel, root `.`, and CJS barrel smoke-tested in Node.

## Reviewer note

`.size-limit.json` lives on #226's branch, not `develop` yet. This is a **follow-up to #226** — the size-limit *tooling* (`size-limit` devDeps, `size`/`size:why` scripts, CI job) lands in #226; this branch carries only the lowered `.size-limit.json` budget. If #226 and this PR are reconciled, keep the 12 KB `Button only` limit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)