### PR TITLE
test(tokens): semantic→primitive resolution test (closes #200)

### DIFF
--- a/.changeset/semantic-token-resolution-test.md
+++ b/.changeset/semantic-token-resolution-test.md
@@ -1,0 +1,12 @@
+---
+---
+
+Add `src/core/tokens/__tests__/resolution.test.ts` — a semantic→primitive
+resolution test that parses `primitives.css` + `semantic.css`, follows every
+`var(...)` chain to its leaf primitive, and pins the result against a fixture
+covering the theme scale, mode-owned base layer, brand tokens, the 4-token
+interactive states (`error` / `success` / `warning` / `info` / `destructive`),
+and the non-interactive states (`disabled` / `readOnly`) in both light and dark
+mode. A typo or hue swap in `semantic.css` previously only surfaced through VRT
+(and not at all for the VRT-less CSS-only consumer surface); it now fails a unit
+test. Test-only — no consumer-facing change, hence an empty changeset.

--- a/.claude/rules/state-token-guideline.md
+++ b/.claude/rules/state-token-guideline.md
@@ -166,9 +166,12 @@ fill achieves higher WCAG contrast than white-on-bright. Verify visually in `Fou
    for `:root`, `@media (prefers-color-scheme: dark)`, and `.dark`.
 2. Register all four in `@theme` inside `src/core/tokens/base.css` so Tailwind utilities
    (`bg-{state}`, `bg-{state}-subtle`, …) become available.
-3. Add a subsection to `src/docs/Color.stories.tsx`.
-4. Add rows to the "Solid Treatments" and "Subtle Treatments" audit sections.
-5. Add a changeset (typically `minor` — additive feature).
+3. Add the four tokens (light + dark expected primitive) to the fixture in
+   `src/core/tokens/__tests__/resolution.test.ts` so the semantic→primitive
+   resolution is pinned and silent drift is caught.
+4. Add a subsection to `src/docs/Color.stories.tsx`.
+5. Add rows to the "Solid Treatments" and "Subtle Treatments" audit sections.
+6. Add a changeset (typically `minor` — additive feature).
 
 ## Non-interactive state tokens (`disabled` / `readOnly`)
 
@@ -246,10 +249,13 @@ so future re-tuning lands at one place. This mirrors the `destructive` /
 2. Add to `semantic.css` in all three blocks (`:root`, `@media (prefers-color-scheme: dark)`,
    `.dark`).
 3. Register in `base.css` `@theme`.
-4. Add a subsection to `src/docs/Color.stories.tsx` under "Non-Interactive
+4. Add the token(s) (light + dark expected primitive) to the
+   `NON_INTERACTIVE_STATE` fixture in
+   `src/core/tokens/__tests__/resolution.test.ts`.
+5. Add a subsection to `src/docs/Color.stories.tsx` under "Non-Interactive
    States" with a side-by-side preview against the existing non-interactive
    states (`disabled` / `readOnly`).
-5. Document the rationale in [docs/decisions/](../../docs/decisions/) — what
+6. Document the rationale in [docs/decisions/](../../docs/decisions/) — what
    the new state *means* (HTML semantics, form-submission behavior, focusability)
    matters more than what it looks like.
-6. Add a changeset (typically `minor` — additive feature).
+7. Add a changeset (typically `minor` — additive feature).

--- a/src/core/tokens/__tests__/resolution.test.ts
+++ b/src/core/tokens/__tests__/resolution.test.ts
@@ -1,0 +1,348 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+/**
+ * Semantic → primitive resolution test (#200).
+ *
+ * Nothing else verifies which primitive a semantic token (`--color-error`,
+ * `--color-surface-disabled`, …) actually bottoms out at. A typo in
+ * `semantic.css` (`--vermillion-600` → `--vermillion-500`, `gray-100` →
+ * `gray-200`) compiles fine, lints fine, and only VRT catches the drift —
+ * and the CSS-only consumer surface (#58 Phase 2) has no VRT at all.
+ *
+ * This test parses `primitives.css` + `semantic.css`, follows every
+ * `var(...)` reference to the **leaf primitive** (the variable whose value
+ * is a literal, not another `var()`), and asserts that leaf against a
+ * hand-maintained fixture derived from
+ * `.claude/rules/state-token-guideline.md` and `theme-architecture.md`.
+ *
+ * Resolving to the *leaf* (not the direct reference) is deliberate: it
+ * catches drift at the intermediate alias layer too — e.g. `--color-ring`
+ * → `--ink-black` → `--sumi-900`, where re-pointing `--ink-black` would be
+ * invisible to a direct-reference check.
+ *
+ * When a token's resolution intentionally changes, update the fixture
+ * below in the same PR (see state-token-guideline.md "Adding a new state
+ * semantic").
+ */
+
+const TOKENS_DIR = resolve(process.cwd(), 'src/core/tokens')
+const primitivesCss = stripComments(readFileSync(resolve(TOKENS_DIR, 'primitives.css'), 'utf8'))
+const semanticCss = stripComments(readFileSync(resolve(TOKENS_DIR, 'semantic.css'), 'utf8'))
+
+/* ------------------------------------------------------------------ */
+/* CSS parsing                                                         */
+/* ------------------------------------------------------------------ */
+
+function stripComments(css: string): string {
+  return css.replace(/\/\*[\s\S]*?\*\//g, '')
+}
+
+/** Extract the `{ ... }` body that follows `selector`, brace-balanced. */
+function extractBlockBody(css: string, selector: string): string {
+  const start = css.indexOf(selector)
+  if (start === -1) throw new Error(`selector not found: ${selector}`)
+  const braceStart = css.indexOf('{', start)
+  let depth = 0
+  for (let i = braceStart; i < css.length; i++) {
+    if (css[i] === '{') depth++
+    else if (css[i] === '}' && --depth === 0) return css.slice(braceStart + 1, i)
+  }
+  throw new Error(`unbalanced braces for selector: ${selector}`)
+}
+
+/** Parse `--name: value;` custom-property declarations from a block body. */
+function parseDeclarations(body: string): Map<string, string> {
+  const map = new Map<string, string>()
+  for (const m of body.matchAll(/(--[\w-]+)\s*:\s*([^;}]+);/g)) {
+    map.set(m[1], m[2].trim())
+  }
+  return map
+}
+
+const primitives = parseDeclarations(extractBlockBody(primitivesCss, ':root {'))
+const semanticLight = parseDeclarations(extractBlockBody(semanticCss, ':root {'))
+const semanticDark = parseDeclarations(extractBlockBody(semanticCss, '.dark {'))
+const semanticMediaDark = parseDeclarations(extractBlockBody(semanticCss, ':root:not(.light) {'))
+
+/**
+ * A resolution scope: primitives + semantic-light, with semantic-dark
+ * overlaid for dark mode. Theme-scale tokens are intentionally absent from
+ * the `.dark` block, so dark mode falls back to the `:root` (light) value —
+ * this map models that fallback by layering, not replacing.
+ */
+const lightScope = new Map([...primitives, ...semanticLight])
+const darkScope = new Map([...primitives, ...semanticLight, ...semanticDark])
+
+/** Follow `var(...)` references to the leaf primitive (value is a literal). */
+function resolveToPrimitive(varName: string, scope: Map<string, string>): string {
+  const seen = new Set<string>()
+  let current = varName
+  for (;;) {
+    if (seen.has(current)) throw new Error(`cyclic var() chain at ${current}`)
+    seen.add(current)
+    const value = scope.get(current)
+    if (value === undefined) throw new Error(`unresolved var: ${current}`)
+    const ref = value.match(/^var\(\s*(--[\w-]+)\s*\)$/)
+    if (!ref) return current.replace(/^--/, '')
+    current = ref[1]
+  }
+}
+
+const inLight = (token: string) => resolveToPrimitive(`--color-${token}`, lightScope)
+const inDark = (token: string) => resolveToPrimitive(`--color-${token}`, darkScope)
+
+/* ------------------------------------------------------------------ */
+/* Fixtures — expected leaf primitive per token, per mode               */
+/* ------------------------------------------------------------------ */
+
+/** 4-token interactive states. base / hover / foreground / subtle. */
+const INTERACTIVE_STATE = {
+  error: {
+    light: { base: 'red-600', hover: 'red-700', foreground: 'paper-white', subtle: 'red-50' },
+    dark: {
+      base: 'red-500',
+      hover: 'red-400',
+      foreground: 'paper-white-inverted',
+      subtle: 'red-900',
+    },
+  },
+  success: {
+    light: { base: 'green-600', hover: 'green-700', foreground: 'paper-white', subtle: 'green-50' },
+    dark: {
+      base: 'green-500',
+      hover: 'green-400',
+      foreground: 'paper-white-inverted',
+      subtle: 'green-900',
+    },
+  },
+  warning: {
+    light: { base: 'amber-600', hover: 'amber-700', foreground: 'paper-white', subtle: 'amber-50' },
+    dark: {
+      base: 'amber-500',
+      hover: 'amber-400',
+      foreground: 'paper-white-inverted',
+      subtle: 'amber-900',
+    },
+  },
+  info: {
+    light: { base: 'blue-600', hover: 'blue-700', foreground: 'paper-white', subtle: 'blue-50' },
+    dark: {
+      base: 'blue-500',
+      hover: 'blue-400',
+      foreground: 'paper-white-inverted',
+      subtle: 'blue-900',
+    },
+  },
+  // `destructive` shares the `red` primitive with `error` but is a distinct
+  // semantic (action intent vs. form state) — see state-token-guideline.md.
+  destructive: {
+    light: { base: 'red-600', hover: 'red-700', foreground: 'paper-white', subtle: 'red-50' },
+    dark: {
+      base: 'red-500',
+      hover: 'red-400',
+      foreground: 'paper-white-inverted',
+      subtle: 'red-900',
+    },
+  },
+} as const
+
+/** Non-interactive states — no `hover` slot, no 4-token shape. */
+const NON_INTERACTIVE_STATE = {
+  light: {
+    'surface-disabled': 'gray-100',
+    'foreground-disabled': 'gray-500',
+    'border-disabled': 'gray-200',
+    'surface-readonly': 'alabaster-100',
+    'border-readonly': 'gray-200',
+  },
+  dark: {
+    'surface-disabled': 'gray-800',
+    // foreground-disabled is intentionally identical light/dark (gray-500).
+    'foreground-disabled': 'gray-500',
+    'border-disabled': 'gray-700',
+    'surface-readonly': 'alabaster-800',
+    'border-readonly': 'gray-700',
+  },
+} as const
+
+/** Mode-owned base layer: surfaces, foreground tiers, borders, ring. */
+const MODE_LAYER = {
+  light: {
+    background: 'paper-warm',
+    surface: 'paper-white',
+    'surface-hover': 'alabaster-200',
+    foreground: 'sumi-900',
+    'foreground-muted': 'sumi-400',
+    'foreground-subtle': 'sumi-300',
+    solid: 'alabaster-700',
+    'solid-hover': 'alabaster-900',
+    'solid-foreground': 'alabaster-100',
+    'solid-foreground-hover': 'alabaster-300',
+    border: 'gray-200',
+    'border-strong': 'sumi-900',
+    ring: 'sumi-900',
+    'ring-offset': 'paper-warm',
+    'inverted-foreground': 'paper-white',
+    'inverted-foreground-muted': 'alabaster-300',
+    'inverted-foreground-subtle': 'alabaster-400',
+  },
+  dark: {
+    background: 'paper-warm-inverted',
+    surface: 'paper-white-inverted',
+    'surface-hover': 'paper-cream-inverted',
+    foreground: 'alabaster-200',
+    'foreground-muted': 'alabaster-500',
+    'foreground-subtle': 'alabaster-600',
+    solid: 'alabaster-300',
+    'solid-hover': 'alabaster-100',
+    'solid-foreground': 'alabaster-800',
+    'solid-foreground-hover': 'alabaster-700',
+    border: 'gray-700',
+    'border-strong': 'alabaster-200',
+    ring: 'alabaster-200',
+    'ring-offset': 'paper-warm-inverted',
+    'inverted-foreground': 'paper-white-inverted',
+    'inverted-foreground-muted': 'alabaster-700',
+    'inverted-foreground-subtle': 'alabaster-600',
+  },
+} as const
+
+/** Brand-named tokens — 朱 vermillion / 藍 indigo. `-600` light, `-400` dark. */
+const BRAND_LAYER = {
+  light: {
+    vermillion: 'vermillion-600',
+    'vermillion-foreground': 'paper-white',
+    indigo: 'indigo-600',
+    'indigo-foreground': 'paper-white',
+  },
+  dark: {
+    vermillion: 'vermillion-400',
+    'vermillion-foreground': 'paper-white-inverted',
+    indigo: 'indigo-400',
+    'indigo-foreground': 'paper-white-inverted',
+  },
+} as const
+
+const THEME_SCALE_SHADES = [
+  '50',
+  '100',
+  '200',
+  '300',
+  '400',
+  '500',
+  '600',
+  '700',
+  '800',
+  '900',
+  '950',
+] as const
+
+/* ------------------------------------------------------------------ */
+/* Tests                                                               */
+/* ------------------------------------------------------------------ */
+
+describe('semantic.css token resolution', () => {
+  describe('theme scale', () => {
+    for (const shade of THEME_SCALE_SHADES) {
+      it(`--color-theme-${shade} resolves to blue-${shade} in light mode`, () => {
+        expect(inLight(`theme-${shade}`)).toBe(`blue-${shade}`)
+      })
+    }
+
+    // The `.dark` block does not redeclare the theme scale — it is
+    // Special-owned (theme-architecture.md), so dark mode falls back to the
+    // `:root` (blue-*) value. This asserts that fallback holds.
+    for (const shade of THEME_SCALE_SHADES) {
+      it(`--color-theme-${shade} falls back to blue-${shade} in dark mode`, () => {
+        expect(inDark(`theme-${shade}`)).toBe(`blue-${shade}`)
+      })
+    }
+  })
+
+  describe('mode-owned base layer', () => {
+    for (const [token, primitive] of Object.entries(MODE_LAYER.light)) {
+      it(`--color-${token} resolves to ${primitive} in light mode`, () => {
+        expect(inLight(token)).toBe(primitive)
+      })
+    }
+    for (const [token, primitive] of Object.entries(MODE_LAYER.dark)) {
+      it(`--color-${token} resolves to ${primitive} in dark mode`, () => {
+        expect(inDark(token)).toBe(primitive)
+      })
+    }
+  })
+
+  describe('brand-named tokens', () => {
+    for (const [token, primitive] of Object.entries(BRAND_LAYER.light)) {
+      it(`--color-${token} resolves to ${primitive} in light mode`, () => {
+        expect(inLight(token)).toBe(primitive)
+      })
+    }
+    for (const [token, primitive] of Object.entries(BRAND_LAYER.dark)) {
+      it(`--color-${token} resolves to ${primitive} in dark mode`, () => {
+        expect(inDark(token)).toBe(primitive)
+      })
+    }
+  })
+
+  describe('interactive state tokens (4-token shape)', () => {
+    for (const [state, modes] of Object.entries(INTERACTIVE_STATE)) {
+      describe(state, () => {
+        for (const mode of ['light', 'dark'] as const) {
+          const slots = modes[mode]
+          const resolveIn = mode === 'light' ? inLight : inDark
+          it(`--color-${state} resolves to ${slots.base} in ${mode} mode`, () => {
+            expect(resolveIn(state)).toBe(slots.base)
+          })
+          it(`--color-${state}-hover resolves to ${slots.hover} in ${mode} mode`, () => {
+            expect(resolveIn(`${state}-hover`)).toBe(slots.hover)
+          })
+          it(`--color-${state}-foreground resolves to ${slots.foreground} in ${mode} mode`, () => {
+            expect(resolveIn(`${state}-foreground`)).toBe(slots.foreground)
+          })
+          it(`--color-${state}-subtle resolves to ${slots.subtle} in ${mode} mode`, () => {
+            expect(resolveIn(`${state}-subtle`)).toBe(slots.subtle)
+          })
+        }
+      })
+    }
+  })
+
+  describe('non-interactive state tokens (disabled / readOnly)', () => {
+    for (const [token, primitive] of Object.entries(NON_INTERACTIVE_STATE.light)) {
+      it(`--color-${token} resolves to ${primitive} in light mode`, () => {
+        expect(inLight(token)).toBe(primitive)
+      })
+    }
+    for (const [token, primitive] of Object.entries(NON_INTERACTIVE_STATE.dark)) {
+      it(`--color-${token} resolves to ${primitive} in dark mode`, () => {
+        expect(inDark(token)).toBe(primitive)
+      })
+    }
+  })
+
+  describe('integrity', () => {
+    it('resolves every --color-* token in :root without a dangling var()', () => {
+      for (const name of semanticLight.keys()) {
+        if (!name.startsWith('--color-')) continue
+        expect(() => resolveToPrimitive(name, lightScope), name).not.toThrow()
+      }
+    })
+
+    it('resolves every --color-* token in .dark without a dangling var()', () => {
+      for (const name of semanticDark.keys()) {
+        if (!name.startsWith('--color-')) continue
+        expect(() => resolveToPrimitive(name, darkScope), name).not.toThrow()
+      }
+    })
+
+    // The `@media (prefers-color-scheme: dark)` and `.dark` blocks must stay
+    // byte-for-byte equivalent — a drift between them means OS-driven dark
+    // mode and explicit `.dark` would render differently.
+    it('keeps the @media dark block identical to the .dark block', () => {
+      expect(Object.fromEntries(semanticMediaDark)).toEqual(Object.fromEntries(semanticDark))
+    })
+  })
+})

--- a/src/core/tokens/__tests__/resolution.test.ts
+++ b/src/core/tokens/__tests__/resolution.test.ts
@@ -75,7 +75,16 @@ const semanticMediaDark = parseDeclarations(extractBlockBody(semanticCss, ':root
 const lightScope = new Map([...primitives, ...semanticLight])
 const darkScope = new Map([...primitives, ...semanticLight, ...semanticDark])
 
-/** Follow `var(...)` references to the leaf primitive (value is a literal). */
+/**
+ * Follow `var(...)` references to the leaf primitive (the variable whose
+ * value is a literal, not another `var()`).
+ *
+ * Only the bare single-reference form `var(--x)` is recognised as a chain
+ * link. Any other `var()` shape — a fallback (`var(--x, …)`), multiple
+ * references, a calc, … — throws instead of being silently treated as a
+ * leaf, so an unhandled form fails loud rather than mis-resolving to the
+ * semantic name itself.
+ */
 function resolveToPrimitive(varName: string, scope: Map<string, string>): string {
   const seen = new Set<string>()
   let current = varName
@@ -85,8 +94,14 @@ function resolveToPrimitive(varName: string, scope: Map<string, string>): string
     const value = scope.get(current)
     if (value === undefined) throw new Error(`unresolved var: ${current}`)
     const ref = value.match(/^var\(\s*(--[\w-]+)\s*\)$/)
-    if (!ref) return current.replace(/^--/, '')
-    current = ref[1]
+    if (ref) {
+      current = ref[1]
+      continue
+    }
+    if (value.includes('var(')) {
+      throw new Error(`unexpected var() form for ${current}: "${value}"`)
+    }
+    return current.replace(/^--/, '')
   }
 }
 
@@ -343,6 +358,14 @@ describe('semantic.css token resolution', () => {
     // mode and explicit `.dark` would render differently.
     it('keeps the @media dark block identical to the .dark block', () => {
       expect(Object.fromEntries(semanticMediaDark)).toEqual(Object.fromEntries(semanticDark))
+    })
+
+    // Guards the resolver itself: an unhandled `var()` shape (fallback,
+    // multi-ref, …) must throw, not silently resolve to the semantic name —
+    // otherwise the dangling-var sweep above would pass on a broken token.
+    it('throws on an unrecognised var() form instead of mis-resolving', () => {
+      const scope = new Map([['--color-foo', 'var(--bar, #fff)']])
+      expect(() => resolveToPrimitive('--color-foo', scope)).toThrow(/unexpected var\(\) form/)
     })
   })
 })


### PR DESCRIPTION
## 概要

semantic token (`--color-error`, `--color-surface-disabled`, …) が **実際にどの primitive に解決されるか** を自動検証する仕組みが無かった (#200)。`semantic.css` の typo / hue 差し替えは build も lint も通り、VRT で初めて捕まる — VRT を持たない CSS-only consumer surface (#58 Phase 2) では永遠に気付けない。

このPRで `src/core/tokens/__tests__/resolution.test.ts` を追加し、`pnpm vitest run`(CI) でその経路を検証する。

## 実装

issue 案の **Option B** を採用。`primitives.css` + `semantic.css` をパースし、`var(...)` チェーンを **leaf primitive**(値が literal になる変数)まで辿って、guideline 由来の fixture と equal 比較する。

- **leaf まで解決する** のは意図的 — 直接参照だけ見ると `--color-ring → --ink-black → --sumi-900` の中間 alias 層 (`--ink-black`) の差し替えを見逃す。leaf 解決はその層の drift も捕まえる。
- パーサは依存追加なし(`primitives.test.ts` と同じ regex ベース)。`@media` / `.dark` のネストは brace-balanced 抽出で対応。

## カバレッジ (117 test)

- **theme scale** `--color-theme-50…950` → `blue-*`(light / dark — dark は `.dark` に未宣言で `:root` fallback する性質も検証)
- **mode-owned base layer** — surface / foreground tiers / solid / border / ring / inverted-foreground(light / dark)
- **brand tokens** — vermillion / indigo(`-600` light, `-400` dark)
- **interactive state(4-token shape)** — error / success / warning / info / destructive × {base, hover, foreground, subtle} × {light, dark}
- **non-interactive state** — surface/foreground/border-disabled, surface/border-readonly(light / dark。`foreground-disabled` が light/dark 同値である点も明示)
- **integrity sweep** — 全 `--color-*` が dangling `var()` を持たないこと / `@media` dark block と `.dark` block が一致すること

> 注: issue 本文の fixture 例は `error → vermillion-600` だが、#238 で error/destructive は `red` primitive へ切り離し済み。fixture は develop 現状の `red-*` を基準にしている。

## DoD

- [x] `src/core/tokens/__tests__/resolution.test.ts` 作成(`__tests__/` 配下 — DoD のパスは `src/**/*.test.ts` glob でそのまま CI 対象)
- [x] non-interactive state tokens を light/dark 両モードで fixture 化
- [x] interactive state tokens(4-token × 5 semantic)を fixture 化
- [x] surface / foreground / border / ring / theme scale を fixture 化(`accent` は #185 で削除済みのため対象外)
- [x] light / dark 両モードを検証
- [x] CI(`pnpm vitest run`)で実行される
- [x] `state-token-guideline.md` の「Adding a new state semantic」/「Adding a new non-interactive state」に resolution test 更新手順を追加
- [ ] #114 の scan pipeline 共有 — `check-theme-allowlist.mjs` が現状 stub のため見送り(共有は "可能なら" 項目)

## テスト

- `pnpm vitest run src/core/tokens/` → 119 passed
- mutation 確認: `--color-error` を `red-600`→`red-500` に書き換えると該当 test が fail することを確認
- `pnpm biome check` / `pnpm typecheck` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)