### PR TITLE
docs(rules): sync api-stability.md schedule — class-name audit/manifest → v0.9.0, link CSS variable audit

### DIFF
--- a/.claude/rules/api-stability.md
+++ b/.claude/rules/api-stability.md
@@ -172,14 +172,17 @@ need to be intentional now, not later. Two checkpoints:
    shape (`base / hover / foreground / subtle` — see
    [state-token-guideline](state-token-guideline.md)) is final before 1.0.
 
-The class-name audit is scheduled for v0.14.0 (#58 Phase 2). The CSS variable
-audit has no fixed release yet; the only hard requirement is that it lands
-**before v1.0.0**. CONTRIBUTING.md (planned for v0.15.0) will reference this
-document as the source of truth for what consumers can rely on.
+The class-name audit is scheduled for v0.9.0 (#58 Phase 2, implemented by
+[#154](https://github.com/yasmro/schatten/issues/154) — pulled forward from
+v0.14.0 so it lands before the lv2 components, see #154 for the rationale).
+The CSS variable audit has no fixed release yet; the only hard requirement is
+that it lands **before v1.0.0**. CONTRIBUTING.md (planned for v0.15.0) will
+reference this document as the source of truth for what consumers can rely on.
 
 ## Manifest as the authoritative API listing (planned)
 
-A `dist/schatten.manifest.json` file is planned for v0.14.0. It will list every
+A `dist/schatten.manifest.json` file is planned for v0.9.0 (part of
+[#154](https://github.com/yasmro/schatten/issues/154)). It will list every
 public class, every CSS variable, and every exported symbol — i.e. the
 machine-readable form of this contract. The intent is for a CI lint to diff
 the generated manifest against the committed one and require a changeset when

--- a/.claude/rules/api-stability.md
+++ b/.claude/rules/api-stability.md
@@ -175,9 +175,11 @@ need to be intentional now, not later. Two checkpoints:
 The class-name audit is scheduled for v0.9.0 (#58 Phase 2, implemented by
 [#154](https://github.com/yasmro/schatten/issues/154) — pulled forward from
 v0.14.0 so it lands before the lv2 components, see #154 for the rationale).
-The CSS variable audit has no fixed release yet; the only hard requirement is
-that it lands **before v1.0.0**. CONTRIBUTING.md (planned for v0.15.0) will
-reference this document as the source of truth for what consumers can rely on.
+The CSS variable audit is tracked by
+[#231](https://github.com/yasmro/schatten/issues/231) (currently milestoned at
+v0.15.0 as a backstop); the only hard requirement is that it lands **before
+v1.0.0**. CONTRIBUTING.md (planned for v0.15.0) will reference this document as
+the source of truth for what consumers can rely on.
 
 ## Manifest as the authoritative API listing (planned)
 


### PR DESCRIPTION
## 概要

`.claude/rules/api-stability.md` のスケジュール記述を、今回のロードマップ整理に同期します。

## 変更内容

1. **クラス名 audit: `v0.14.0` → `v0.9.0`** — [#154](https://github.com/yasmro/schatten/issues/154)（= #58 Phase 2）を lv2 着手前に前倒ししたため
2. **`dist/schatten.manifest.json`: `v0.14.0` → `v0.9.0`** — 同上（#154 の出口条件）
3. **CSS 変数 audit に追跡 issue を紐付け** — 新規 [#231](https://github.com/yasmro/schatten/issues/231)（外部 Tailwind / 消費者トークンとの `--color-*` 衝突回避・命名の名前空間化）。milestone は v0.15.0 をバックストップとして設定

## なぜ #154 を前倒ししたか

#116 の SSR 検証で「消費者が Tailwind なしで schatten をスタイルできない」と判明。恒久解決は #154（意味的クラス + コンポーネント CSS 同梱）に集約される。遅らせるほど v0.9〜v0.13 で増えるコンポーネントを後から `@layer components` へ retrofit する債務が膨らむため、lv2 着手前の v0.9.0 へ移動。

ドキュメントのみ・公開パッケージに影響なしのため `no-changeset`。

## 関連

- [#154](https://github.com/yasmro/schatten/issues/154) — 実装本体（milestone v0.9.0 に更新済み）
- [#58](https://github.com/yasmro/schatten/issues/58) — umbrella（Phase 2 / milestone v0.9.0 に更新済み）
- [#231](https://github.com/yasmro/schatten/issues/231) — CSS 変数命名 audit（新規）
- 旧 #229（生ユーティリティ配布案）はカニバル懸念によりクローズ済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)