### PR TITLE
feat(skill): .claude/skills/add-lv1-component/ を新設 (closes #130)

### DIFF
--- a/.claude/skills/add-lv1-component/SKILL.md
+++ b/.claude/skills/add-lv1-component/SKILL.md
@@ -1,0 +1,177 @@
+---
+name: add-lv1-component
+description: >-
+  Scaffold a new lv1 primitive component for the Schatten design system.
+  Use whenever the user wants to add, create, or generate a new lv1 / primitive
+  component (e.g. "add a new lv1 component", "新しいコンポーネントを追加して",
+  "lv1 に Alert を作って", "Banner コンポーネントを新設"). Generates the full
+  6-file set — variants CVA / tsx / stories / unit test / VRT spec / index —
+  in a form that complies with every .claude/rules/ guideline, and registers
+  the component in src/components/lv1/index.ts. Prevents test-less or
+  VRT-less component additions structurally.
+---
+
+# add-lv1-component
+
+Scaffold a new **lv1 primitive** component. The point of this skill: a new lv1
+*always* ships with its unit test and VRT spec, and *always* matches the
+project's API conventions — no test-less or convention-drifting additions.
+
+## What it generates
+
+For a component named `Foo`:
+
+| File | Purpose |
+|---|---|
+| `src/variants/foo.ts` | CVA variant definition (`fooVariants` + `FooVariants` type) |
+| `src/components/lv1/Foo/Foo.tsx` | The component (`forwardRef`, typed `Props`, TSDoc) |
+| `src/components/lv1/Foo/Foo.stories.tsx` | Storybook — `Playground` + grouped render stories |
+| `src/components/lv1/Foo/Foo.test.tsx` | Vitest unit test |
+| `src/components/lv1/Foo/Foo.vrt.spec.ts` | Playwright VRT spec |
+| `src/components/lv1/Foo/index.ts` | Folder barrel re-export |
+
+Plus an edit to **`src/components/lv1/index.ts`** adding the public re-export,
+and to **`src/variants/index.ts`** adding the variants re-export.
+
+## Templates
+
+Placeholder templates live in [`templates/`](templates/). They are a *correct
+scaffold*, not the finished component — after substitution you must adapt the
+variant vocabulary, classes, and tests to the answers gathered in Step 2.
+
+Placeholder tokens (replace **every** occurrence):
+
+| Token | Replace with | Example (`SearchField`) |
+|---|---|---|
+| `__ComponentName__` | PascalCase name | `SearchField` |
+| `__componentName__` | camelCase name | `searchField` |
+| `__component-name__` | kebab-case name | `search-field` |
+
+## Procedure
+
+### Step 1 — Read the rules (always, every run)
+
+Rules drift; never scaffold from memory. Read these before generating anything:
+
+- `.claude/rules/component-architecture.md` — lv1 vs lv2, compound vs flat,
+  `asChild` (default **off** for new lv1s), dependency direction, a11y contract
+- `.claude/rules/component-api-conventions.md` — the two prop patterns, the
+  per-component matrix, common prop names/types
+- `.claude/rules/storybook-guideline.md` — `Playground` first, group by prop,
+  TSDoc as source of truth
+- `.claude/rules/testing-guideline.md` — required test cases per component type
+- `.claude/rules/vrt-spec-guideline.md` — VRT spec template, story-id mapping
+- `.claude/rules/state-token-guideline.md` — semantic tokens only, never
+  primitive color classes (`bg-red-500` is banned by a lint plugin)
+- `.claude/rules/component-testid-guideline.md` — `...props` pass-through
+
+### Step 2 — Gather requirements (ask the user)
+
+Ask, and wait for answers, in this order. Use `AskUserQuestion` when the
+choices are closed.
+
+1. **Component name** — PascalCase (e.g. `Alert`, `Banner`). Confirm it does
+   not already exist under `src/components/lv1/`.
+2. **Pattern** (`component-api-conventions.md`):
+   - **A — Role-based** (single `variant` axis; action components like Button)
+   - **B — Tone × Shape** (`variant` tone × `appearance` shape; state
+     components like Badge / Callout / Toast)
+   - **Form** (no `variant`; error via `isError` boolean)
+   - **Display / out-of-pattern** (Separator / Spinner / Text-like)
+3. **Compound or flat** (`component-architecture.md` §2). Default **flat**.
+   Compound is for wrapping a Radix primitive with multiple parts — if so,
+   tell the user the templates cover the flat case and the compound parts
+   must be hand-written following `Select` / `Dialog`.
+4. **`variant` values** and **`size` values** (default `sm | md | lg`).
+5. **Root element / role** — interactive components MUST render a native
+   interactive element or a Radix primitive (a11y contract §8). A plain
+   `<div>` is only for non-interactive display content.
+
+Do not invent variant vocabulary — subset the canonical lists; extending them
+requires a discussion per `component-api-conventions.md`.
+
+### Step 3 — Generate the files
+
+1. Copy each file in [`templates/`](templates/) to its destination, renaming
+   `Component.*` → `<Name>.*` and `variants.ts` → `<kebab>.ts`.
+2. Substitute every placeholder token (table above).
+3. Adapt to the Step 2 answers:
+   - Replace the placeholder `variant: { neutral: '' }` with the real
+     vocabulary; for Pattern B add the `appearance` axis.
+   - Fill CVA classes with **semantic tokens only** (`bg-error`,
+     `text-foreground-muted`, …) — never primitive classes (`bg-red-500`).
+   - Form components: drop `variant`, add `isError`, wire `FieldContext`
+     per `.claude/rules/field-context-guideline.md`.
+   - Replace the `it.todo(...)` placeholders in the test with real
+     assertions for the component's type (`testing-guideline.md`).
+   - Add/rename Storybook `argTypes` and render stories to match the real
+     props; keep `Playground` first.
+4. Edit `src/components/lv1/index.ts` — add the re-export, keeping the list
+   alphabetically sorted.
+5. Edit `src/variants/index.ts` — add the variants re-export, alphabetically.
+
+### Step 4 — Strip the scaffold residue
+
+The templates carry placeholders that are **not** meant to survive into a
+finished component. After Step 3, grep the generated files and make sure none
+of these remain:
+
+```sh
+grep -rn 'it\.todo(\|describe each option here\|__ComponentName__\|__componentName__\|__component-name__' \
+  src/components/lv1/<Name> src/variants/<kebab>.ts
+```
+
+- `__ComponentName__` / `__componentName__` / `__component-name__` — an
+  un-substituted placeholder token. Must be **zero** hits.
+- `it.todo(...)` — a stub test. Each one must be replaced with a real
+  assertion (or deleted if genuinely not applicable) per
+  `testing-guideline.md` § Required test cases. A component that ships with
+  `it.todo` is an under-tested component — the `check-lv1-companions.mjs`
+  hook only checks that the test *file* exists, not that it is meaningful.
+- `describe each option here` and similar instruction text inside TSDoc —
+  replace with the real per-option documentation.
+
+Do not proceed to Step 5 while any of the above is still present.
+
+### Step 5 — Verify
+
+Run, and fix anything that fails:
+
+```sh
+pnpm lint:fix          # auto-format — generated indentation/line-wrapping is
+                       # name-length dependent, so always format before linting
+pnpm typecheck
+pnpm lint              # confirm lint + format are clean
+pnpm test --run src/components/lv1/<Name>
+```
+
+VRT baselines do not exist yet — the first `pnpm test:vrt` run writes them.
+Tell the user to review the generated PNGs before committing
+(`vrt-spec-guideline.md` § Re-baselining).
+
+### Step 6 — Add a changeset
+
+A new lv1 component is a **user-facing, additive change**, so it needs a
+changeset — CI enforces this (`changeset status`). Create one:
+
+```sh
+pnpm changeset         # pick `minor` — a new component is an additive feature
+```
+
+Write the summary as `Add <Name> component` (see `api-stability.md` for the
+CHANGELOG prefix conventions). This is *not* a `.claude/`-only change, so the
+`no-changeset` label does **not** apply here.
+
+### Step 7 — Hand off
+
+Stop before committing. Show the user the file list and tell them to review,
+then commit. The project's `Stop` / `PostToolUse` hooks
+(`scripts/check-lv1-companions.mjs`, `scripts/check-lv1-export-integrity.mjs`)
+will cross-check that the test, VRT spec, and index export are all present.
+
+## Recovery
+
+If generation stops partway, the files written so far are plain new files —
+`git status` lists them and `git clean -fd src/components/lv1/<Name>` (plus
+removing `src/variants/<kebab>.ts` and reverting the two `index.ts` edits)
+fully rolls back. Nothing here is destructive.

--- a/.claude/skills/add-lv1-component/templates.test.ts
+++ b/.claude/skills/add-lv1-component/templates.test.ts
@@ -1,0 +1,73 @@
+import { readFileSync, readdirSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import ts from 'typescript'
+import { describe, expect, it } from 'vitest'
+
+// The 6 placeholder templates in `templates/` are expanded by the
+// add-lv1-component skill, but carry a `.template` extension so neither
+// `tsc` nor Biome inspects them during normal CI. This test is the standing
+// guard: it expands every template with a probe name and asserts the result
+// is syntactically valid TypeScript — so a template that drifts into broken
+// syntax is caught here, not the next time someone runs the skill.
+
+const here = dirname(fileURLToPath(import.meta.url))
+const templatesDir = join(here, 'templates')
+
+const PLACEHOLDERS: Record<string, string> = {
+  __ComponentName__: 'TemplateProbe',
+  __componentName__: 'templateProbe',
+  '__component-name__': 'template-probe',
+}
+
+function expand(source: string): string {
+  let out = source
+  for (const [token, value] of Object.entries(PLACEHOLDERS)) {
+    out = out.split(token).join(value)
+  }
+  return out
+}
+
+const templates = readdirSync(templatesDir).filter((file) => file.endsWith('.template'))
+
+describe('add-lv1-component templates', () => {
+  it('ships exactly the documented 6-file set', () => {
+    expect([...templates].sort()).toEqual([
+      'Component.stories.tsx.template',
+      'Component.test.tsx.template',
+      'Component.tsx.template',
+      'Component.vrt.spec.ts.template',
+      'index.ts.template',
+      'variants.ts.template',
+    ])
+  })
+
+  for (const file of templates) {
+    describe(file, () => {
+      const expanded = expand(readFileSync(join(templatesDir, file), 'utf8'))
+
+      it('leaves no un-substituted placeholder token', () => {
+        for (const token of Object.keys(PLACEHOLDERS)) {
+          expect(expanded).not.toContain(token)
+        }
+      })
+
+      it('expands to syntactically valid TypeScript', () => {
+        const isTsx = file.endsWith('.tsx.template')
+        const result = ts.transpileModule(expanded, {
+          reportDiagnostics: true,
+          fileName: isTsx ? 'probe.tsx' : 'probe.ts',
+          compilerOptions: {
+            jsx: ts.JsxEmit.ReactJSX,
+            module: ts.ModuleKind.ESNext,
+            target: ts.ScriptTarget.ESNext,
+          },
+        })
+        const syntaxErrors = (result.diagnostics ?? []).map((diagnostic) =>
+          ts.flattenDiagnosticMessageText(diagnostic.messageText, '\n'),
+        )
+        expect(syntaxErrors).toEqual([])
+      })
+    })
+  }
+})

--- a/.claude/skills/add-lv1-component/templates/Component.stories.tsx.template
+++ b/.claude/skills/add-lv1-component/templates/Component.stories.tsx.template
@@ -1,0 +1,86 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { __ComponentName__ } from './__ComponentName__'
+
+/**
+ * __ComponentName__ — one-line description shown at the top of the
+ * autodocs page. Mirror the component's TSDoc header.
+ */
+const meta: Meta<typeof __ComponentName__> = {
+  title: 'Components/lv1/__ComponentName__',
+  component: __ComponentName__,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    variant: {
+      description: 'Visual style of the __componentName__.',
+      control: 'select',
+      options: ['neutral'],
+      table: {
+        type: { summary: '"neutral"' },
+        defaultValue: { summary: 'neutral' },
+      },
+    },
+    size: {
+      description: 'Size of the __componentName__.',
+      control: 'select',
+      options: ['sm', 'md', 'lg'],
+      table: {
+        type: { summary: '"sm" | "md" | "lg"' },
+        defaultValue: { summary: 'md' },
+      },
+    },
+    children: {
+      description: 'Content displayed inside the __componentName__.',
+      control: 'text',
+      table: {
+        type: { summary: 'ReactNode' },
+      },
+    },
+  },
+}
+
+export default meta
+type Story = StoryObj<typeof __ComponentName__>
+
+const VARIANTS = ['neutral'] as const
+const SIZES = ['sm', 'md', 'lg'] as const
+
+/** Interactive single instance — always the first export (storybook-guideline.md). */
+export const Playground: Story = {
+  name: 'Playground',
+  args: {
+    variant: 'neutral',
+    size: 'md',
+    children: '__ComponentName__',
+  },
+}
+
+/** All visual variants side by side. Group by prop — do not create one story per value. */
+export const AllVariants: Story = {
+  name: 'All Variants',
+  render: () => (
+    <div className="flex flex-wrap items-center gap-4">
+      {VARIANTS.map((variant) => (
+        <__ComponentName__ key={variant} variant={variant}>
+          {variant}
+        </__ComponentName__>
+      ))}
+    </div>
+  ),
+}
+
+/** All size options side by side. */
+export const Sizes: Story = {
+  name: 'Sizes',
+  render: () => (
+    <div className="flex items-center gap-4">
+      {SIZES.map((size) => (
+        <__ComponentName__ key={size} size={size}>
+          {size}
+        </__ComponentName__>
+      ))}
+    </div>
+  ),
+}

--- a/.claude/skills/add-lv1-component/templates/Component.test.tsx.template
+++ b/.claude/skills/add-lv1-component/templates/Component.test.tsx.template
@@ -1,0 +1,37 @@
+import { render, screen } from '@testing-library/react'
+import { createRef } from 'react'
+import { describe, expect, it } from 'vitest'
+import { __ComponentName__ } from './__ComponentName__'
+
+describe('__ComponentName__', () => {
+  it('renders children', () => {
+    render(<__ComponentName__>Content</__ComponentName__>)
+    expect(screen.getByText('Content')).toBeInTheDocument()
+  })
+
+  it('forwards className to the root element', () => {
+    const { container } = render(
+      <__ComponentName__ className="custom-class">Content</__ComponentName__>,
+    )
+    expect(container.firstChild).toHaveClass('custom-class')
+  })
+
+  it('forwards data-* and other HTML attributes (testid pass-through)', () => {
+    // component-testid-guideline.md — every lv1 forwards `...props` to its root.
+    render(<__ComponentName__ data-testid="my-__component-name__">Content</__ComponentName__>)
+    expect(screen.getByTestId('my-__component-name__')).toBeInTheDocument()
+  })
+
+  it('forwards ref to the root element', () => {
+    const ref = createRef<HTMLDivElement>()
+    render(<__ComponentName__ ref={ref}>Content</__ComponentName__>)
+    expect(ref.current).toBeInstanceOf(HTMLDivElement)
+  })
+
+  // Fill these in once the real variant / size / state vocabulary exists.
+  // See .claude/rules/testing-guideline.md § Required test cases for the
+  // minimum set per component type (form / compound / action / display).
+  it.todo('applies a distinct class for each variant')
+  it.todo('applies a distinct class for each size')
+  it.todo('exposes a queryable accessible role + name (interactive components)')
+})

--- a/.claude/skills/add-lv1-component/templates/Component.tsx.template
+++ b/.claude/skills/add-lv1-component/templates/Component.tsx.template
@@ -1,0 +1,46 @@
+import { forwardRef, type HTMLAttributes } from 'react'
+import { cn } from '../../../lib/utils'
+import {
+  type __ComponentName__Variants,
+  __componentName__Variants,
+} from '../../../variants/__component-name__'
+
+export interface __ComponentName__Props
+  extends HTMLAttributes<HTMLDivElement>,
+    __ComponentName__Variants {
+  /**
+   * Visual style of the __componentName__.
+   * - `neutral` — describe each option here (bullet list per option)
+   * @default 'neutral'
+   */
+  variant?: __ComponentName__Variants['variant']
+  /**
+   * Size of the __componentName__.
+   * @default 'md'
+   */
+  size?: __ComponentName__Variants['size']
+}
+
+/**
+ * __ComponentName__ — one-line description of what this primitive is for.
+ *
+ * Accessibility contract (component-architecture.md §8): an interactive
+ * component MUST render a native interactive element (or a Radix primitive)
+ * so it exposes a stable role + accessible name. A plain `<div>` is only
+ * acceptable for non-interactive display content.
+ */
+export const __ComponentName__ = forwardRef<HTMLDivElement, __ComponentName__Props>(
+  ({ className, variant, size, children, ...props }, ref) => {
+    return (
+      <div
+        ref={ref}
+        className={cn(__componentName__Variants({ variant, size }), className)}
+        {...props}
+      >
+        {children}
+      </div>
+    )
+  },
+)
+
+__ComponentName__.displayName = '__ComponentName__'

--- a/.claude/skills/add-lv1-component/templates/Component.vrt.spec.ts.template
+++ b/.claude/skills/add-lv1-component/templates/Component.vrt.spec.ts.template
@@ -1,0 +1,34 @@
+import { expect, test } from '@playwright/test'
+
+const STORY_ID_PREFIX = 'components-lv1-__component-name__'
+
+// Only stories that represent distinct visual states. Exclude `Playground`.
+// Story export names map to kebab-case ids: `AllVariants` → `all-variants`.
+const stories = ['all-variants', 'sizes'] as const
+
+const themes = ['light', 'dark'] as const
+
+function storyUrl(storyId: string, theme: string) {
+  return `/iframe.html?id=${STORY_ID_PREFIX}--${storyId}&globals=theme:${theme}&viewMode=story`
+}
+
+for (const story of stories) {
+  for (const theme of themes) {
+    test(`__ComponentName__ / ${story} / ${theme}`, async ({ page }) => {
+      await page.goto(storyUrl(story, theme))
+      await page.waitForLoadState('networkidle')
+
+      const root = page.locator('#storybook-root')
+      await root.waitFor({ state: 'visible', timeout: 10_000 })
+      await page.waitForFunction(
+        () => {
+          const el = document.querySelector('#storybook-root')
+          return el && el.children.length > 0
+        },
+        { timeout: 10_000 },
+      )
+
+      await expect(root).toHaveScreenshot(`${story}-${theme}.png`)
+    })
+  }
+}

--- a/.claude/skills/add-lv1-component/templates/index.ts.template
+++ b/.claude/skills/add-lv1-component/templates/index.ts.template
@@ -1,0 +1,1 @@
+export { __ComponentName__, type __ComponentName__Props } from './__ComponentName__'

--- a/.claude/skills/add-lv1-component/templates/variants.ts.template
+++ b/.claude/skills/add-lv1-component/templates/variants.ts.template
@@ -1,0 +1,41 @@
+import { cva, type VariantProps } from 'class-variance-authority'
+
+/**
+ * CVA variant definition for `<__ComponentName__ />`.
+ *
+ * Keep this file in sync with the component's `Props` interface and its
+ * Storybook `argTypes`. See:
+ * - .claude/rules/component-api-conventions.md — variant vocabularies
+ * - .claude/rules/state-token-guideline.md — never hard-code primitive
+ *   colors (`bg-red-500`); always go through semantic tokens (`bg-error`, …)
+ */
+export const __componentName__Variants = cva(
+  // Base classes shared by every variant.
+  // For an INTERACTIVE component, keep the focus-visible ring chain:
+  //   focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring
+  //   focus-visible:ring-offset-2
+  // (component-architecture.md §8 — accessibility contract).
+  'inline-flex items-center',
+  {
+    variants: {
+      // Pattern A (Button-like): each value names a complete role.
+      // Pattern B (Badge/Callout/Toast-like): `variant` = tone, add a
+      //   separate `appearance` axis for shape/weight.
+      // Replace `neutral` with the real vocabulary for this component.
+      variant: {
+        neutral: '',
+      },
+      size: {
+        sm: '',
+        md: '',
+        lg: '',
+      },
+    },
+    defaultVariants: {
+      variant: 'neutral',
+      size: 'md',
+    },
+  },
+)
+
+export type __ComponentName__Variants = VariantProps<typeof __componentName__Variants>

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,7 +65,7 @@ pnpm changeset         # Create a changeset for user-facing changes
 - **Do not** write primitive color classes (`bg-red-500`, `text-blue-700`, `bg-vermillion-600`, …) directly in JSX or CSS. Use **state semantic tokens** (`bg-error`, `text-error-foreground`, `bg-error-subtle`, `bg-destructive`, …) so light/dark and seasonal themes stay correct. See [state-token-guideline](.claude/rules/state-token-guideline.md).
 - **Do not** confuse `destructive` and `error`. They share the same primitive (`red`) but are semantically distinct — `destructive` is for actions (e.g. `<Button variant="destructive">`), `error` is for form/notification state (e.g. `<Input isError>`). See [state-token-guideline](.claude/rules/state-token-guideline.md#destructive-vs-error).
 - **Do not** build new components with ad-hoc styles outside the design system. Compose existing `lv1` primitives, or extend the variant definitions in `src/variants/`.
-- **Do not** add a new `lv1` / `lv2` component without **Storybook story + Vitest test + VRT spec** alongside it. Follow the Storybook conventions (Playground story first, group by prop) and place the VRT spec at `ComponentName.vrt.spec.ts` next to the component.
+- **Do not** add a new `lv1` / `lv2` component without **Storybook story + Vitest test + VRT spec** alongside it. Follow the Storybook conventions (Playground story first, group by prop) and place the VRT spec at `ComponentName.vrt.spec.ts` next to the component. The canonical 6-file shape (variants / tsx / stories / test / vrt / index) is captured in [`.claude/skills/add-lv1-component/templates/`](.claude/skills/add-lv1-component/templates) — use those placeholder templates as the reference scaffold even if your tool cannot run the Claude Code skill itself.
 - **Do not** create individual stories for every prop value (`Default`, `Secondary`, `Outline` as separate exports). Group them into render stories (`AllVariants`, `Sizes`, `Disabled`, …). See [storybook-guideline](.claude/rules/storybook-guideline.md).
 - **Do not** write Storybook `description`, `argTypes`, button labels, etc. in Japanese — Storybook surfaces use **English only**.
 - **Do not** ship user-facing changes without a changeset entry. Run `pnpm changeset` and pick the appropriate semver bump. CI enforces this via `changeset status --since=origin/main`. For internal-only PRs (`.github/` workflow changes, docs, test-only additions), apply the `no-changeset` label to skip the check; dependabot PRs are auto-skipped.
@@ -87,7 +87,10 @@ pnpm changeset         # Create a changeset for user-facing changes
 | [.claude/rules/lint-rules-guideline.md](.claude/rules/lint-rules-guideline.md) | Biome rules added on top of `recommended` and the rationale for each. |
 | [.claude/rules/api-stability.md](.claude/rules/api-stability.md) | Public API stability contract (effective v1.0.0) — what is public, breaking-change policy, CHANGELOG conventions. |
 | [.claude/rules/component-testid-guideline.md](.claude/rules/component-testid-guideline.md) | `data-testid` pass-through policy, Portal content handling, no-auto-testid rule. |
+| [.claude/skills/add-lv1-component/](.claude/skills/add-lv1-component) | Claude Code skill that scaffolds a new lv1 — `templates/` doubles as the reference 6-file shape for any AI tool. |
 
 ## Maintenance
 
 When you add or remove a file under [`.claude/rules/`](.claude/rules), update **Required reading** and **Resource Map** above so AI agents pick it up automatically. CLAUDE.md's `Guidelines` section also lists the same files — keep both indexes in sync.
+
+When you change a rule that the [`add-lv1-component`](.claude/skills/add-lv1-component) skill depends on (component API conventions, testing, VRT, storybook, token usage), check that the skill's `templates/` still match the updated rule — the templates are a frozen scaffold and do not auto-update. `templates.test.ts` only guards their *syntax*, not their *conformance* to the rules.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,6 +40,12 @@ When adding or modifying components, follow shadcn/ui conventions (Radix UI + CV
 - See [.claude/rules/api-stability.md](.claude/rules/api-stability.md) for the public API stability contract (effective from v1.0.0) — what counts as public API across React props, CSS classes, CSS variables, and CVA output, and the breaking-change policy
 - See [.claude/rules/component-testid-guideline.md](.claude/rules/component-testid-guideline.md) for the `data-testid` pass-through policy and the no-auto-testid rule
 
+## Claude Code skills
+
+`.claude/skills/` holds project-level skills (team-shared, checked into git):
+
+- **[add-lv1-component](.claude/skills/add-lv1-component/SKILL.md)** — scaffolds a new lv1 primitive. Generates the full 6-file set (variants CVA / tsx / stories / unit test / VRT spec / index) from placeholder templates, registers the component in [src/components/lv1/index.ts](src/components/lv1/index.ts) and [src/variants/index.ts](src/variants/index.ts), and follows every `.claude/rules/` guideline. Use it whenever you add a new lv1 — it structurally prevents test-less / VRT-less additions. Triggered automatically by requests like "add a new lv1 component" or invoked explicitly via the skill name.
+
 ## Claude Code hooks
 
 `.claude/settings.json` registers two project-level hooks (team-shared, checked into git — distinct from the per-user `.claude/settings.local.json`):

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,5 +1,10 @@
 {
   "extends": "./tsconfig.json",
-  "include": ["src/**/*", "biome-plugins/**/*.ts", "vitest.setup.ts"],
+  "include": [
+    "src/**/*",
+    "biome-plugins/**/*.ts",
+    ".claude/skills/**/*.test.ts",
+    "vitest.setup.ts"
+  ],
   "exclude": ["node_modules", "dist"]
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,6 +5,10 @@ export default defineConfig({
     environment: 'jsdom',
     globals: true,
     setupFiles: ['./vitest.setup.ts'],
-    include: ['src/**/*.test.{ts,tsx}', 'biome-plugins/**/*.test.ts'],
+    include: [
+      'src/**/*.test.{ts,tsx}',
+      'biome-plugins/**/*.test.ts',
+      '.claude/skills/**/*.test.ts',
+    ],
   },
 })


### PR DESCRIPTION
## 概要

「新しい lv1 コンポーネントを追加して」と AI に依頼した時に必要なファイル一式を生成する Claude Code skill を新設。test/vrt 抜きの追加を構造的に防ぐ (#130)。

## 変更内容

### `.claude/skills/add-lv1-component/`
- **`SKILL.md`** — 起動条件 (description)・手順を定義。実行時に必ず `.claude/rules/` を読み直す手順を含む。対話で コンポーネント名 / パターン (A: Role-based / B: Tone × Shape / Form / Display) / compound・flat / variant・size / root element を確認 → 6 ファイル生成 → `pnpm lint:fix → typecheck → lint → test` で検証 → commit はユーザーに委ねる。
- **`templates/`** — placeholder テンプレ 6 種:
  - `variants.ts.template` (CVA 定義)
  - `Component.tsx.template` (forwardRef + Props + TSDoc)
  - `Component.stories.tsx.template` (Playground 先頭 + group story)
  - `Component.test.tsx.template` (基本 4 ケース + `it.todo` の雛形)
  - `Component.vrt.spec.ts.template` (vrt-spec-guideline 準拠テンプレ)
  - `index.ts.template`
  - placeholder: `__ComponentName__` / `__componentName__` / `__component-name__`

### 案内の追記
- `CLAUDE.md` に **「Claude Code skills」** セクションを新設
- `AGENTS.md` の MUST NOT 項目 / Resource Map から `templates/` を参照 (非 Claude ツールも 6 ファイル形の参照スキャフォルドとして利用可)

## 動作確認 (DoD)

仮想コンポーネント `Banner` をテンプレから生成し、index 登録まで行って検証:

- ✅ `pnpm typecheck`
- ✅ `pnpm lint` (`biome check --write` で整形後)
- ✅ `pnpm test --run` — 4 passed / 3 todo

検証後、生成物は撤去済み。

## メモ

- `.claude/` のみの変更で公開パッケージに影響しないため `no-changeset` ラベルを付与。
- VRT ベースラインは初回 `pnpm test:vrt` 実行時に生成される旨を SKILL.md に明記。

closes #130

🤖 Generated with [Claude Code](https://claude.com/claude-code)