### PR TITLE
fix(storybook): read STORYBOOK_CHANNEL via import.meta.env in preview

### DIFF
--- a/.changeset/fix-storybook-dev-process-undefined.md
+++ b/.changeset/fix-storybook-dev-process-undefined.md
@@ -1,0 +1,7 @@
+---
+'@yasmro/schatten': patch
+---
+
+Fix `pnpm dev` failing to render any Storybook story with `ReferenceError: process is not defined`.
+
+`.storybook/preview.tsx` read `process.env.STORYBOOK_CHANNEL` at module scope, but the file is bundled into the browser preview iframe where `process` is not a global. The bare reference threw on module evaluation and left `#storybook-root` empty. It now reads `import.meta.env.STORYBOOK_CHANNEL`, which Storybook's Vite builder populates for `STORYBOOK_`-prefixed vars in both the dev server and the production build. The published `@yasmro/schatten` package is unchanged — this is a tooling-only fix.

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -6,9 +6,17 @@ import '../src/styles/globals.css'
 
 // `STORYBOOK_CHANNEL` is injected by `.github/workflows/deploy-storybook.yml`:
 // the `develop` build (published at /schatten/next/) sets it to `next`, the
-// `main` build leaves it `stable`. Storybook exposes `STORYBOOK_`-prefixed env
-// vars to preview code, so this is also `undefined` in local dev and VRT runs.
-const isNextChannel = process.env.STORYBOOK_CHANNEL === 'next'
+// `main` build leaves it `stable`.
+//
+// Read via `import.meta.env`, NOT `process.env`: this file is bundled into the
+// browser preview iframe, where `process` is not a global. A bare `process.env`
+// reference there throws `ReferenceError: process is not defined` and aborts
+// story rendering — Storybook 10's Vite builder does not shim `process` for the
+// preview. Storybook's Vite builder does add `STORYBOOK_` to Vite's `envPrefix`,
+// so `STORYBOOK_`-prefixed vars surface on `import.meta.env` in both dev and
+// build, resolving to `undefined` in local dev / VRT where the var is unset.
+const importMetaEnv = (import.meta as ImportMeta & { env?: Record<string, string | undefined> }).env
+const isNextChannel = importMetaEnv?.STORYBOOK_CHANNEL === 'next'
 
 const BANNER_ID = 'schatten-unreleased-banner'
 


### PR DESCRIPTION
## Problem

`pnpm dev` (Storybook dev server) rendered **no stories** — every story failed with `ReferenceError: process is not defined` in the browser, leaving `#storybook-root` empty/hidden.

`.storybook/preview.tsx` read `process.env.STORYBOOK_CHANNEL` at module scope. `preview.tsx` is bundled into the browser preview iframe, where `process` is not a global; Storybook 10's Vite builder does not shim it for the preview. The bare reference threw on module evaluation and aborted story rendering.

The TSDoc comment claimed the expression evaluates to `undefined` in local dev — it actually **throws**.

Introduced by 1ae4d379 ("feat(ci): add sidebar badge + single-mount the /next/ banner").

## Fix

Read the channel via `import.meta.env.STORYBOOK_CHANNEL` instead. Storybook's Vite builder adds `STORYBOOK_` to Vite's `envPrefix` and defines `import.meta.env`, so the var resolves in **both** the dev server and the production build, and is `undefined` in local dev / VRT (as intended).

## `.storybook/manager.ts` — deliberately left unchanged

The brief suggested applying the same fix to `manager.ts:9`. Investigation shows it is **not** affected and changing it would break it:

- The Storybook **manager** is bundled by a separate esbuild builder that does `define: { "process.env": JSON.stringify(envs), ... }` — it injects `process.env` as a literal object, so `process.env.STORYBOOK_CHANNEL` resolves safely there (no `process` reference survives).
- That esbuild config never defines `import.meta.env`, so switching `manager.ts` to `import.meta.env` would throw instead.

Confirmed empirically: the built manager bundle contains the `未リリース` sidebar badge and zero bare `process.env` references.

## Note on production

The brief stated the production build was unaffected. In fact builder-vite only defines `import.meta.env.*` (never `process.env.STORYBOOK_CHANNEL`), so the deployed `/schatten/next/` preview was likely broken the same way. This fix corrects both the dev and build paths.

## Verification

- `pnpm dev` → loaded `iframe.html?id=components-lv1-spinner--sizes`; `#storybook-root` populated (3 spinners), not hidden, **0 console errors**.
- `STORYBOOK_CHANNEL=next pnpm build:storybook` → succeeds; built preview bundle has **no bare `process.env.STORYBOOK*`**; manager badge present.

## Changeset

`patch` on `@yasmro/schatten`. The published npm artifact is byte-identical (tooling-only change) — flagging that the repo precedent for `.storybook/`-only changes (`develop-storybook-next.md`) is an *empty* changeset, in case an empty one is preferred for consistency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)