### PR TITLE
feat(tokens): 藍 (indigo) primitive color scale を追加 (closes #181)

### DIFF
--- a/.changeset/indigo-primitive-scale.md
+++ b/.changeset/indigo-primitive-scale.md
@@ -1,0 +1,17 @@
+---
+'@yasmro/schatten': minor
+---
+
+CSS API: add the `--indigo-*` primitive color scale (`--indigo-50` … `--indigo-950`),
+a traditional Japanese indigo (藍) intended as the second brand color alongside
+vermillion (朱). Registered in the Tailwind `@theme` so `bg-indigo-*` / `text-indigo-*`
+utilities are available, and shown in the Foundation/Color story next to the
+vermillion scale.
+
+This is purely additive — `--blue-*` is untouched and stays pinned to the
+`info` semantic. The indigo scale is hue-shifted toward purple (hue 265) and
+more saturated than `blue`, giving a deeper, darker character. OKLCH values and
+WCAG AA contrast were verified in #181: solid treatment reaches 4.78 (light, on
+`-500`) and 5.73 (dark, on `-400`).
+
+Semantic-layer integration (`--color-indigo`) lands separately in #185.

--- a/src/core/tokens/base.css
+++ b/src/core/tokens/base.css
@@ -132,6 +132,19 @@
   --color-gray-900: var(--gray-900);
   --color-gray-950: var(--gray-950);
 
+  /* Indigo scale (brand color — 藍) */
+  --color-indigo-50: var(--indigo-50);
+  --color-indigo-100: var(--indigo-100);
+  --color-indigo-200: var(--indigo-200);
+  --color-indigo-300: var(--indigo-300);
+  --color-indigo-400: var(--indigo-400);
+  --color-indigo-500: var(--indigo-500);
+  --color-indigo-600: var(--indigo-600);
+  --color-indigo-700: var(--indigo-700);
+  --color-indigo-800: var(--indigo-800);
+  --color-indigo-900: var(--indigo-900);
+  --color-indigo-950: var(--indigo-950);
+
   /* Blue scale */
   --color-blue-50: var(--blue-50);
   --color-blue-100: var(--blue-100);

--- a/src/core/tokens/primitives.css
+++ b/src/core/tokens/primitives.css
@@ -68,6 +68,27 @@
   --vermillion-900: oklch(0.27 0.07 22);
   --vermillion-950: oklch(0.15 0.05 22);
 
+  /* Brand: Indigo (藍) — Japanese traditional indigo, the second brand color
+   * alongside vermillion (朱). Distinct from --blue-* (which stays pinned to the
+   * lighter `info` semantic): indigo is hue-shifted toward purple and more
+   * saturated for a deeper, darker character.
+   * Note: hue 265 sits in the 紺 (kon) color range — literal 藍色 (ai-iro) is a
+   * greener blue (hue ≈ 237). Final wording of this Japanese-name comment is a
+   * deferred designer call (see issue #181).
+   * Gamut: -50 / -100 chroma are clamped to the sRGB ceiling at hue 265
+   * (≈0.014 / ≈0.033) — specifying higher would silently clamp anyway. */
+  --indigo-50: oklch(0.97 0.014 265);
+  --indigo-100: oklch(0.93 0.033 265);
+  --indigo-200: oklch(0.86 0.07 265);
+  --indigo-300: oklch(0.77 0.11 265);
+  --indigo-400: oklch(0.67 0.14 265);
+  --indigo-500: oklch(0.55 0.16 265);
+  --indigo-600: oklch(0.46 0.15 265);
+  --indigo-700: oklch(0.37 0.13 265);
+  --indigo-800: oklch(0.28 0.1 265);
+  --indigo-900: oklch(0.2 0.07 265);
+  --indigo-950: oklch(0.13 0.04 265);
+
   /* Blue scale (default primary) */
   --blue-50: oklch(0.98 0.01 250);
   --blue-100: oklch(0.96 0.02 250);

--- a/src/core/tokens/primitives.css
+++ b/src/core/tokens/primitives.css
@@ -55,7 +55,8 @@
   --paper-warm-inverted: #1e1e1c;
   --paper-cream-inverted: #44403a;
 
-  /* Accent: Vermillion (Japanese traditional, brand anchor: 600 ≈ #c53d43) */
+  /* Brand: Vermillion (朱) — Japanese traditional vermillion, brand anchor: 600 ≈ #c53d43.
+   * The first brand color; backs the --color-accent semantic. */
   --vermillion-50: oklch(0.98 0.02 22);
   --vermillion-100: oklch(0.96 0.04 22);
   --vermillion-200: oklch(0.91 0.08 22);

--- a/src/docs/Color.stories.tsx
+++ b/src/docs/Color.stories.tsx
@@ -514,6 +514,28 @@ export const Colors: Story = {
         ]}
       />
 
