### PR TITLE
feat(ci): develop ブランチの常設 Storybook を /next/ に追加 (closes #248)

### DIFF
--- a/.changeset/develop-storybook-next.md
+++ b/.changeset/develop-storybook-next.md
@@ -1,0 +1,6 @@
+---
+---
+
+ci: deploy the `develop` Storybook to `/schatten/next/` as a standing unreleased
+integration preview. CI-config only — no package change, so this is an empty
+changeset.

--- a/.github/workflows/deploy-storybook.yml
+++ b/.github/workflows/deploy-storybook.yml
@@ -2,7 +2,7 @@ name: Deploy Storybook to GitHub Pages
 
 on:
   push:
-    branches: [main]
+    branches: [main, develop]
   workflow_dispatch:
 
 permissions:
@@ -14,6 +14,26 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      # Resolve where this build is published, based on the pushed ref:
+      #   main    -> root (/schatten/)        — canonical, consumer-facing
+      #   develop -> /next/ (/schatten/next/) — unreleased integration preview
+      - name: Resolve deploy target
+        id: target
+        run: |
+          if [ "${{ github.ref }}" = "refs/heads/develop" ]; then
+            {
+              echo "base=/schatten/next/"
+              echo "channel=next"
+              echo "target-folder=next"
+            } >> "$GITHUB_OUTPUT"
+          else
+            {
+              echo "base=/schatten/"
+              echo "channel=stable"
+              echo "target-folder="
+            } >> "$GITHUB_OUTPUT"
+          fi
+
       - uses: pnpm/action-setup@v6
 
       - uses: actions/setup-node@v6
@@ -24,11 +44,19 @@ jobs:
       - run: pnpm install --frozen-lockfile
 
       - name: Build Storybook
+        env:
+          STORYBOOK_BASE: ${{ steps.target.outputs.base }}
+          STORYBOOK_CHANNEL: ${{ steps.target.outputs.channel }}
         run: pnpm build:storybook
 
       - name: Deploy to GitHub Pages
         uses: JamesIves/github-pages-deploy-action@v4
         with:
           folder: storybook-static
+          # main -> root; develop -> next/ subpath (root stays canonical)
+          target-folder: ${{ steps.target.outputs.target-folder }}
           clean: true
-          clean-exclude: pr
+          # main deploy must not wipe PR previews or the develop /next/ build
+          clean-exclude: |
+            pr
+            next

--- a/.storybook/manager.ts
+++ b/.storybook/manager.ts
@@ -1,0 +1,25 @@
+import { addons } from 'storybook/manager-api'
+import { create } from 'storybook/theming'
+
+// `STORYBOOK_CHANNEL` is injected by `.github/workflows/deploy-storybook.yml`:
+// the `develop` build (published at /schatten/next/) sets it to `next`, the
+// `main` build leaves it `stable`. Storybook exposes `STORYBOOK_`-prefixed env
+// vars to the manager bundle too, so this is `undefined` in local dev / VRT.
+// Mirrors the same check in `.storybook/preview.tsx`.
+const isNextChannel = process.env.STORYBOOK_CHANNEL === 'next'
+
+// On the develop (/next/) build, brand the sidebar header with a persistent
+// "unreleased" badge. Unlike the preview-canvas banner this survives every
+// story / docs navigation and never overlaps itself. The brand links back to
+// the canonical (main) Storybook so a viewer can leave the unreleased surface.
+if (isNextChannel) {
+  addons.setConfig({
+    theme: create({
+      base: 'light',
+      brandTitle:
+        'Schatten <span style="margin-left:6px;padding:1px 6px;border-radius:4px;background:#92400e;color:#fff;font-size:10px;font-weight:700;vertical-align:middle">未リリース · develop</span>',
+      brandUrl: 'https://yasmro.github.io/schatten/',
+      brandTarget: '_blank',
+    }),
+  })
+}

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -4,6 +4,53 @@ import { useEffect } from 'react'
 // Import Tailwind + design tokens + themes
 import '../src/styles/globals.css'
 
+// `STORYBOOK_CHANNEL` is injected by `.github/workflows/deploy-storybook.yml`:
+// the `develop` build (published at /schatten/next/) sets it to `next`, the
+// `main` build leaves it `stable`. Storybook exposes `STORYBOOK_`-prefixed env
+// vars to preview code, so this is also `undefined` in local dev and VRT runs.
+const isNextChannel = process.env.STORYBOOK_CHANNEL === 'next'
+
+/**
+ * Banner shown only on the develop (`/next/`) Storybook. It warns viewers that
+ * the page reflects unreleased, npm-unpublished tokens and APIs — see
+ * `.claude/rules/api-stability.md`. The canonical, consumer-facing docs stay
+ * at the root URL (the `main` build).
+ */
+function UnreleasedBanner() {
+  return (
+    <div
+      style={{
+        position: 'fixed',
+        top: 0,
+        left: 0,
+        right: 0,
+        zIndex: 2147483647,
+        display: 'flex',
+        gap: '0.5rem',
+        flexWrap: 'wrap',
+        alignItems: 'center',
+        justifyContent: 'center',
+        padding: '0.4rem 1rem',
+        backgroundColor: '#92400e',
+        color: '#fff',
+        font: '500 12px/1.4 system-ui, sans-serif',
+        textAlign: 'center',
+      }}
+    >
+      <span>
+        ⚠ 未リリース (develop) — 次バージョンの統合プレビューです。npm 未公開のトークン・API
+        が含まれます。
+      </span>
+      <a
+        href="https://yasmro.github.io/schatten/"
+        style={{ color: '#fff', textDecoration: 'underline', fontWeight: 700 }}
+      >
+        公開版を見る →
+      </a>
+    </div>
+  )
+}
+
 const preview: Preview = {
   parameters: {
     controls: {
@@ -90,7 +137,11 @@ const preview: Preview = {
       }, [isDark, season])
 
       return (
-        <div className={`${isDark ? 'dark bg-background' : ''} p-8`}>
+        <div
+          className={`${isDark ? 'dark bg-background' : ''} p-8`}
+          style={isNextChannel ? { paddingTop: '3rem' } : undefined}
+        >
+          {isNextChannel && <UnreleasedBanner />}
           <Story />
         </div>
       )

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -10,45 +10,46 @@ import '../src/styles/globals.css'
 // vars to preview code, so this is also `undefined` in local dev and VRT runs.
 const isNextChannel = process.env.STORYBOOK_CHANNEL === 'next'
 
+const BANNER_ID = 'schatten-unreleased-banner'
+
 /**
- * Banner shown only on the develop (`/next/`) Storybook. It warns viewers that
- * the page reflects unreleased, npm-unpublished tokens and APIs — see
- * `.claude/rules/api-stability.md`. The canonical, consumer-facing docs stay
- * at the root URL (the `main` build).
+ * Mounts the develop (`/next/`) warning banner once into the preview `<body>`.
+ *
+ * It warns viewers that the page reflects unreleased, npm-unpublished tokens
+ * and APIs — see `.claude/rules/api-stability.md`. The manager sidebar carries
+ * the same marker (`.storybook/manager.ts`); this banner additionally covers
+ * direct `iframe.html` links, which never render the manager chrome.
+ *
+ * Mounted imperatively (not via the per-story decorator) so a Docs page — which
+ * renders many stories at once — shows exactly one banner instead of a stack.
  */
-function UnreleasedBanner() {
-  return (
-    <div
-      style={{
-        position: 'fixed',
-        top: 0,
-        left: 0,
-        right: 0,
-        zIndex: 2147483647,
-        display: 'flex',
-        gap: '0.5rem',
-        flexWrap: 'wrap',
-        alignItems: 'center',
-        justifyContent: 'center',
-        padding: '0.4rem 1rem',
-        backgroundColor: '#92400e',
-        color: '#fff',
-        font: '500 12px/1.4 system-ui, sans-serif',
-        textAlign: 'center',
-      }}
-    >
-      <span>
-        ⚠ 未リリース (develop) — 次バージョンの統合プレビューです。npm 未公開のトークン・API
-        が含まれます。
-      </span>
-      <a
-        href="https://yasmro.github.io/schatten/"
-        style={{ color: '#fff', textDecoration: 'underline', fontWeight: 700 }}
-      >
-        公開版を見る →
-      </a>
-    </div>
-  )
+function mountUnreleasedBanner() {
+  if (document.getElementById(BANNER_ID)) return
+
+  const banner = document.createElement('div')
+  banner.id = BANNER_ID
+  banner.setAttribute('role', 'note')
+  Object.assign(banner.style, {
+    position: 'fixed',
+    top: '0',
+    left: '0',
+    right: '0',
+    zIndex: '2147483647',
+    display: 'flex',
+    gap: '0.5rem',
+    flexWrap: 'wrap',
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: '0.4rem 1rem',
+    backgroundColor: '#92400e',
+    color: '#fff',
+    font: '500 12px/1.4 system-ui, sans-serif',
+    textAlign: 'center',
+  })
+  banner.innerHTML =
+    '<span>⚠ 未リリース (develop) — 次バージョンの統合プレビューです。npm 未公開のトークン・API が含まれます。</span>' +
+    '<a href="https://yasmro.github.io/schatten/" style="color:#fff;text-decoration:underline;font-weight:700">公開版を見る →</a>'
+  document.body.appendChild(banner)
 }
 
 const preview: Preview = {
@@ -136,12 +137,15 @@ const preview: Preview = {
         }
       }, [isDark, season])
 
+      useEffect(() => {
+        if (isNextChannel) mountUnreleasedBanner()
+      }, [])
+
       return (
         <div
           className={`${isDark ? 'dark bg-background' : ''} p-8`}
           style={isNextChannel ? { paddingTop: '3rem' } : undefined}
         >
-          {isNextChannel && <UnreleasedBanner />}
           <Story />
         </div>
       )


### PR DESCRIPTION
## 概要

`develop` ブランチの統合状態を `https://yasmro.github.io/schatten/next/` に常設デプロイする。`main` の常設 Storybook はルート（canonical）のまま据え置き。

closes #248

## 変更点

### `.github/workflows/deploy-storybook.yml`
- push trigger に `develop` を追加。
- 「Resolve deploy target」ステップで ref により出し分け:
  - `main` → ルート `/schatten/`（現状どおり）
  - `develop` → `target-folder: next` + `STORYBOOK_BASE=/schatten/next/`
- `main` デプロイの `clean-exclude` に `next` を追加 — ルート再デプロイで develop プレビュー（および PR プレビュー）を消さない。develop 側は `next/` サブフォルダのみを対象に `clean` するのでルートを上書きしない。

### `.storybook/manager.ts`（新規）
- develop ビルドで Storybook サイドバーのヘッダーに「未リリース · develop」バッジを常設表示（公開版 Storybook へのリンク付き）。ストーリー / Docs を切り替えても残る。

### `.storybook/preview.tsx`
- develop ビルドは `STORYBOOK_CHANNEL=next` を受け取り、プレビュー `<body>` に「⚠ 未リリース (develop)」バナーを1回だけ imperative にマウント。Docs ページ（1ページに複数ストーリー）でもバナーは1本に集約され、固定要素が重ならない。`iframe.html` 直リンク（manager chrome 無し）もこのバナーでカバー。
- バッジ・バナーとも `STORYBOOK_CHANNEL=next` でのみ表示。ローカル開発・VRT 実行では未設定 → 非表示。VRT スナップショットには影響しない。

### `.changeset/develop-storybook-next.md`
- CI 設定のみの変更のため empty changeset。

## DoD

- [x] push trigger に `develop` を追加、ref で出し分け
- [x] `develop` ビルドは `/next/` サブパスへ（ルートを上書きしない）
- [x] ルート URL = `main` を canonical に維持
- [x] `/next/` Storybook に「未リリース(develop)」バナー（プレビュー）+ バッジ（サイドバー）を明示
- [x] empty changeset

## 検証

- `STORYBOOK_CHANNEL=next STORYBOOK_BASE=/schatten/next/ pnpm build:storybook` がローカルで成功。バナー文字列がプレビューバンドルに含まれることを確認。
- `pnpm biome ci` パス。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