+      <SubsectionTitle>Indigo (藍)</SubsectionTitle>
+      <p className="text-sm text-foreground-muted mb-3">
+        Traditional Japanese indigo, the second brand color alongside vermillion. Deeper and more
+        saturated than the <code>blue</code> scale, which stays pinned to the lighter{' '}
+        <code>info</code> semantic.
+      </p>
+      <ScaleRow
+        shades={[
+          { level: '50', className: 'bg-indigo-50' },
+          { level: '100', className: 'bg-indigo-100' },
+          { level: '200', className: 'bg-indigo-200' },
+          { level: '300', className: 'bg-indigo-300' },
+          { level: '400', className: 'bg-indigo-400' },
+          { level: '500', className: 'bg-indigo-500' },
+          { level: '600', className: 'bg-indigo-600' },
+          { level: '700', className: 'bg-indigo-700' },
+          { level: '800', className: 'bg-indigo-800' },
+          { level: '900', className: 'bg-indigo-900' },
+          { level: '950', className: 'bg-indigo-950' },
+        ]}
+      />
+
       <SubsectionTitle>Green</SubsectionTitle>
       <ScaleRow
         shades={[


### PR DESCRIPTION
## 概要

朱 (vermillion) と並ぶブランド色として、藍 (indigo) の primitive scale を追加します。Color system v2 (semantic 層の brand-named tokens — #185) の前提となる、依存チェーンの起点です。

`--blue-*` は **削除せず据え置き**: `info` semantic を支える明るめの青として継続利用します ([state-token-guideline](.claude/rules/state-token-guideline.md) により `info` は blue にピン留め)。`--indigo-*` は hue を紫寄り (265) に振り、彩度を高めた「深い・濃い藍」です。

## 採用値

#181 のレビュー結論に従い、**仮スケール (hue 265 / chroma ピーク 0.16) をそのまま採用**しました。派生検討した「紺・勝色アンカー版」「vivid 版」はいずれも hue が 264〜265 に収束し、仮スケールから動かす利点が無いとの結論です。Solid light の WCAG コントラストも仮スケールが最良 (4.78)。

| shade | OKLCH | 備考 |
|---|---|---|
| 50  | `0.97 0.014 265` | chroma を sRGB 色域上限へ丸め |
| 100 | `0.93 0.033 265` | chroma を sRGB 色域上限へ丸め |
| 200 | `0.86 0.07 265` | |
| 300 | `0.77 0.11 265` | |
| 400 | `0.67 0.14 265` | dark base 想定 |
| 500 | `0.55 0.16 265` | 主色候補 |
| 600 | `0.46 0.15 265` | |
| 700 | `0.37 0.13 265` | |
| 800 | `0.28 0.1 265` | |
| 900 | `0.2 0.07 265` | |
| 950 | `0.13 0.04 265` | |

`-50` / `-100` は指定どおりの chroma が hue 265 の sRGB 彩度上限を僅かに超え clamp されるため、結論コメントの指摘どおり上限値 (≈0.014 / ≈0.033) に丸めています。

## 変更内容

- `src/core/tokens/primitives.css` — `--indigo-50` 〜 `--indigo-950` を追加。和名「藍」の意図と、hue 265 が実際は紺 (kon) 色域である旨を CSS コメントに併記。
- `src/core/tokens/base.css` — `@theme` に `--color-indigo-*` を登録し `bg-indigo-*` / `text-indigo-*` ユーティリティを有効化。
- `src/docs/Color.stories.tsx` — Foundation/Color の primitive scale 一覧に `Indigo (藍)` サブセクションを追加。vermillion の直後に配置し並列展示。
- changeset (`minor` — additive)。

## WCAG AA 検証 (#181 で実施済み)

- **Solid**: light `paper-white on indigo-500` = 4.78 ✅ / dark `paper-dark on indigo-400` = 5.73 ✅ — 両モードで通常テキスト可。
- text 用途で light に「藍そのもの」を使うなら `-600` (7.03) 以上推奨。

## DoD

- [x] `--indigo-50` 〜 `--indigo-950` の OKLCH 値を決定
- [x] `primitives.css` に追加
- [x] `Color.stories.tsx` の primitive scale 一覧に追加
- [x] vermillion との並列展示
- [x] WCAG AA コントラスト検証 (#181 結論コメント)
- [x] changeset (minor — additive)

## 残課題 (本 PR スコープ外)

- 和名コメントの最終文言 (「藍」のままにするか「紺」へ寄せるか) はデザイナー判断として #181 で deferred。本 PR では「藍」を主表記としつつ、hue 265 が紺色域である旨を注記。
- semantic 層への組み込み (`--color-indigo`) は #185。

## 検証

- `pnpm lint` ✅
- `pnpm build` ✅ — `dist/schatten.css` に `--indigo-*` が出力されることを確認

closes #181

🤖 Generated with [Claude Code](https://claude.com/claude-code)