### PR TITLE
feat(theme): ThemeProvider + FOUC snippet — closes #128, #129

### DIFF
--- a/.changeset/theme-provider.md
+++ b/.changeset/theme-provider.md
@@ -1,0 +1,24 @@
+---
+'@yasmro/schatten': minor
+---
+
+Add `<ThemeProvider>` / `useTheme()` — a declarative API for managing the
+Mode (light/dark) and Special (`data-theme`) axes from a React tree. Wraps
+the previously-manual `document.documentElement.classList.toggle('dark')`
++ `setAttribute('data-theme', …)` plumbing into a client-only Provider:
+
+- `defaultMode` accepts `'light' | 'dark' | 'system'`; `'system'` subscribes
+  to `matchMedia('(prefers-color-scheme: dark)')`.
+- `defaultSpecial` accepts an explicit `SpecialThemeId`, `'auto-seasonal'`
+  (resolves the current date via `getCurrentSeason()`), or `null`.
+- State persists to `localStorage` under `storageKey` (default
+  `'schatten-theme'`); pass `null` to disable. Cross-tab updates sync via
+  the native `storage` event.
+- `useTheme()` exposes both the resolved `mode` (`'light' | 'dark'`) and
+  the user-facing `modeSetting` (which can include `'system'`).
+- Optional `disableTransitionOnChange` strips CSS transitions during a swap
+  for instant feedback.
+
+New entry point: `@yasmro/schatten/providers`.
+
+Component / lv1 / lv2 / CSS API: unchanged.

--- a/.changeset/theme-provider.md
+++ b/.changeset/theme-provider.md
@@ -19,6 +19,12 @@ the previously-manual `document.documentElement.classList.toggle('dark')`
 - Optional `disableTransitionOnChange` strips CSS transitions during a swap
   for instant feedback.
 
+The README now documents the Provider, the `useTheme()` hook, and a
+synchronous FOUC-avoidance inline script (Next.js App Router / Vite /
+Remix variants + strict-CSP fallback) that mirrors the Provider's
+`localStorage` contract. The storage shape `{ mode, special }` under the
+default `storageKey` `'schatten-theme'` is part of the public API surface.
+
 New entry point: `@yasmro/schatten/providers`.
 
 Component / lv1 / lv2 / CSS API: unchanged.

--- a/.claude/rules/api-stability.md
+++ b/.claude/rules/api-stability.md
@@ -33,8 +33,9 @@ CHANGELOG:
 | CSS class names | `.btn`, `.btn--primary`, `.input-wrapper`, `[data-variant="solid"]` (Phase 2 of #58) |
 | CSS custom properties | `--color-primary-600`, `--color-error`, `--spacing-4`, `--font-sans` |
 | CVA output strings | The class string returned by `buttonVariants({ variant: 'primary' })` |
-| Multi-entry exports | `@yasmro/schatten/components/lv1`, `/tokens`, `/variants`, `/themes/default`, `/themes/seasonal` |
+| Multi-entry exports | `@yasmro/schatten/components/lv1`, `/tokens`, `/variants`, `/themes/default`, `/themes/seasonal`, `/providers` |
 | Theme contract | Which CSS variables a custom theme must define to be valid |
+| Provider runtime contract | The `localStorage` key (`'schatten-theme'`) and JSON shape (`{ mode, special }`) that `<ThemeProvider>` reads/writes. This is the contract the FOUC inline snippet ([#129](https://github.com/yasmro/schatten/issues/129)) and any consumer-side persistence code depends on. Renaming the key, adding/removing a field, or changing field semantics is a breaking change. See [#262](https://github.com/yasmro/schatten/issues/262) for the upcoming SHA-256 hash publication that further pins the inline snippet body. |
 
 ## What is **not** public API
 

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -116,8 +116,14 @@ const preview: Preview = {
       const theme = context.globals.theme
       const season = context.globals.season
       const isDark = theme === 'dark'
+      // Stories that own their own theme state (e.g. ThemeProvider
+      // stories) opt out of this decorator to avoid two writers racing
+      // on `<html>`. Stories declare it via:
+      //   parameters: { disableGlobalThemeDecorator: true }
+      const disableGlobalThemeDecorator = context.parameters?.disableGlobalThemeDecorator === true
 
       useEffect(() => {
+        if (disableGlobalThemeDecorator) return
         const root = document.documentElement
         const body = document.body
 
@@ -143,7 +149,7 @@ const preview: Preview = {
         } else {
           root.removeAttribute('data-theme')
         }
-      }, [isDark, season])
+      }, [isDark, season, disableGlobalThemeDecorator])
 
       useEffect(() => {
         if (isNextChannel) mountUnreleasedBanner()
@@ -151,7 +157,7 @@ const preview: Preview = {
 
       return (
         <div
-          className={`${isDark ? 'dark bg-background' : ''} p-8`}
+          className={`${isDark && !disableGlobalThemeDecorator ? 'dark bg-background' : ''} p-8`}
           style={isNextChannel ? { paddingTop: '3rem' } : undefined}
         >
           <Story />

--- a/README.md
+++ b/README.md
@@ -281,6 +281,13 @@ theme — don't branch JSX subtrees on `mode`. Schatten components repaint
 through the CSS cascade with no React reconciliation, so a switch is free;
 JSX branching forfeits that.
 
+Multiple React roots on the same page (Astro Islands, micro-frontends,
+two separate React mounts) work without explicit coordination: each
+`ThemeProvider` observes `<html>` via `MutationObserver`, so when one
+root mutates Mode or Special, the others sync automatically. `modeSetting`
+(the `'system'` / `'light'` / `'dark'` choice itself) is not encoded in
+the DOM — keep the actual switcher in one root if you need to expose it.
+
 ### FOUC avoidance
 
 When `defaultMode="system"` (or any persisted selection differs from the

--- a/README.md
+++ b/README.md
@@ -211,62 +211,190 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
 }
 ```
 
-### Theme switching *(Coming in v0.9.0)*
+### Theme switching
 
-Runtime light/dark and seasonal (Special) theme switching will be driven by
-a `ThemeProvider` / `useTheme` pair landing in **v0.9.0**
-([#128](https://github.com/yasmro/schatten/issues/128)). Because it relies on
-React context and state, it must be mounted as a Client Component:
+Runtime light/dark and seasonal (Special) theme switching is driven by the
+`ThemeProvider` / `useTheme` pair exported from `@yasmro/schatten/providers`
+(added in **v0.9.0**, [#128](https://github.com/yasmro/schatten/issues/128)).
+The Provider is a thin wrapper around the existing `<html>` contract
+(`.dark` class for Mode + `data-theme="<id>"` for Special — see
+[`.claude/rules/theme-architecture.md`](.claude/rules/theme-architecture.md)),
+so Schatten components themselves never subscribe to it — they're repainted
+via the CSS cascade.
 
-```tsx
-// app/providers.tsx — Coming in v0.9.0
-'use client'
-import { ThemeProvider } from '@yasmro/schatten'
-
-export function Providers({ children }: { children: React.ReactNode }) {
-  return <ThemeProvider>{children}</ThemeProvider>
-}
-```
+The Provider is a Client Component (its bundle ships with a `'use client'`
+banner), so you can import it from a Server Component layout directly — no
+wrapper file needed:
 
 ```tsx
-// app/layout.tsx — Coming in v0.9.0
-import { Providers } from './providers'
+// app/layout.tsx
+import '@yasmro/schatten/schatten.css'
+import { ThemeProvider } from '@yasmro/schatten/providers'
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
-    <html lang="en">
+    <html lang="en" suppressHydrationWarning>
       <body>
-        <Providers>{children}</Providers>
+        <ThemeProvider defaultMode="system" defaultSpecial="auto-seasonal">
+          {children}
+        </ThemeProvider>
       </body>
     </html>
   )
 }
 ```
 
-Until v0.9.0 ships, set the theme on `<html>` directly — `class="dark"` for
-Mode and `data-theme="season--spring-early"` for a Special. The cascade is
-plain CSS (see
-[`.claude/rules/theme-architecture.md`](.claude/rules/theme-architecture.md)),
-so no React runtime is involved.
+```tsx
+// Anywhere in a Client Component
+'use client'
+import { useTheme } from '@yasmro/schatten/providers'
 
-### FOUC avoidance *(Coming in v0.9.0)*
+export function ThemeSwitcher() {
+  const { mode, modeSetting, setMode } = useTheme()
+  return (
+    <select value={modeSetting} onChange={(e) => setMode(e.target.value as never)}>
+      <option value="system">System</option>
+      <option value="light">Light</option>
+      <option value="dark">Dark</option>
+    </select>
+  )
+}
+```
 
-A server-rendered page can briefly flash the wrong Mode before the client
-resolves the user's preference (FOUC — flash of unstyled content). The fix is
-a tiny synchronous inline script in `<head>` that sets the `<html>` class
-before first paint. The exact snippet ships with the v0.9.0 theming work and
-is documented in [#129](https://github.com/yasmro/schatten/issues/129):
+**Props (most useful)**:
+
+- `defaultMode`: `'light' | 'dark' | 'system'` — `'system'` subscribes to `prefers-color-scheme: dark`. Default `'system'`.
+- `defaultSpecial`: a `SpecialThemeId` (e.g. `'season--spring-late'`), `'auto-seasonal'` (resolves the current date), or `null`. Default `null`.
+- `storageKey`: `localStorage` key used to persist the user's selection across reloads. Default `'schatten-theme'`; pass `null` to disable persistence.
+- `disableTransitionOnChange`: pass `true` for instantaneous swaps (suppresses CSS transitions during a Mode/Special change).
+
+**`useTheme()` returns**:
+
+- `mode`: the **resolved** `'light' | 'dark'` value (use this for CSS judgments).
+- `modeSetting`: the **raw** setting including `'system'` (use this for UI toggles that need to show the system-tracking state).
+- `setMode(setting)`: pass `'system'` to return to OS-following.
+- `special` / `setSpecial(id | null)`: writes / removes `data-theme`.
+- `isHydrated`: `true` once the client effect has reconciled with `localStorage` + `matchMedia`.
+
+Reach for `useTheme()` only when you need to **read or mutate** the active
+theme — don't branch JSX subtrees on `mode`. Schatten components repaint
+through the CSS cascade with no React reconciliation, so a switch is free;
+JSX branching forfeits that.
+
+### FOUC avoidance
+
+When `defaultMode="system"` (or any persisted selection differs from the
+SSR default), a server-rendered page can briefly flash light before the
+client effect upgrades the DOM. The fix is a tiny synchronous inline
+script in `<head>` that mirrors the same `localStorage` / `matchMedia`
+logic the Provider runs — but **before** first paint
+([#129](https://github.com/yasmro/schatten/issues/129)).
+
+The snippet contract is fixed: it reads the same JSON shape the Provider
+writes (`{ mode, special }`) under the same `storageKey` (default
+`'schatten-theme'`). Drop it in as the very first `<head>` child:
+
+#### Next.js App Router
 
 ```tsx
-// app/layout.tsx — Coming in v0.9.0
+// app/layout.tsx
+import '@yasmro/schatten/schatten.css'
+import { ThemeProvider } from '@yasmro/schatten/providers'
+
+const themeInitScript = `(function(){try{var s=localStorage.getItem('schatten-theme');var t=s?JSON.parse(s):{};var m=t.mode||'system';var d=m==='dark'||(m==='system'&&window.matchMedia('(prefers-color-scheme: dark)').matches);if(d)document.documentElement.classList.add('dark');if(t.special)document.documentElement.setAttribute('data-theme',t.special)}catch(e){}})();`
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en" suppressHydrationWarning>
+      <head>
+        <script dangerouslySetInnerHTML={{ __html: themeInitScript }} />
+      </head>
+      <body>
+        <ThemeProvider defaultMode="system">{children}</ThemeProvider>
+      </body>
+    </html>
+  )
+}
+```
+
+`suppressHydrationWarning` on `<html>` is required because the script
+mutates that element before React hydrates the tree.
+
+#### Vite / plain HTML
+
+```html
+<!-- index.html -->
 <head>
-  <script
-    dangerouslySetInnerHTML={{
-      __html: `/* FOUC-avoidance snippet — finalized in v0.9.0 (#129) */`,
-    }}
-  />
+  <script>
+    (function () {
+      try {
+        var s = localStorage.getItem('schatten-theme')
+        var t = s ? JSON.parse(s) : {}
+        var m = t.mode || 'system'
+        var d =
+          m === 'dark' ||
+          (m === 'system' &&
+            window.matchMedia('(prefers-color-scheme: dark)').matches)
+        if (d) document.documentElement.classList.add('dark')
+        if (t.special) document.documentElement.setAttribute('data-theme', t.special)
+      } catch (e) {}
+    })()
+  </script>
+  <link rel="stylesheet" href="/path/to/schatten.css" />
 </head>
 ```
+
+#### Remix
+
+Render the snippet in `root.tsx`'s `<head>`:
+
+```tsx
+// app/root.tsx
+import { Links, Meta, Outlet, Scripts, ScrollRestoration } from '@remix-run/react'
+
+const themeInitScript = `(function(){try{var s=localStorage.getItem('schatten-theme');var t=s?JSON.parse(s):{};var m=t.mode||'system';var d=m==='dark'||(m==='system'&&window.matchMedia('(prefers-color-scheme: dark)').matches);if(d)document.documentElement.classList.add('dark');if(t.special)document.documentElement.setAttribute('data-theme',t.special)}catch(e){}})();`
+
+export default function App() {
+  return (
+    <html lang="en" suppressHydrationWarning>
+      <head>
+        <script dangerouslySetInnerHTML={{ __html: themeInitScript }} />
+        <Meta />
+        <Links />
+      </head>
+      <body>
+        <Outlet />
+        <ScrollRestoration />
+        <Scripts />
+      </body>
+    </html>
+  )
+}
+```
+
+#### Strict CSP environments
+
+If your CSP forbids inline scripts, either (a) attach a `nonce` to the
+`<script>` element matching your `script-src 'nonce-…'` directive, or
+(b) move the snippet into a standalone `.js` file served from your own
+origin and reference it with `<script src="/theme-init.js">`.
+
+The snippet runs **synchronously** and **must not be deferred** — `defer`
+/ `async` / loading from a delayed CDN re-introduces the flash this
+exists to prevent.
+
+#### What the snippet handles
+
+- Reads `localStorage.schatten-theme` if present, otherwise treats it as
+  `mode='system'` with no Special.
+- Adds `class="dark"` to `<html>` when the resolved Mode is dark.
+- Writes `data-theme="<id>"` when the persisted Special is set.
+- Wraps everything in `try/catch` so a disabled-storage or private window
+  silently falls back to the SSR default — never throws.
+
+If you customize `storageKey` on the Provider, update the `'schatten-theme'`
+literal in the snippet to match. The two values are a public contract: a
+mismatch silently breaks FOUC avoidance with no error.
 
 ### Remix
 

--- a/package.json
+++ b/package.json
@@ -60,6 +60,14 @@
       },
       "import": "./dist/components/lv1/index.js",
       "require": "./dist/components/lv1/index.cjs"
+    },
+    "./providers": {
+      "types": {
+        "import": "./dist/providers/index.d.ts",
+        "require": "./dist/providers/index.d.cts"
+      },
+      "import": "./dist/providers/index.js",
+      "require": "./dist/providers/index.cjs"
     }
   },
   "files": [

--- a/scripts/check-use-client-banner.mjs
+++ b/scripts/check-use-client-banner.mjs
@@ -32,10 +32,17 @@ function collectBundles(dir) {
 
 const errors = []
 
-// Must carry the directive — every emitted bundle under dist/components.
-const reactBundles = existsSync('dist/components') ? collectBundles('dist/components') : []
+// Must carry the directive — every emitted bundle under dist/components
+// AND dist/providers (Provider entry — same client-only constraints as
+// component bundles).
+const reactBundleDirs = ['dist/components', 'dist/providers']
+const reactBundles = reactBundleDirs.flatMap((dir) =>
+  existsSync(dir) ? collectBundles(dir) : [],
+)
 if (reactBundles.length === 0) {
-  errors.push('dist/components has no .js/.cjs output — did `pnpm build:js` run?')
+  errors.push(
+    `${reactBundleDirs.join(' / ')} has no .js/.cjs output — did \`pnpm build:js\` run?`,
+  )
 }
 for (const file of reactBundles) {
   if (firstLine(file) !== DIRECTIVE) {
@@ -58,4 +65,4 @@ if (errors.length > 0) {
   process.exit(1)
 }
 
-console.log(`check-use-client-banner: OK — ${reactBundles.length} component bundles carry ${DIRECTIVE}`)
+console.log(`check-use-client-banner: OK — ${reactBundles.length} React bundles carry ${DIRECTIVE}`)

--- a/src/providers/ThemeProvider/ThemeProvider.hydration.test.tsx
+++ b/src/providers/ThemeProvider/ThemeProvider.hydration.test.tsx
@@ -10,6 +10,19 @@ import { useTheme } from './useTheme'
 // calls below run their own roots.
 ;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
 
+/**
+ * Drain pending microtask-scheduled React work. The hydration effect's
+ * `applyToDocument` call schedules a MutationObserver callback in a
+ * microtask, which then schedules a (no-op) setState that React wants
+ * to see inside an `act` boundary. Two passes are enough: the first
+ * drains the observer microtask, the second picks up the setState it
+ * scheduled.
+ */
+async function flushObserverMicrotasks() {
+  await act(async () => {})
+  await act(async () => {})
+}
+
 // Renders the SSR output into a jsdom container, then hydrates with
 // the same tree. Verifies that React does NOT log a hydration mismatch
 // warning, and that the post-effect state converges on the right
@@ -44,6 +57,14 @@ function installMatchMediaMock(initialDark: boolean) {
   })
 }
 
+// Note: these hydration tests log a few "update to ThemeProvider was
+// not wrapped in act(...)" warnings under React 19. They are false
+// positives — the MutationObserver inside ThemeProvider fires in a
+// microtask that straddles the `act(async () => {})` boundary, then
+// lands a no-op functional setState. The same DOM-as-source-of-truth
+// behaviour is verified deterministically by the regular tests in
+// `ThemeProvider.test.tsx`, so the warnings here are cosmetic.
+
 beforeEach(() => {
   document.documentElement.classList.remove('dark', 'light')
   document.documentElement.removeAttribute('data-theme')
@@ -52,6 +73,12 @@ beforeEach(() => {
 })
 
 afterEach(() => {
+  // Remove any container that a test appended so the hydrated React
+  // root is unmounted with the DOM node. Otherwise the Provider's
+  // MutationObserver / matchMedia subscription stays live into the next
+  // test, where `vi.restoreAllMocks()` has already cleared their backing
+  // doubles → leftover handlers throw.
+  for (const node of [...document.body.children]) node.remove()
   vi.restoreAllMocks()
   document.documentElement.classList.remove('dark', 'light')
   document.documentElement.removeAttribute('data-theme')
@@ -74,6 +101,7 @@ describe('ThemeProvider (hydration)', () => {
     await act(async () => {
       hydrateRoot(container, tree)
     })
+    await flushObserverMicrotasks()
 
     const mismatch = errorSpy.mock.calls.find(([msg]) => {
       if (typeof msg !== 'string') return false
@@ -97,6 +125,7 @@ describe('ThemeProvider (hydration)', () => {
     await act(async () => {
       hydrateRoot(container, tree)
     })
+    await flushObserverMicrotasks()
 
     expect(document.documentElement.classList.contains('dark')).toBe(true)
     expect(container.querySelector('[data-testid="probe"]')?.getAttribute('data-mode')).toBe('dark')
@@ -120,6 +149,7 @@ describe('ThemeProvider (hydration)', () => {
     await act(async () => {
       hydrateRoot(container, tree)
     })
+    await flushObserverMicrotasks()
 
     expect(document.documentElement.classList.contains('dark')).toBe(true)
     expect(document.documentElement.getAttribute('data-theme')).toBe('season--autumn-late')

--- a/src/providers/ThemeProvider/ThemeProvider.hydration.test.tsx
+++ b/src/providers/ThemeProvider/ThemeProvider.hydration.test.tsx
@@ -1,5 +1,6 @@
+import type * as React from 'react'
 import { act } from 'react'
-import { hydrateRoot } from 'react-dom/client'
+import { hydrateRoot, type Root } from 'react-dom/client'
 import { renderToString } from 'react-dom/server'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { ThemeProvider } from './ThemeProvider'
@@ -65,6 +66,23 @@ function installMatchMediaMock(initialDark: boolean) {
 // behaviour is verified deterministically by the regular tests in
 // `ThemeProvider.test.tsx`, so the warnings here are cosmetic.
 
+/**
+ * Tracks the React roots created in each test so afterEach can unmount
+ * them. Without explicit unmount, the Provider's effects (matchMedia
+ * subscription, MutationObserver) stay live past the test boundary and
+ * fire after Vitest has torn down jsdom — `window` is undefined at that
+ * point and the leftover work throws. CI catches this; local runs are
+ * lucky enough to schedule garbage collection first.
+ */
+const activeRoots: Root[] = []
+
+/** Hydrate + register for teardown. Use instead of `hydrateRoot` directly. */
+function hydrateAndTrack(container: Element, tree: React.ReactNode): Root {
+  const root = hydrateRoot(container, tree)
+  activeRoots.push(root)
+  return root
+}
+
 beforeEach(() => {
   document.documentElement.classList.remove('dark', 'light')
   document.documentElement.removeAttribute('data-theme')
@@ -72,12 +90,13 @@ beforeEach(() => {
   installMatchMediaMock(false)
 })
 
-afterEach(() => {
-  // Remove any container that a test appended so the hydrated React
-  // root is unmounted with the DOM node. Otherwise the Provider's
-  // MutationObserver / matchMedia subscription stays live into the next
-  // test, where `vi.restoreAllMocks()` has already cleared their backing
-  // doubles → leftover handlers throw.
+afterEach(async () => {
+  // Unmount every React root the test created. This stops the
+  // Provider's MutationObserver / matchMedia subscription / storage
+  // listener cleanly so no work is scheduled into a torn-down jsdom.
+  await act(async () => {
+    for (const root of activeRoots.splice(0)) root.unmount()
+  })
   for (const node of [...document.body.children]) node.remove()
   vi.restoreAllMocks()
   document.documentElement.classList.remove('dark', 'light')
@@ -99,7 +118,7 @@ describe('ThemeProvider (hydration)', () => {
     const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
 
     await act(async () => {
-      hydrateRoot(container, tree)
+      hydrateAndTrack(container, tree)
     })
     await flushObserverMicrotasks()
 
@@ -123,7 +142,7 @@ describe('ThemeProvider (hydration)', () => {
     document.body.appendChild(container)
 
     await act(async () => {
-      hydrateRoot(container, tree)
+      hydrateAndTrack(container, tree)
     })
     await flushObserverMicrotasks()
 
@@ -147,7 +166,7 @@ describe('ThemeProvider (hydration)', () => {
     document.body.appendChild(container)
 
     await act(async () => {
-      hydrateRoot(container, tree)
+      hydrateAndTrack(container, tree)
     })
     await flushObserverMicrotasks()
 

--- a/src/providers/ThemeProvider/ThemeProvider.hydration.test.tsx
+++ b/src/providers/ThemeProvider/ThemeProvider.hydration.test.tsx
@@ -1,0 +1,127 @@
+import { act } from 'react'
+import { hydrateRoot } from 'react-dom/client'
+import { renderToString } from 'react-dom/server'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { ThemeProvider } from './ThemeProvider'
+import { useTheme } from './useTheme'
+
+// React 19 looks at this global to allow `act()` boundaries outside the
+// usual `@testing-library/react` `render(...)` wrapper. The `hydrateRoot`
+// calls below run their own roots.
+;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+
+// Renders the SSR output into a jsdom container, then hydrates with
+// the same tree. Verifies that React does NOT log a hydration mismatch
+// warning, and that the post-effect state converges on the right
+// values (matchMedia / localStorage).
+
+function Probe() {
+  const { mode, special, modeSetting } = useTheme()
+  return (
+    <div
+      data-testid="probe"
+      data-mode={mode}
+      data-modesetting={modeSetting}
+      data-special={special ?? 'null'}
+    />
+  )
+}
+
+function installMatchMediaMock(initialDark: boolean) {
+  Object.defineProperty(window, 'matchMedia', {
+    configurable: true,
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches: initialDark && query.includes('dark'),
+      media: query,
+      onchange: null,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: () => false,
+    })),
+  })
+}
+
+beforeEach(() => {
+  document.documentElement.classList.remove('dark', 'light')
+  document.documentElement.removeAttribute('data-theme')
+  localStorage.clear()
+  installMatchMediaMock(false)
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  document.documentElement.classList.remove('dark', 'light')
+  document.documentElement.removeAttribute('data-theme')
+})
+
+describe('ThemeProvider (hydration)', () => {
+  it('hydrates without React mismatch warnings when system=light', async () => {
+    const tree = (
+      <ThemeProvider defaultMode="system">
+        <Probe />
+      </ThemeProvider>
+    )
+    const ssrHtml = renderToString(tree)
+    const container = document.createElement('div')
+    container.innerHTML = ssrHtml
+    document.body.appendChild(container)
+
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    await act(async () => {
+      hydrateRoot(container, tree)
+    })
+
+    const mismatch = errorSpy.mock.calls.find(([msg]) => {
+      if (typeof msg !== 'string') return false
+      return msg.includes('did not match') || msg.includes('Hydration')
+    })
+    expect(mismatch, errorSpy.mock.calls.map((c) => c[0]).join('\n')).toBeUndefined()
+  })
+
+  it('converges to OS dark mode after effect when system=dark', async () => {
+    installMatchMediaMock(true)
+    const tree = (
+      <ThemeProvider defaultMode="system">
+        <Probe />
+      </ThemeProvider>
+    )
+    const ssrHtml = renderToString(tree)
+    const container = document.createElement('div')
+    container.innerHTML = ssrHtml
+    document.body.appendChild(container)
+
+    await act(async () => {
+      hydrateRoot(container, tree)
+    })
+
+    expect(document.documentElement.classList.contains('dark')).toBe(true)
+    expect(container.querySelector('[data-testid="probe"]')?.getAttribute('data-mode')).toBe('dark')
+  })
+
+  it('converges to persisted dark + special after effect', async () => {
+    localStorage.setItem(
+      'schatten-theme',
+      JSON.stringify({ mode: 'dark', special: 'season--autumn-late' }),
+    )
+    const tree = (
+      <ThemeProvider defaultMode="light">
+        <Probe />
+      </ThemeProvider>
+    )
+    const ssrHtml = renderToString(tree)
+    const container = document.createElement('div')
+    container.innerHTML = ssrHtml
+    document.body.appendChild(container)
+
+    await act(async () => {
+      hydrateRoot(container, tree)
+    })
+
+    expect(document.documentElement.classList.contains('dark')).toBe(true)
+    expect(document.documentElement.getAttribute('data-theme')).toBe('season--autumn-late')
+  })
+})

--- a/src/providers/ThemeProvider/ThemeProvider.ssr.test.tsx
+++ b/src/providers/ThemeProvider/ThemeProvider.ssr.test.tsx
@@ -1,0 +1,80 @@
+// @vitest-environment node
+import { renderToString } from 'react-dom/server'
+import { describe, expect, it } from 'vitest'
+import { ThemeProvider } from './ThemeProvider'
+import { useTheme } from './useTheme'
+
+// On the server `window` / `document` / `localStorage` / `matchMedia`
+// are all undefined. These tests verify that the Provider:
+//   1. renders to a deterministic string,
+//   2. emits `mode='light'` + `special=null` as the SSR baseline (so
+//      the FOUC inline snippet at #129 is the single source of truth
+//      for the real first-paint values), and
+//   3. never throws when DOM globals are missing.
+
+function Probe() {
+  const { mode, modeSetting, special, isHydrated } = useTheme()
+  return (
+    <div
+      data-mode={mode}
+      data-modesetting={modeSetting}
+      data-special={special ?? 'null'}
+      data-hydrated={isHydrated ? 'yes' : 'no'}
+    />
+  )
+}
+
+describe('ThemeProvider (SSR / node env)', () => {
+  it('renders to a string without touching DOM globals', () => {
+    expect(typeof window).toBe('undefined')
+    expect(() =>
+      renderToString(
+        <ThemeProvider>
+          <Probe />
+        </ThemeProvider>,
+      ),
+    ).not.toThrow()
+  })
+
+  it('emits mode=light / special=null as the SSR baseline (defaultMode="system")', () => {
+    const html = renderToString(
+      <ThemeProvider defaultMode="system">
+        <Probe />
+      </ThemeProvider>,
+    )
+    expect(html).toContain('data-mode="light"')
+    expect(html).toContain('data-modesetting="system"')
+    expect(html).toContain('data-special="null"')
+    expect(html).toContain('data-hydrated="no"')
+  })
+
+  it('honors explicit defaultMode on the server', () => {
+    const html = renderToString(
+      <ThemeProvider defaultMode="dark">
+        <Probe />
+      </ThemeProvider>,
+    )
+    expect(html).toContain('data-mode="dark"')
+    expect(html).toContain('data-modesetting="dark"')
+  })
+
+  it('resolves defaultSpecial=auto-seasonal on the server', () => {
+    // The function is date-dependent; assert only that *some* season id
+    // landed (we just need to know it didn't throw / SSR'd null).
+    const html = renderToString(
+      <ThemeProvider defaultSpecial="auto-seasonal">
+        <Probe />
+      </ThemeProvider>,
+    )
+    expect(html).toMatch(/data-special="season--[a-z-]+"/)
+  })
+
+  it('renders the SSR baseline even when storageKey is null', () => {
+    const html = renderToString(
+      <ThemeProvider storageKey={null}>
+        <Probe />
+      </ThemeProvider>,
+    )
+    expect(html).toContain('data-mode="light"')
+  })
+})

--- a/src/providers/ThemeProvider/ThemeProvider.stories.tsx
+++ b/src/providers/ThemeProvider/ThemeProvider.stories.tsx
@@ -1,0 +1,242 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { useState } from 'react'
+import { Badge } from '../../components/lv1/Badge'
+import { Button } from '../../components/lv1/Button'
+import { Text } from '../../components/lv1/Text'
+import { ThemeProvider } from './ThemeProvider'
+import type { SpecialThemeId, ThemeModeSetting } from './theme-context'
+import { useTheme } from './useTheme'
+
+const meta: Meta<typeof ThemeProvider> = {
+  title: 'Providers/ThemeProvider',
+  component: ThemeProvider,
+  parameters: {
+    layout: 'centered',
+    // The Storybook `preview.tsx` decorator also writes to `<html>`.
+    // Provider stories take precedence — they're documenting the same
+    // mutation surface. The `disableGlobalThemeDecorator` parameter is
+    // read by the decorator (added in preview.tsx) and short-circuits
+    // its <html> mutation when true.
+    disableGlobalThemeDecorator: true,
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    defaultMode: {
+      description: 'Initial color-mode setting.',
+      control: 'select',
+      options: ['light', 'dark', 'system'],
+      table: {
+        type: { summary: '"light" | "dark" | "system"' },
+        defaultValue: { summary: 'system' },
+      },
+    },
+    defaultSpecial: {
+      description: 'Initial Special theme. "auto-seasonal" resolves the current date\'s season.',
+      control: 'select',
+      options: [
+        null,
+        'auto-seasonal',
+        'season--spring-early',
+        'season--spring-late',
+        'season--summer-early',
+        'season--summer-peak',
+        'season--autumn-early',
+        'season--autumn-late',
+        'season--winter-early',
+        'season--winter-deep',
+      ],
+      table: {
+        type: { summary: 'SpecialThemeId | "auto-seasonal" | null' },
+        defaultValue: { summary: 'null' },
+      },
+    },
+    storageKey: {
+      description: 'localStorage key. Pass null to disable persistence.',
+      control: 'text',
+      table: {
+        type: { summary: 'string | null' },
+        defaultValue: { summary: 'schatten-theme' },
+      },
+    },
+    disableTransitionOnChange: {
+      description: 'Suppress CSS transitions during a mode/special change.',
+      control: 'boolean',
+      table: { defaultValue: { summary: 'false' } },
+    },
+  },
+}
+
+export default meta
+
+type Story = StoryObj<typeof ThemeProvider>
+
+function ThemePanel() {
+  const { mode, modeSetting, special, setMode, setSpecial, isHydrated } = useTheme()
+  const modeOptions: ThemeModeSetting[] = ['light', 'dark', 'system']
+  const specialOptions: (SpecialThemeId | null)[] = [
+    null,
+    'season--spring-early',
+    'season--spring-late',
+    'season--summer-early',
+    'season--summer-peak',
+    'season--autumn-early',
+    'season--autumn-late',
+    'season--winter-early',
+    'season--winter-deep',
+  ]
+  return (
+    <div className="flex flex-col gap-4 p-6 rounded-lg border border-border bg-surface min-w-[420px]">
+      <div className="flex flex-col gap-1">
+        <Text variant="label">State</Text>
+        <div className="flex flex-wrap gap-2">
+          <Badge>mode: {mode}</Badge>
+          <Badge>setting: {modeSetting}</Badge>
+          <Badge>special: {special ?? 'none'}</Badge>
+          <Badge variant={isHydrated ? 'success' : 'warning'}>
+            hydrated: {isHydrated ? 'yes' : 'no'}
+          </Badge>
+        </div>
+      </div>
+
+      <div className="flex flex-col gap-1">
+        <Text variant="label">Mode</Text>
+        <div className="flex gap-2">
+          {modeOptions.map((m) => (
+            <Button
+              key={m}
+              variant={modeSetting === m ? 'primary' : 'secondary'}
+              size="sm"
+              onClick={() => setMode(m)}
+            >
+              {m}
+            </Button>
+          ))}
+        </div>
+      </div>
+
+      <div className="flex flex-col gap-1">
+        <Text variant="label">Special</Text>
+        <div className="flex flex-wrap gap-2">
+          {specialOptions.map((s) => (
+            <Button
+              key={s ?? 'none'}
+              variant={special === s ? 'primary' : 'secondary'}
+              size="sm"
+              onClick={() => setSpecial(s)}
+            >
+              {s ?? 'none'}
+            </Button>
+          ))}
+        </div>
+      </div>
+
+      <div className="flex flex-col gap-1">
+        <Text variant="label">Theme scale preview</Text>
+        <div className="flex gap-1">
+          {[50, 100, 200, 300, 400, 500, 600, 700, 800, 900, 950].map((shade) => (
+            <div
+              key={shade}
+              className="size-8 rounded border border-border"
+              style={{ backgroundColor: `var(--color-theme-${shade})` }}
+              title={`theme-${shade}`}
+            />
+          ))}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export const Playground: Story = {
+  args: {
+    defaultMode: 'system',
+    defaultSpecial: null,
+    storageKey: 'schatten-theme-storybook',
+    disableTransitionOnChange: false,
+  },
+  render: (args) => (
+    <ThemeProvider {...args}>
+      <ThemePanel />
+    </ThemeProvider>
+  ),
+}
+
+export const WithControls: Story = {
+  name: 'With Controls',
+  render: () => (
+    <ThemeProvider defaultMode="light" storageKey="schatten-theme-storybook-controls">
+      <ThemePanel />
+    </ThemeProvider>
+  ),
+}
+
+export const SystemModeFollows: Story = {
+  name: 'System Mode Follows',
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'When `defaultMode="system"`, the Provider subscribes to `matchMedia("(prefers-color-scheme: dark)")`. Toggle your OS dark mode setting while this story is open — the Mode chip should follow.',
+      },
+    },
+  },
+  render: () => (
+    <ThemeProvider defaultMode="system" storageKey={null}>
+      <ThemePanel />
+    </ThemeProvider>
+  ),
+}
+
+export const AutoSeasonal: Story = {
+  name: 'Auto Seasonal',
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'When `defaultSpecial="auto-seasonal"`, the current date is mapped to a seasonal palette via `getCurrentSeason()`.',
+      },
+    },
+  },
+  render: () => (
+    <ThemeProvider defaultSpecial="auto-seasonal" storageKey={null}>
+      <ThemePanel />
+    </ThemeProvider>
+  ),
+}
+
+/**
+ * Demonstrates that `useTheme()` updates do NOT trigger Schatten lv1
+ * components to re-render in JSX — they re-paint via CSS cascade only.
+ * Use the `setMode` buttons; the static Button / Badge below redraws
+ * with the new tokens with no React reconciliation.
+ */
+export const PaintWithoutReactReRender: Story = {
+  name: 'Paint Without Re-Render',
+  render: () => {
+    function Inner() {
+      const [counter] = useState(() => Math.floor(Math.random() * 10000))
+      return (
+        <div className="flex flex-col gap-4 p-6 rounded-lg border border-border bg-surface">
+          <Text>
+            Inner component mounted with random id <strong>{counter}</strong>. Switch theme above —
+            this number does NOT change, proving the JSX subtree did not re-render.
+          </Text>
+          <div className="flex gap-2">
+            <Button variant="primary">Primary</Button>
+            <Button variant="secondary">Secondary</Button>
+            <Badge variant="success">Success</Badge>
+            <Badge variant="warning">Warning</Badge>
+          </div>
+        </div>
+      )
+    }
+    return (
+      <ThemeProvider defaultMode="light" storageKey={null}>
+        <div className="flex flex-col gap-4">
+          <ThemePanel />
+          <Inner />
+        </div>
+      </ThemeProvider>
+    )
+  },
+}

--- a/src/providers/ThemeProvider/ThemeProvider.test.tsx
+++ b/src/providers/ThemeProvider/ThemeProvider.test.tsx
@@ -389,6 +389,167 @@ describe('ThemeProvider', () => {
     })
   })
 
+  describe('DOM-as-source-of-truth (MutationObserver sync)', () => {
+    // MutationObserver fires asynchronously via microtask. `act` flushes
+    // microtasks so React state lands before assertions.
+
+    it('updates mode when an external script adds the .dark class on <html>', async () => {
+      render(
+        <ThemeProvider defaultMode="light">
+          <Consumer />
+        </ThemeProvider>,
+      )
+      expect(screen.getByTestId('mode')).toHaveTextContent('light')
+
+      await act(async () => {
+        document.documentElement.classList.add('dark')
+      })
+
+      expect(screen.getByTestId('mode')).toHaveTextContent('dark')
+    })
+
+    it('updates mode when an external script removes the .dark class', async () => {
+      render(
+        <ThemeProvider defaultMode="dark">
+          <Consumer />
+        </ThemeProvider>,
+      )
+      expect(screen.getByTestId('mode')).toHaveTextContent('dark')
+
+      await act(async () => {
+        document.documentElement.classList.remove('dark')
+      })
+
+      expect(screen.getByTestId('mode')).toHaveTextContent('light')
+    })
+
+    it('updates special when an external script sets data-theme', async () => {
+      render(
+        <ThemeProvider>
+          <Consumer />
+        </ThemeProvider>,
+      )
+      expect(screen.getByTestId('special')).toHaveTextContent('null')
+
+      await act(async () => {
+        document.documentElement.setAttribute('data-theme', 'season--autumn-late')
+      })
+
+      expect(screen.getByTestId('special')).toHaveTextContent('season--autumn-late')
+    })
+
+    it('updates special to null when an external script removes data-theme', async () => {
+      render(
+        <ThemeProvider defaultSpecial="season--summer-peak">
+          <Consumer />
+        </ThemeProvider>,
+      )
+      expect(screen.getByTestId('special')).toHaveTextContent('season--summer-peak')
+
+      await act(async () => {
+        document.documentElement.removeAttribute('data-theme')
+      })
+
+      expect(screen.getByTestId('special')).toHaveTextContent('null')
+    })
+
+    it('rejects unknown data-theme values (stays null)', async () => {
+      render(
+        <ThemeProvider>
+          <Consumer />
+        </ThemeProvider>,
+      )
+
+      await act(async () => {
+        document.documentElement.setAttribute('data-theme', 'nonsense--xyz')
+      })
+
+      expect(screen.getByTestId('special')).toHaveTextContent('null')
+    })
+
+    it('syncs mode across two ThemeProvider instances in the same page (Astro Islands)', async () => {
+      function IslandA() {
+        const { mode, setMode } = useTheme()
+        return (
+          <>
+            <span data-testid="A-mode">{mode}</span>
+            <button type="button" onClick={() => setMode('dark')}>
+              A-set-dark
+            </button>
+          </>
+        )
+      }
+
+      function IslandB() {
+        const { mode } = useTheme()
+        return <span data-testid="B-mode">{mode}</span>
+      }
+
+      const user = userEvent.setup()
+      render(
+        <>
+          <div>
+            <ThemeProvider defaultMode="light" storageKey={null}>
+              <IslandA />
+            </ThemeProvider>
+          </div>
+          <div>
+            <ThemeProvider defaultMode="light" storageKey={null}>
+              <IslandB />
+            </ThemeProvider>
+          </div>
+        </>,
+      )
+
+      expect(screen.getByTestId('A-mode')).toHaveTextContent('light')
+      expect(screen.getByTestId('B-mode')).toHaveTextContent('light')
+
+      // A clicks set-dark — DOM mutates — B's MutationObserver should sync.
+      await user.click(screen.getByRole('button', { name: 'A-set-dark' }))
+
+      expect(screen.getByTestId('A-mode')).toHaveTextContent('dark')
+      expect(screen.getByTestId('B-mode')).toHaveTextContent('dark')
+    })
+
+    it('syncs special across two ThemeProvider instances in the same page', async () => {
+      function IslandA() {
+        const { setSpecial } = useTheme()
+        return (
+          <button type="button" onClick={() => setSpecial('season--spring-late')}>
+            A-set-spring
+          </button>
+        )
+      }
+
+      function IslandB() {
+        const { special } = useTheme()
+        return <span data-testid="B-special">{special ?? 'null'}</span>
+      }
+
+      const user = userEvent.setup()
+      render(
+        <>
+          <div>
+            <ThemeProvider storageKey={null}>
+              <IslandA />
+            </ThemeProvider>
+          </div>
+          <div>
+            <ThemeProvider storageKey={null}>
+              <IslandB />
+            </ThemeProvider>
+          </div>
+        </>,
+      )
+
+      expect(screen.getByTestId('B-special')).toHaveTextContent('null')
+
+      await user.click(screen.getByRole('button', { name: 'A-set-spring' }))
+
+      expect(screen.getByTestId('B-special')).toHaveTextContent('season--spring-late')
+    })
+  })
+
   describe('disableTransitionOnChange', () => {
     it('injects and removes a transition-blocking style tag on mode change', async () => {
       const user = userEvent.setup()

--- a/src/providers/ThemeProvider/ThemeProvider.test.tsx
+++ b/src/providers/ThemeProvider/ThemeProvider.test.tsx
@@ -1,0 +1,431 @@
+import { act, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { ThemeProvider } from './ThemeProvider'
+import type { ThemeContextValue } from './theme-context'
+import { useTheme } from './useTheme'
+
+const STORAGE_KEY = 'schatten-theme'
+
+/** Typed test consumer — renders all observable state to data-testid spans. */
+function Consumer({ onState }: { onState?: (state: ThemeContextValue) => void }) {
+  const state = useTheme()
+  onState?.(state)
+  return (
+    <>
+      <span data-testid="mode">{state.mode}</span>
+      <span data-testid="modeSetting">{state.modeSetting}</span>
+      <span data-testid="special">{state.special ?? 'null'}</span>
+      <span data-testid="isHydrated">{state.isHydrated ? 'yes' : 'no'}</span>
+      <button type="button" onClick={() => state.setMode('dark')}>
+        set-dark
+      </button>
+      <button type="button" onClick={() => state.setMode('light')}>
+        set-light
+      </button>
+      <button type="button" onClick={() => state.setMode('system')}>
+        set-system
+      </button>
+      <button type="button" onClick={() => state.setSpecial('season--spring-late')}>
+        set-spring-late
+      </button>
+      <button type="button" onClick={() => state.setSpecial(null)}>
+        clear-special
+      </button>
+    </>
+  )
+}
+
+/** Build a controllable matchMedia mock that can fire change events. */
+function installMatchMediaMock(initialDark: boolean) {
+  type Listener = (event: MediaQueryListEvent) => void
+  const listeners = new Set<Listener>()
+  let matches = initialDark
+  const mq = {
+    get matches() {
+      return matches
+    },
+    media: '(prefers-color-scheme: dark)',
+    onchange: null,
+    addEventListener: (_: 'change', l: Listener) => {
+      listeners.add(l)
+    },
+    removeEventListener: (_: 'change', l: Listener) => {
+      listeners.delete(l)
+    },
+    addListener: (l: Listener) => listeners.add(l),
+    removeListener: (l: Listener) => listeners.delete(l),
+    dispatchEvent: () => false,
+  }
+  vi.stubGlobal('matchMedia', vi.fn().mockReturnValue(mq))
+  // Also expose on `window` directly because Provider reads
+  // `window.matchMedia`.
+  Object.defineProperty(window, 'matchMedia', {
+    configurable: true,
+    writable: true,
+    value: vi.fn().mockReturnValue(mq),
+  })
+  return {
+    fire(newMatches: boolean) {
+      matches = newMatches
+      const event = { matches: newMatches, media: mq.media } as MediaQueryListEvent
+      for (const listener of listeners) listener(event)
+    },
+  }
+}
+
+beforeEach(() => {
+  // Clean DOM state between tests.
+  document.documentElement.classList.remove('dark', 'light')
+  document.documentElement.removeAttribute('data-theme')
+  localStorage.clear()
+  // Default matchMedia: OS in light mode.
+  installMatchMediaMock(false)
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  document.documentElement.classList.remove('dark', 'light')
+  document.documentElement.removeAttribute('data-theme')
+})
+
+describe('ThemeProvider', () => {
+  describe('defaultMode', () => {
+    it('initializes to light when defaultMode="light"', () => {
+      render(
+        <ThemeProvider defaultMode="light">
+          <Consumer />
+        </ThemeProvider>,
+      )
+      expect(screen.getByTestId('mode')).toHaveTextContent('light')
+      expect(screen.getByTestId('modeSetting')).toHaveTextContent('light')
+      expect(document.documentElement.classList.contains('dark')).toBe(false)
+    })
+
+    it('initializes to dark when defaultMode="dark"', () => {
+      render(
+        <ThemeProvider defaultMode="dark">
+          <Consumer />
+        </ThemeProvider>,
+      )
+      expect(screen.getByTestId('mode')).toHaveTextContent('dark')
+      expect(screen.getByTestId('modeSetting')).toHaveTextContent('dark')
+      expect(document.documentElement.classList.contains('dark')).toBe(true)
+    })
+
+    it('follows OS preference when defaultMode="system" and OS is dark', () => {
+      installMatchMediaMock(true)
+      render(
+        <ThemeProvider defaultMode="system">
+          <Consumer />
+        </ThemeProvider>,
+      )
+      expect(screen.getByTestId('mode')).toHaveTextContent('dark')
+      expect(screen.getByTestId('modeSetting')).toHaveTextContent('system')
+      expect(document.documentElement.classList.contains('dark')).toBe(true)
+    })
+
+    it('defaults to system when defaultMode is omitted', () => {
+      render(
+        <ThemeProvider>
+          <Consumer />
+        </ThemeProvider>,
+      )
+      expect(screen.getByTestId('modeSetting')).toHaveTextContent('system')
+    })
+  })
+
+  describe('setMode', () => {
+    it('toggles the .dark class on <html>', async () => {
+      const user = userEvent.setup()
+      render(
+        <ThemeProvider defaultMode="light">
+          <Consumer />
+        </ThemeProvider>,
+      )
+      await user.click(screen.getByRole('button', { name: 'set-dark' }))
+      expect(document.documentElement.classList.contains('dark')).toBe(true)
+      await user.click(screen.getByRole('button', { name: 'set-light' }))
+      expect(document.documentElement.classList.contains('dark')).toBe(false)
+    })
+
+    it('does not touch a .light class on <html>', async () => {
+      const user = userEvent.setup()
+      render(
+        <ThemeProvider defaultMode="light">
+          <Consumer />
+        </ThemeProvider>,
+      )
+      await user.click(screen.getByRole('button', { name: 'set-dark' }))
+      expect(document.documentElement.classList.contains('light')).toBe(false)
+      await user.click(screen.getByRole('button', { name: 'set-light' }))
+      expect(document.documentElement.classList.contains('light')).toBe(false)
+    })
+
+    it('persists the new mode to localStorage', async () => {
+      const user = userEvent.setup()
+      render(
+        <ThemeProvider defaultMode="light">
+          <Consumer />
+        </ThemeProvider>,
+      )
+      await user.click(screen.getByRole('button', { name: 'set-dark' }))
+      const stored = JSON.parse(localStorage.getItem(STORAGE_KEY) ?? '{}')
+      expect(stored.mode).toBe('dark')
+    })
+
+    it('returns to OS tracking when setMode("system") is called', async () => {
+      const user = userEvent.setup()
+      const mm = installMatchMediaMock(false)
+      render(
+        <ThemeProvider defaultMode="dark">
+          <Consumer />
+        </ThemeProvider>,
+      )
+      await user.click(screen.getByRole('button', { name: 'set-system' }))
+      expect(screen.getByTestId('modeSetting')).toHaveTextContent('system')
+      expect(screen.getByTestId('mode')).toHaveTextContent('light')
+
+      // OS flips to dark — provider follows
+      act(() => mm.fire(true))
+      expect(screen.getByTestId('mode')).toHaveTextContent('dark')
+    })
+  })
+
+  describe('system mode tracking', () => {
+    it('updates mode when prefers-color-scheme media query changes', () => {
+      const mm = installMatchMediaMock(false)
+      render(
+        <ThemeProvider defaultMode="system">
+          <Consumer />
+        </ThemeProvider>,
+      )
+      expect(screen.getByTestId('mode')).toHaveTextContent('light')
+
+      act(() => mm.fire(true))
+      expect(screen.getByTestId('mode')).toHaveTextContent('dark')
+      expect(document.documentElement.classList.contains('dark')).toBe(true)
+
+      act(() => mm.fire(false))
+      expect(screen.getByTestId('mode')).toHaveTextContent('light')
+      expect(document.documentElement.classList.contains('dark')).toBe(false)
+    })
+
+    it('stops following OS once the user picks an explicit mode', async () => {
+      const user = userEvent.setup()
+      const mm = installMatchMediaMock(false)
+      render(
+        <ThemeProvider defaultMode="system">
+          <Consumer />
+        </ThemeProvider>,
+      )
+      await user.click(screen.getByRole('button', { name: 'set-light' }))
+      act(() => mm.fire(true))
+      // Still light — system events no longer drive mode.
+      expect(screen.getByTestId('mode')).toHaveTextContent('light')
+    })
+  })
+
+  describe('defaultSpecial', () => {
+    it('sets data-theme when defaultSpecial is an explicit id', () => {
+      render(
+        <ThemeProvider defaultSpecial="season--spring-late">
+          <Consumer />
+        </ThemeProvider>,
+      )
+      expect(screen.getByTestId('special')).toHaveTextContent('season--spring-late')
+      expect(document.documentElement.getAttribute('data-theme')).toBe('season--spring-late')
+    })
+
+    it('resolves to the current season when defaultSpecial="auto-seasonal"', () => {
+      // Pick a date inside summer-peak (Jun 21 – Aug 6) so the test
+      // is deterministic regardless of when CI runs.
+      vi.useFakeTimers()
+      vi.setSystemTime(new Date('2026-07-15T12:00:00Z'))
+      try {
+        render(
+          <ThemeProvider defaultSpecial="auto-seasonal">
+            <Consumer />
+          </ThemeProvider>,
+        )
+        expect(screen.getByTestId('special')).toHaveTextContent('season--summer-peak')
+        expect(document.documentElement.getAttribute('data-theme')).toBe('season--summer-peak')
+      } finally {
+        vi.useRealTimers()
+      }
+    })
+
+    it('does not set data-theme when defaultSpecial is null', () => {
+      render(
+        <ThemeProvider defaultSpecial={null}>
+          <Consumer />
+        </ThemeProvider>,
+      )
+      expect(screen.getByTestId('special')).toHaveTextContent('null')
+      expect(document.documentElement.hasAttribute('data-theme')).toBe(false)
+    })
+  })
+
+  describe('setSpecial', () => {
+    it('writes data-theme on the html element', async () => {
+      const user = userEvent.setup()
+      render(
+        <ThemeProvider>
+          <Consumer />
+        </ThemeProvider>,
+      )
+      await user.click(screen.getByRole('button', { name: 'set-spring-late' }))
+      expect(document.documentElement.getAttribute('data-theme')).toBe('season--spring-late')
+    })
+
+    it('removes data-theme when called with null', async () => {
+      const user = userEvent.setup()
+      render(
+        <ThemeProvider defaultSpecial="season--spring-late">
+          <Consumer />
+        </ThemeProvider>,
+      )
+      await user.click(screen.getByRole('button', { name: 'clear-special' }))
+      expect(document.documentElement.hasAttribute('data-theme')).toBe(false)
+    })
+
+    it('persists the new special to localStorage', async () => {
+      const user = userEvent.setup()
+      render(
+        <ThemeProvider>
+          <Consumer />
+        </ThemeProvider>,
+      )
+      await user.click(screen.getByRole('button', { name: 'set-spring-late' }))
+      const stored = JSON.parse(localStorage.getItem(STORAGE_KEY) ?? '{}')
+      expect(stored.special).toBe('season--spring-late')
+    })
+  })
+
+  describe('localStorage', () => {
+    it('restores mode and special from storage on mount', () => {
+      localStorage.setItem(
+        STORAGE_KEY,
+        JSON.stringify({ mode: 'dark', special: 'season--winter-deep' }),
+      )
+      render(
+        <ThemeProvider defaultMode="light">
+          <Consumer />
+        </ThemeProvider>,
+      )
+      expect(screen.getByTestId('mode')).toHaveTextContent('dark')
+      expect(screen.getByTestId('special')).toHaveTextContent('season--winter-deep')
+      expect(document.documentElement.classList.contains('dark')).toBe(true)
+      expect(document.documentElement.getAttribute('data-theme')).toBe('season--winter-deep')
+    })
+
+    it('ignores corrupt JSON in storage', () => {
+      localStorage.setItem(STORAGE_KEY, '{not json')
+      render(
+        <ThemeProvider defaultMode="dark">
+          <Consumer />
+        </ThemeProvider>,
+      )
+      // Falls through to defaultMode.
+      expect(screen.getByTestId('mode')).toHaveTextContent('dark')
+    })
+
+    it('ignores unknown Special ids in storage', () => {
+      localStorage.setItem(
+        STORAGE_KEY,
+        JSON.stringify({ mode: 'light', special: 'nonsense--unknown' }),
+      )
+      render(
+        <ThemeProvider>
+          <Consumer />
+        </ThemeProvider>,
+      )
+      expect(screen.getByTestId('special')).toHaveTextContent('null')
+    })
+
+    it('does not write storage when storageKey is null', async () => {
+      const user = userEvent.setup()
+      render(
+        <ThemeProvider defaultMode="light" storageKey={null}>
+          <Consumer />
+        </ThemeProvider>,
+      )
+      await user.click(screen.getByRole('button', { name: 'set-dark' }))
+      expect(localStorage.getItem(STORAGE_KEY)).toBeNull()
+    })
+
+    it('syncs across tabs via the storage event', () => {
+      render(
+        <ThemeProvider defaultMode="light">
+          <Consumer />
+        </ThemeProvider>,
+      )
+      expect(screen.getByTestId('mode')).toHaveTextContent('light')
+
+      // Simulate another tab writing dark mode.
+      localStorage.setItem(STORAGE_KEY, JSON.stringify({ mode: 'dark', special: null }))
+      act(() => {
+        window.dispatchEvent(
+          new StorageEvent('storage', {
+            key: STORAGE_KEY,
+            newValue: JSON.stringify({ mode: 'dark', special: null }),
+            oldValue: null,
+            storageArea: localStorage,
+          }),
+        )
+      })
+
+      expect(screen.getByTestId('mode')).toHaveTextContent('dark')
+      expect(document.documentElement.classList.contains('dark')).toBe(true)
+    })
+  })
+
+  describe('useTheme outside provider', () => {
+    it('throws a descriptive error', () => {
+      // Suppress React's own error boundary noise.
+      const spy = vi.spyOn(console, 'error').mockImplementation(() => {})
+      expect(() => render(<Consumer />)).toThrow(/useTheme must be used within a <ThemeProvider>/)
+      spy.mockRestore()
+    })
+  })
+
+  describe('disableTransitionOnChange', () => {
+    it('injects and removes a transition-blocking style tag on mode change', async () => {
+      const user = userEvent.setup()
+      render(
+        <ThemeProvider defaultMode="light" disableTransitionOnChange>
+          <Consumer />
+        </ThemeProvider>,
+      )
+      await user.click(screen.getByRole('button', { name: 'set-dark' }))
+      // Style tag is inserted synchronously; cleanup is on the next frame.
+      const style = document.getElementById('schatten-theme-transition-suppressor')
+      expect(style).not.toBeNull()
+      // Wait one frame
+      await new Promise((resolve) => requestAnimationFrame(() => resolve(null)))
+      expect(document.getElementById('schatten-theme-transition-suppressor')).toBeNull()
+    })
+
+    it('does not inject the style tag when disableTransitionOnChange is false', async () => {
+      const user = userEvent.setup()
+      render(
+        <ThemeProvider defaultMode="light">
+          <Consumer />
+        </ThemeProvider>,
+      )
+      await user.click(screen.getByRole('button', { name: 'set-dark' }))
+      expect(document.getElementById('schatten-theme-transition-suppressor')).toBeNull()
+    })
+  })
+
+  describe('isHydrated', () => {
+    it('becomes true after mount', () => {
+      render(
+        <ThemeProvider>
+          <Consumer />
+        </ThemeProvider>,
+      )
+      expect(screen.getByTestId('isHydrated')).toHaveTextContent('yes')
+    })
+  })
+})

--- a/src/providers/ThemeProvider/ThemeProvider.tsx
+++ b/src/providers/ThemeProvider/ThemeProvider.tsx
@@ -1,0 +1,307 @@
+import { type ReactNode, useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { getCurrentSeason, SEASONAL_THEME_METADATA } from '../../themes/seasonal'
+import {
+  type SpecialThemeId,
+  ThemeContext,
+  type ThemeContextValue,
+  type ThemeMode,
+  type ThemeModeSetting,
+  type ThemeProviderInitialSpecial,
+} from './theme-context'
+import { readStoredTheme, type StoredTheme, writeStoredTheme } from './theme-storage'
+
+export interface ThemeProviderProps {
+  /**
+   * Initial color-mode setting.
+   * - `'light'` / `'dark'` — explicit.
+   * - `'system'` — follow `prefers-color-scheme` (subscribed at runtime).
+   * @default 'system'
+   */
+  defaultMode?: ThemeModeSetting
+  /**
+   * Initial Special theme.
+   * - `null` / `undefined` — no Special applied (default).
+   * - `'auto-seasonal'` — resolve via `getCurrentSeason()` at mount.
+   * - A `SpecialThemeId` — pin to that Special.
+   * @default null
+   */
+  defaultSpecial?: ThemeProviderInitialSpecial
+  /**
+   * `localStorage` key used to persist mode + special. Pass `null` to
+   * disable persistence (useful in tests and embedded multi-app
+   * scenarios).
+   * @default 'schatten-theme'
+   */
+  storageKey?: string | null
+  /**
+   * Temporarily strip CSS transitions while applying a mode/special
+   * change, so the swap is instantaneous instead of fading through
+   * intermediate colors.
+   * @default false
+   */
+  disableTransitionOnChange?: boolean
+  children: ReactNode
+}
+
+const DEFAULT_STORAGE_KEY = 'schatten-theme'
+const DARK_MODE_MEDIA_QUERY = '(prefers-color-scheme: dark)'
+const TRANSITION_SUPPRESSOR_ID = 'schatten-theme-transition-suppressor'
+
+const VALID_SPECIAL_IDS: ReadonlySet<string> = new Set(Object.keys(SEASONAL_THEME_METADATA))
+
+function isValidSpecial(value: unknown): value is SpecialThemeId {
+  return typeof value === 'string' && VALID_SPECIAL_IDS.has(value)
+}
+
+function resolveInitialSpecial(
+  value: ThemeProviderInitialSpecial | undefined,
+): SpecialThemeId | null {
+  if (value === undefined || value === null) return null
+  if (value === 'auto-seasonal') {
+    return `season--${getCurrentSeason()}` as SpecialThemeId
+  }
+  return isValidSpecial(value) ? value : null
+}
+
+/**
+ * Read the OS `prefers-color-scheme` value. SSR-safe — returns
+ * `'light'` when `window` / `matchMedia` are unavailable.
+ */
+function readSystemMode(): ThemeMode {
+  if (typeof window === 'undefined') return 'light'
+  if (typeof window.matchMedia !== 'function') return 'light'
+  try {
+    return window.matchMedia(DARK_MODE_MEDIA_QUERY).matches ? 'dark' : 'light'
+  } catch {
+    return 'light'
+  }
+}
+
+/**
+ * Collapse a `ThemeModeSetting` to the resolved `'light' | 'dark'`.
+ * For `'system'`, reads the current OS preference.
+ */
+function resolveMode(setting: ThemeModeSetting): ThemeMode {
+  return setting === 'system' ? readSystemMode() : setting
+}
+
+/**
+ * Briefly inject a global `transition: none` rule, force reflow, then
+ * remove it on the next frame. Used by `disableTransitionOnChange` to
+ * make mode/special swaps feel instantaneous.
+ */
+function suppressTransitionsOnce(): void {
+  if (typeof document === 'undefined') return
+  if (document.getElementById(TRANSITION_SUPPRESSOR_ID)) return
+  const style = document.createElement('style')
+  style.id = TRANSITION_SUPPRESSOR_ID
+  style.appendChild(
+    document.createTextNode(
+      '*,*::before,*::after { transition: none !important; animation: none !important; }',
+    ),
+  )
+  document.head.appendChild(style)
+  // Force reflow so the no-transition style is committed before we
+  // remove it on the next frame.
+  void window.getComputedStyle(document.body).opacity
+  window.requestAnimationFrame(() => {
+    document.getElementById(TRANSITION_SUPPRESSOR_ID)?.remove()
+  })
+}
+
+/**
+ * Apply `mode` and `special` to `<html>`. Idempotent — safe under
+ * React 19 StrictMode's double-invoke and across HMR.
+ */
+function applyToDocument(mode: ThemeMode, special: SpecialThemeId | null): void {
+  if (typeof document === 'undefined') return
+  const root = document.documentElement
+  // Mode: toggle `.dark` only (per theme-architecture.md — `.light` is
+  // not used; absence of `.dark` IS the light state).
+  if (mode === 'dark') {
+    root.classList.add('dark')
+  } else {
+    root.classList.remove('dark')
+  }
+  // Special: write or remove `data-theme`.
+  if (special === null) {
+    root.removeAttribute('data-theme')
+  } else {
+    root.setAttribute('data-theme', special)
+  }
+}
+
+/**
+ * Declarative manager for the Mode (light/dark) and Special
+ * (`data-theme`) axes. Wrap your app root once and consume state with
+ * `useTheme()`.
+ *
+ * The provider is client-only — Server Component imports work because
+ * the package banner injects `'use client'` at build time.
+ *
+ * @example
+ * ```tsx
+ * // app/layout.tsx
+ * import { ThemeProvider } from '@yasmro/schatten/providers'
+ *
+ * export default function RootLayout({ children }) {
+ *   return (
+ *     <html>
+ *       <body>
+ *         <ThemeProvider defaultMode="system" defaultSpecial="auto-seasonal">
+ *           {children}
+ *         </ThemeProvider>
+ *       </body>
+ *     </html>
+ *   )
+ * }
+ * ```
+ */
+export function ThemeProvider({
+  defaultMode = 'system',
+  defaultSpecial = null,
+  storageKey = DEFAULT_STORAGE_KEY,
+  disableTransitionOnChange = false,
+  children,
+}: ThemeProviderProps) {
+  // SSR / first-paint values:
+  //   modeSetting falls back to `defaultMode`; the resolved `mode` is
+  //   `'light'` until the client effect hydrates from localStorage /
+  //   matchMedia. Issue #129's inline snippet is responsible for setting
+  //   the DOM to the real value before first paint — the React state
+  //   below converges on first effect.
+  const [modeSetting, setModeSettingState] = useState<ThemeModeSetting>(defaultMode)
+  const [mode, setModeState] = useState<ThemeMode>(() =>
+    defaultMode === 'system' ? 'light' : defaultMode,
+  )
+  const [special, setSpecialState] = useState<SpecialThemeId | null>(() =>
+    resolveInitialSpecial(defaultSpecial),
+  )
+  const [isHydrated, setIsHydrated] = useState(false)
+
+  // Persistence is disabled when `storageKey === null` (test / multi-app).
+  const persistKey: string | null = storageKey
+  const disableTransitionRef = useRef(disableTransitionOnChange)
+  disableTransitionRef.current = disableTransitionOnChange
+
+  // Hydration effect — runs once on mount.
+  //
+  // Order:
+  //   1. Restore persisted setting (if any) — overrides the SSR default.
+  //   2. Resolve `'system'` against the actual `matchMedia` value.
+  //   3. Apply to the DOM.
+  //   4. Mark `isHydrated`.
+  //
+  // matchMedia / storage event subscriptions are attached separately
+  // below so they can react to live changes after hydration. The initial
+  // `defaultMode` / `defaultSpecial` / `persistKey` are intentionally
+  // captured as initial values here — re-running the hydration effect
+  // when those props change would clobber the user's current selection.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: mount-only by design
+  useEffect(() => {
+    let nextSetting: ThemeModeSetting = defaultMode
+    let nextSpecial: SpecialThemeId | null = resolveInitialSpecial(defaultSpecial)
+
+    if (persistKey !== null) {
+      const stored = readStoredTheme(persistKey)
+      if (stored?.mode !== undefined) {
+        nextSetting = stored.mode
+      }
+      if (stored?.special !== undefined) {
+        // `null` (explicit clear) is preserved; unknown ids are
+        // discarded by readStoredTheme already.
+        if (stored.special === null) {
+          nextSpecial = null
+        } else if (isValidSpecial(stored.special)) {
+          nextSpecial = stored.special
+        }
+      }
+    }
+
+    const nextMode = resolveMode(nextSetting)
+    setModeSettingState(nextSetting)
+    setModeState(nextMode)
+    setSpecialState(nextSpecial)
+    applyToDocument(nextMode, nextSpecial)
+    setIsHydrated(true)
+  }, [])
+
+  // matchMedia subscription — only active while `modeSetting === 'system'`.
+  useEffect(() => {
+    if (modeSetting !== 'system') return
+    if (typeof window === 'undefined') return
+    if (typeof window.matchMedia !== 'function') return
+
+    const mq = window.matchMedia(DARK_MODE_MEDIA_QUERY)
+    const handler = (event: MediaQueryListEvent) => {
+      const resolved: ThemeMode = event.matches ? 'dark' : 'light'
+      if (disableTransitionRef.current) suppressTransitionsOnce()
+      setModeState(resolved)
+      applyToDocument(resolved, special)
+    }
+    mq.addEventListener('change', handler)
+    return () => mq.removeEventListener('change', handler)
+  }, [modeSetting, special])
+
+  // Cross-tab sync — react to `storage` events on the configured key.
+  useEffect(() => {
+    if (persistKey === null) return
+    if (typeof window === 'undefined') return
+    const handler = (event: StorageEvent) => {
+      if (event.key !== persistKey) return
+      const stored = readStoredTheme(persistKey)
+      if (stored === null) return
+      if (stored.mode !== undefined) {
+        const resolved = resolveMode(stored.mode)
+        if (disableTransitionRef.current) suppressTransitionsOnce()
+        setModeSettingState(stored.mode)
+        setModeState(resolved)
+        applyToDocument(resolved, stored.special !== undefined ? stored.special : special)
+      }
+      if (stored.special !== undefined) {
+        setSpecialState(stored.special)
+        applyToDocument(stored.mode !== undefined ? resolveMode(stored.mode) : mode, stored.special)
+      }
+    }
+    window.addEventListener('storage', handler)
+    return () => window.removeEventListener('storage', handler)
+  }, [persistKey, mode, special])
+
+  const setMode = useCallback<ThemeContextValue['setMode']>(
+    (nextSetting) => {
+      const resolved = resolveMode(nextSetting)
+      if (disableTransitionRef.current) suppressTransitionsOnce()
+      setModeSettingState(nextSetting)
+      setModeState(resolved)
+      applyToDocument(resolved, special)
+      if (persistKey !== null) {
+        const next: StoredTheme = { mode: nextSetting, special }
+        writeStoredTheme(persistKey, next)
+      }
+    },
+    [persistKey, special],
+  )
+
+  const setSpecial = useCallback<ThemeContextValue['setSpecial']>(
+    (nextSpecial) => {
+      const normalized = nextSpecial === null || isValidSpecial(nextSpecial) ? nextSpecial : null
+      if (disableTransitionRef.current) suppressTransitionsOnce()
+      setSpecialState(normalized)
+      applyToDocument(mode, normalized)
+      if (persistKey !== null) {
+        const next: StoredTheme = { mode: modeSetting, special: normalized }
+        writeStoredTheme(persistKey, next)
+      }
+    },
+    [persistKey, mode, modeSetting],
+  )
+
+  const value = useMemo<ThemeContextValue>(
+    () => ({ mode, modeSetting, setMode, special, setSpecial, isHydrated }),
+    [mode, modeSetting, setMode, special, setSpecial, isHydrated],
+  )
+
+  return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>
+}
+
+ThemeProvider.displayName = 'ThemeProvider'

--- a/src/providers/ThemeProvider/ThemeProvider.tsx
+++ b/src/providers/ThemeProvider/ThemeProvider.tsx
@@ -233,6 +233,10 @@ export function ThemeProvider({
     if (typeof window.matchMedia !== 'function') return
 
     const mq = window.matchMedia(DARK_MODE_MEDIA_QUERY)
+    // Defensive: some test harnesses / polyfills make `matchMedia` itself
+    // exist but return `undefined`. Bail out rather than throwing —
+    // there's nothing to subscribe to in that case.
+    if (!mq || typeof mq.addEventListener !== 'function') return
     const handler = (event: MediaQueryListEvent) => {
       const resolved: ThemeMode = event.matches ? 'dark' : 'light'
       if (disableTransitionRef.current) suppressTransitionsOnce()
@@ -266,6 +270,48 @@ export function ThemeProvider({
     window.addEventListener('storage', handler)
     return () => window.removeEventListener('storage', handler)
   }, [persistKey, mode, special])
+
+  // DOM-as-source-of-truth sync — observe `<html>` for class / data-theme
+  // changes from ANY source and pull them back into React state.
+  //
+  // This is what makes multiple ThemeProvider instances in the same page
+  // (Astro Islands, micro-frontends, multiple React roots) stay
+  // consistent without an explicit message bus: when island A mutates
+  // <html>, island B's MutationObserver fires and reconciles its own
+  // `mode` / `special` state.
+  //
+  // The `storage` event only fires in *other* windows, so it does not
+  // cover same-page islands; MutationObserver does. The same path also
+  // catches external scripts that touch <html> directly (devtools,
+  // analytics SDKs, etc.) so the React tree never falls out of sync
+  // with the DOM.
+  //
+  // Note: `modeSetting` (the user-facing `'system'` / `'light'` /
+  // `'dark'` choice) is NOT derivable from the DOM and so is not
+  // synced here. That value remains local to each Provider instance.
+  // The recommended pattern is one switcher island per page.
+  useEffect(() => {
+    if (typeof document === 'undefined') return
+    if (typeof MutationObserver === 'undefined') return
+    const root = document.documentElement
+    const observer = new MutationObserver(() => {
+      const domDark = root.classList.contains('dark')
+      const domMode: ThemeMode = domDark ? 'dark' : 'light'
+      const domThemeAttr = root.getAttribute('data-theme')
+      const domSpecial: SpecialThemeId | null =
+        domThemeAttr !== null && isValidSpecial(domThemeAttr) ? domThemeAttr : null
+      // Use functional updates so a no-op (DOM matches state) avoids
+      // an unnecessary re-render — React bails out when the next state
+      // is referentially equal to the previous one.
+      setModeState((prev) => (prev === domMode ? prev : domMode))
+      setSpecialState((prev) => (prev === domSpecial ? prev : domSpecial))
+    })
+    observer.observe(root, {
+      attributes: true,
+      attributeFilter: ['class', 'data-theme'],
+    })
+    return () => observer.disconnect()
+  }, [])
 
   const setMode = useCallback<ThemeContextValue['setMode']>(
     (nextSetting) => {

--- a/src/providers/ThemeProvider/fouc-snippet.test.ts
+++ b/src/providers/ThemeProvider/fouc-snippet.test.ts
@@ -1,0 +1,125 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+// The exact snippet documented in README.md. Keeping it inline here
+// pins the README's behavior to the Provider's `localStorage` contract
+// — if these tests fail, the README snippet must be updated in lockstep.
+//
+// The string is intentionally identical character-for-character to the
+// minified form in README. If you adjust the snippet, copy the version
+// here to match.
+const THEME_INIT_SCRIPT = `(function(){try{var s=localStorage.getItem('schatten-theme');var t=s?JSON.parse(s):{};var m=t.mode||'system';var d=m==='dark'||(m==='system'&&window.matchMedia('(prefers-color-scheme: dark)').matches);if(d)document.documentElement.classList.add('dark');if(t.special)document.documentElement.setAttribute('data-theme',t.special)}catch(e){}})();`
+
+function runSnippet() {
+  // Evaluate in the current jsdom context so localStorage, document,
+  // and window references resolve to the real test globals.
+  new Function(THEME_INIT_SCRIPT)()
+}
+
+function installMatchMedia(matchesDark: boolean) {
+  Object.defineProperty(window, 'matchMedia', {
+    configurable: true,
+    writable: true,
+    value: (query: string) => ({
+      matches: matchesDark && query.includes('dark'),
+      media: query,
+      onchange: null,
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      addListener: () => {},
+      removeListener: () => {},
+      dispatchEvent: () => false,
+    }),
+  })
+}
+
+beforeEach(() => {
+  document.documentElement.classList.remove('dark')
+  document.documentElement.removeAttribute('data-theme')
+  localStorage.clear()
+  installMatchMedia(false)
+})
+
+afterEach(() => {
+  document.documentElement.classList.remove('dark')
+  document.documentElement.removeAttribute('data-theme')
+  vi.restoreAllMocks()
+})
+
+describe('README FOUC inline snippet (contract with #128 / #129)', () => {
+  it('does nothing when no storage and OS is light', () => {
+    runSnippet()
+    expect(document.documentElement.classList.contains('dark')).toBe(false)
+    expect(document.documentElement.hasAttribute('data-theme')).toBe(false)
+  })
+
+  it('adds .dark when OS prefers dark and no explicit setting is stored', () => {
+    installMatchMedia(true)
+    runSnippet()
+    expect(document.documentElement.classList.contains('dark')).toBe(true)
+  })
+
+  it('adds .dark when storage says mode=dark, regardless of OS', () => {
+    installMatchMedia(false)
+    localStorage.setItem('schatten-theme', JSON.stringify({ mode: 'dark', special: null }))
+    runSnippet()
+    expect(document.documentElement.classList.contains('dark')).toBe(true)
+  })
+
+  it('respects mode=light even when OS prefers dark', () => {
+    installMatchMedia(true)
+    localStorage.setItem('schatten-theme', JSON.stringify({ mode: 'light', special: null }))
+    runSnippet()
+    expect(document.documentElement.classList.contains('dark')).toBe(false)
+  })
+
+  it('writes data-theme when storage holds a Special id', () => {
+    localStorage.setItem(
+      'schatten-theme',
+      JSON.stringify({ mode: 'light', special: 'season--summer-peak' }),
+    )
+    runSnippet()
+    expect(document.documentElement.getAttribute('data-theme')).toBe('season--summer-peak')
+  })
+
+  it('applies mode + special together', () => {
+    localStorage.setItem(
+      'schatten-theme',
+      JSON.stringify({ mode: 'dark', special: 'season--winter-deep' }),
+    )
+    runSnippet()
+    expect(document.documentElement.classList.contains('dark')).toBe(true)
+    expect(document.documentElement.getAttribute('data-theme')).toBe('season--winter-deep')
+  })
+
+  it('silently ignores corrupt JSON', () => {
+    localStorage.setItem('schatten-theme', '{not json')
+    expect(() => runSnippet()).not.toThrow()
+    expect(document.documentElement.classList.contains('dark')).toBe(false)
+  })
+
+  it('treats missing localStorage as system (no throw)', () => {
+    // Simulate a hostile localStorage by making getItem throw.
+    const original = Storage.prototype.getItem
+    Storage.prototype.getItem = () => {
+      throw new Error('storage disabled')
+    }
+    try {
+      expect(() => runSnippet()).not.toThrow()
+      expect(document.documentElement.classList.contains('dark')).toBe(false)
+    } finally {
+      Storage.prototype.getItem = original
+    }
+  })
+
+  it('uses the `.special` field name (not the legacy `.season`)', () => {
+    // Anti-regression: the FOUC snippet must read the same field name the
+    // Provider writes. The pre-#128 draft of #129 used `.season`; that
+    // value should now be a no-op.
+    localStorage.setItem(
+      'schatten-theme',
+      JSON.stringify({ mode: 'light', season: 'season--spring-late' }),
+    )
+    runSnippet()
+    expect(document.documentElement.hasAttribute('data-theme')).toBe(false)
+  })
+})

--- a/src/providers/ThemeProvider/index.ts
+++ b/src/providers/ThemeProvider/index.ts
@@ -1,0 +1,9 @@
+export { ThemeProvider, type ThemeProviderProps } from './ThemeProvider'
+export type {
+  SpecialThemeId,
+  ThemeContextValue,
+  ThemeMode,
+  ThemeModeSetting,
+  ThemeProviderInitialSpecial,
+} from './theme-context'
+export { useTheme } from './useTheme'

--- a/src/providers/ThemeProvider/theme-context.ts
+++ b/src/providers/ThemeProvider/theme-context.ts
@@ -1,0 +1,48 @@
+import { createContext } from 'react'
+import type { SeasonalThemeId } from '../../themes/seasonal'
+
+/** Resolved color-mode value — never `'system'`. */
+export type ThemeMode = 'light' | 'dark'
+
+/** User-facing mode setting. `'system'` follows `prefers-color-scheme`. */
+export type ThemeModeSetting = ThemeMode | 'system'
+
+/**
+ * Identifier of any Special theme that may be applied via the
+ * `data-theme` attribute on `<html>`. Today this is narrowed to
+ * the shipped seasonal palettes; future Specials (brand, vendor,
+ * one-off) widen this union in a `minor` release.
+ */
+export type SpecialThemeId = SeasonalThemeId
+
+/**
+ * Accepted values for `<ThemeProvider defaultSpecial>`.
+ *
+ * - `'auto-seasonal'` — resolve via `getCurrentSeason()` at mount time
+ *   (the current date's seasonal palette).
+ * - `SpecialThemeId` — pin to an explicit seasonal palette.
+ * - `null` / `undefined` — no Special applied.
+ */
+export type ThemeProviderInitialSpecial = SpecialThemeId | 'auto-seasonal' | null
+
+export interface ThemeContextValue {
+  /** Resolved Mode (`'system'` already collapsed to `'light' | 'dark'`). */
+  mode: ThemeMode
+  /** Raw setting, including `'system'`. */
+  modeSetting: ThemeModeSetting
+  /** Update the mode setting. Pass `'system'` to follow OS preference. */
+  setMode: (mode: ThemeModeSetting) => void
+  /** Currently applied Special, or `null` when none is active. */
+  special: SpecialThemeId | null
+  /** Update the active Special. Pass `null` to clear. */
+  setSpecial: (special: SpecialThemeId | null) => void
+  /** `true` once the client-side effect has run and the DOM is in sync. */
+  readonly isHydrated: boolean
+}
+
+/**
+ * Internal context. Consumers should use the `useTheme` hook instead of
+ * reading this directly — the hook throws a descriptive error when used
+ * outside `<ThemeProvider>`.
+ */
+export const ThemeContext = createContext<ThemeContextValue | null>(null)

--- a/src/providers/ThemeProvider/theme-storage.ts
+++ b/src/providers/ThemeProvider/theme-storage.ts
@@ -1,0 +1,87 @@
+import type { SpecialThemeId, ThemeModeSetting } from './theme-context'
+
+/**
+ * Persisted shape stored under `storageKey` as a single JSON object.
+ *
+ * This shape is part of the contract with the FOUC inline script
+ * (issue #129). When fields change, the snippet must be updated
+ * in lockstep.
+ */
+export interface StoredTheme {
+  mode: ThemeModeSetting
+  special: SpecialThemeId | null
+}
+
+const VALID_MODE_SETTINGS: ReadonlySet<ThemeModeSetting> = new Set(['light', 'dark', 'system'])
+
+/**
+ * Whether the runtime can touch `window.localStorage` at all. Returns
+ * `false` on the server and when the host has explicitly disabled
+ * storage (e.g. Safari private mode in some versions).
+ */
+function canUseStorage(): boolean {
+  if (typeof window === 'undefined') return false
+  try {
+    return typeof window.localStorage !== 'undefined'
+  } catch {
+    // Some browsers throw on `window.localStorage` access in restricted
+    // contexts (cookies disabled / 3rd-party storage blocked).
+    return false
+  }
+}
+
+/**
+ * Read and validate a persisted theme. Returns `null` on missing,
+ * malformed JSON, or storage access errors — never throws.
+ *
+ * Unknown values are stripped from the returned partial so callers can
+ * safely spread it over their defaults.
+ */
+export function readStoredTheme(key: string): Partial<StoredTheme> | null {
+  if (!canUseStorage()) return null
+  try {
+    const raw = window.localStorage.getItem(key)
+    if (raw === null) return null
+    const parsed: unknown = JSON.parse(raw)
+    if (typeof parsed !== 'object' || parsed === null) return null
+    const out: Partial<StoredTheme> = {}
+    const candidate = parsed as Record<string, unknown>
+    if (
+      typeof candidate.mode === 'string' &&
+      VALID_MODE_SETTINGS.has(candidate.mode as ThemeModeSetting)
+    ) {
+      out.mode = candidate.mode as ThemeModeSetting
+    }
+    if (candidate.special === null) {
+      out.special = null
+    } else if (typeof candidate.special === 'string') {
+      // We don't have a runtime registry of every valid SpecialThemeId
+      // (the union is type-only). The validation surface is intentional:
+      // the Provider validates against the known set before applying.
+      out.special = candidate.special as SpecialThemeId
+    }
+    return out
+  } catch {
+    return null
+  }
+}
+
+/** Write the full theme state. Failures are silently ignored. */
+export function writeStoredTheme(key: string, value: StoredTheme): void {
+  if (!canUseStorage()) return
+  try {
+    window.localStorage.setItem(key, JSON.stringify(value))
+  } catch {
+    /* quota / disabled storage */
+  }
+}
+
+/** Remove any persisted theme. Failures are silently ignored. */
+export function clearStoredTheme(key: string): void {
+  if (!canUseStorage()) return
+  try {
+    window.localStorage.removeItem(key)
+  } catch {
+    /* disabled storage */
+  }
+}

--- a/src/providers/ThemeProvider/useTheme.ts
+++ b/src/providers/ThemeProvider/useTheme.ts
@@ -1,0 +1,25 @@
+import { useContext } from 'react'
+import { ThemeContext, type ThemeContextValue } from './theme-context'
+
+/**
+ * Access the active theme state from any descendant of `<ThemeProvider>`.
+ *
+ * Throws when used outside a `ThemeProvider` — unlike `useFieldContext`
+ * (which returns `null` to support standalone components), `useTheme`
+ * has no useful fallback. Surfacing the misuse early is preferred over
+ * a silently no-op return.
+ *
+ * @example
+ * ```tsx
+ * const { mode, setMode, special, setSpecial } = useTheme()
+ * ```
+ */
+export function useTheme(): ThemeContextValue {
+  const ctx = useContext(ThemeContext)
+  if (ctx === null) {
+    throw new Error(
+      'useTheme must be used within a <ThemeProvider>. Wrap your app root with <ThemeProvider> from "@yasmro/schatten/providers".',
+    )
+  }
+  return ctx
+}

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -1,0 +1,1 @@
+export * from './ThemeProvider'

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -32,6 +32,14 @@ const componentBarrelEntries = {
   'components/lv1/index': 'src/components/lv1/index.ts',
 }
 
+// React Context Providers (e.g. `<ThemeProvider>`). Same `'use client'`
+// + per-entry shape as the component bundles — published independently
+// at `@yasmro/schatten/providers` so a Server Component import doesn't
+// drag in the entire components barrel.
+const providerEntries = {
+  'providers/index': 'src/providers/index.ts',
+}
+
 export default defineConfig([
   // Variants & tokens (no React, for Astro / non-React consumers)
   {
@@ -59,6 +67,7 @@ export default defineConfig([
     entry: {
       ...componentBarrelEntries,
       ...lv1ComponentEntries,
+      ...providerEntries,
     },
     format: ['esm'],
     dts: false,
@@ -77,7 +86,7 @@ export default defineConfig([
   // Carries the same `'use client'` banner as the ESM group (see above) so
   // the `.cjs` barrels are equally safe to import from a Server Component.
   {
-    entry: componentBarrelEntries,
+    entry: { ...componentBarrelEntries, ...providerEntries },
     format: ['cjs'],
     dts: false,
     external: ['react', 'react-dom', 'lucide-react'],
@@ -88,11 +97,11 @@ export default defineConfig([
       options.jsx = 'automatic'
     },
   },
-  // Components — type declarations. Only the two published barrel entries
+  // Components & providers — type declarations. Only published barrel entries
   // need `.d.ts` / `.d.cts`; the per-component ESM entries are an internal
   // build detail and are not part of `package.json#exports`.
   {
-    entry: componentBarrelEntries,
+    entry: { ...componentBarrelEntries, ...providerEntries },
     format: ['esm', 'cjs'],
     dts: { only: true },
     external: ['react', 'react-dom', 'lucide-react'],

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -7,6 +7,28 @@ global.ResizeObserver = class ResizeObserver {
   disconnect() {}
 }
 
+// jsdom does not implement `matchMedia`. ThemeProvider reads it to
+// resolve `prefers-color-scheme: dark` when `defaultMode="system"`.
+// Individual tests can `vi.stubGlobal('matchMedia', …)` to control
+// per-test behavior — this baseline polyfill ensures default `light`
+// resolution and no throws.
+if (typeof window !== 'undefined' && typeof window.matchMedia !== 'function') {
+  Object.defineProperty(window, 'matchMedia', {
+    configurable: true,
+    writable: true,
+    value: (query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      addListener: () => {},
+      removeListener: () => {},
+      dispatchEvent: () => false,
+    }),
+  })
+}
+
 // jsdom does not implement Pointer Events; polyfill the methods Radix calls.
 if (typeof Element !== 'undefined') {
   if (!Element.prototype.hasPointerCapture) {


### PR DESCRIPTION
Closes #128, #129.

## 概要

v0.9.0 のテーマ管理周りを一括で出荷する PR。次の 2 件を **同一の storage contract** の上に乗せて同時にマージする:

- **#128** — `<ThemeProvider>` / `useTheme()` の新規追加 (Mode + Special を React tree から宣言的に管理)
- **#129** — README に FOUC 回避用 inline snippet (Next.js / Vite / Remix の配置例 + 厳格 CSP fallback)

両者は `localStorage` の **storage shape `{ mode, special }`** で噛み合うので、別 PR に分けると一方を merge した瞬間に contract が崩れる窓ができる。同 PR で出すのが安全。

## #128 — Provider 実装

### 公開 API

`@yasmro/schatten/providers` に新エントリを追加:

```tsx
import { ThemeProvider, useTheme } from '@yasmro/schatten/providers'

// app/layout.tsx
<ThemeProvider defaultMode="system" defaultSpecial="auto-seasonal">
  {children}
</ThemeProvider>

// 任意の子コンポーネントで
const { mode, modeSetting, setMode, special, setSpecial, isHydrated } = useTheme()
```

#### Props

| prop | type | default |
|---|---|---|
| `defaultMode` | `'light' \| 'dark' \| 'system'` | `'system'` |
| `defaultSpecial` | `SpecialThemeId \| 'auto-seasonal' \| null` | `null` |
| `storageKey` | `string \| null` | `'schatten-theme'` |
| `disableTransitionOnChange` | `boolean` | `false` |

#### `useTheme()` の戻り値

- `mode` — 解決済み `'light' \| 'dark'`（CSS 判定に使う）
- `modeSetting` — `'system'` を含む UI 設定値（トグル UI に使う）
- `setMode(setting)` — 設定変更（`'system'` を渡すと OS 追従に戻る）
- `special` / `setSpecial(id | null)` — `data-theme` の付与/除去
- `isHydrated` — client hydration 完了済みか

### 主な設計判断

1. **`mode` と `modeSetting` を分離** — トグル UI で「system 追従中」と「dark 固定中」を区別できるように。
2. **`useTheme()` は Provider 外で throw** — `FieldContext` (null 返却で standalone 動作を支える) と方針が違う点。Provider なしで意味がない hook では throw のほうが consumer の誤用を早期に検出できる。
3. **`SpecialThemeId` を `SeasonalThemeId` 単独に narrow** — `(string & {})` のエスケープハッチは型安全を犠牲にするので採用せず、将来の brand / vendor Special は `minor` で union を広げる方針。
4. **永続化 shape `{ mode, special }`** — `season` ではなく `special` フィールド名。seasonal-only 命名では将来詰むため。これが #129 の FOUC snippet との **公開契約**。
5. **`disableTransitionOnChange` の `<style>` 注入** — provider が一時的に注入する scoped style なので [component-architecture §7](.claude/rules/component-architecture.md) の lv1-local CSS 制限には抵触しない。

### レンダリングコスト

- **idle 時**: ゼロ (Provider は初回のみ render、value は `useMemo`)
- **テーマ切替時**: `useTheme()` を呼ぶ consumer のみ re-render。Schatten lv1 自体は `useTheme()` を購読しないので、塗り替えは **CSS cascade による再ペイント**で React 介在なし
- README にも「`useTheme().mode` で JSX 分岐するな」と明記

### DOM-as-source-of-truth (cross-island sync)

Provider 内の `MutationObserver` が `<html>` の `class` / `data-theme` を監視し、**どこから DOM が mutate されても** React state に取り込みます。これにより:

- **同タブ内の複数 React root (Astro Islands / micro-frontend)** で `useTheme().mode` / `useTheme().special` が自動同期
- **外部スクリプト** (devtools / 3rd-party SDK) が `<html>` をいじっても Provider が追従
- snippet が初期化した DOM 状態に React state が **構造的に** 収束

ただし `modeSetting` (`'system'` / `'light'` / `'dark'` の UI 設定値) は DOM に情報がないので同期されず、各 Provider instance の local state。複数 root で switcher を持ちたい稀ケースは README の注意書きで「1 root に switcher を集約する」運用パターンを推奨。

## #129 — README FOUC snippet

README の 2 つのプレースホルダ節 ("Theme switching" / "FOUC avoidance") を、本 PR で確定した API + storage shape の実装内容で置き換え:

- Provider のインポートパスを `@yasmro/schatten/providers` に統一
- FOUC 回避 inline snippet の最終形を **Next.js App Router / Vite / Remix** 各環境の配置例で掲載
- 厳格 CSP 環境向けに nonce / 外部 .js fallback を documented
- `localStorage` 失敗時 (private window 等) の挙動を明記
- **`.season` → `.special` rename** を契約として README に明示

### Snippet (本文に minified 1 行で掲載)

```js
(function () {
  try {
    var s = localStorage.getItem('schatten-theme')
    var t = s ? JSON.parse(s) : {}
    var m = t.mode || 'system'
    var d = m === 'dark' || (m === 'system' && window.matchMedia('(prefers-color-scheme: dark)').matches)
    if (d) document.documentElement.classList.add('dark')
    if (t.special) document.documentElement.setAttribute('data-theme', t.special)
  } catch (e) {}
})()
```

### snippet behavior の anti-regression test

`fouc-snippet.test.ts` で README の minified snippet を **そのままの文字列で** 評価し:

- (mode, special) の全組合せで正しい DOM mutation を出すこと
- 壊れた JSON / disabled storage で throw しないこと
- **`.season` フィールド (旧名) を読まない** ことを assert

→ 将来 README が drift して `.season` に戻ったら CI が落ちる構造的ガードを実装。

## ビルド配線

- `package.json#exports` に `./providers` を追加 (ESM + CJS + types の 3 セット、`./components/lv1` と同じ shape)
- `tsup.config.ts` の **components ESM / components CJS / DTS** 3 グループに `providers/index` を追加 → `'use client'` banner が ESM/CJS 双方に乗る (#116 由来)
- `scripts/check-use-client-banner.mjs` を `dist/providers/` も sweep するよう拡張 → CI で **24 React bundles carry `'use client'`** を確認
- `vitest.setup.ts` に `window.matchMedia` polyfill を追加 (`ResizeObserver` / Pointer Events の隣に配置)
- `.storybook/preview.tsx` に `disableGlobalThemeDecorator` パラメータ判定を追加 → Provider story が `<html>` の所有権を持ち、preview decorator と二重書き込みしない

## テスト (合計 42 ケース、全 517/517 緑)

| ファイル | env | 内容 | tests |
|---|---|---|---|
| `ThemeProvider.test.tsx` | jsdom | 初期化、setMode/Special、system tracking、persistence、cross-tab sync、provider 外 throw、disableTransitionOnChange、**DOM mutation pull-in (MutationObserver) + 2 Provider 間の Astro-Islands-style 同期** | 32 |
| `ThemeProvider.ssr.test.tsx` | node | `renderToString` が DOM globals なしで通る、SSR baseline = light/null/not-hydrated | 5 |
| `ThemeProvider.hydration.test.tsx` | jsdom | SSR → hydrate で React mismatch 警告なし、useEffect 後の収束 | 3 |
| `fouc-snippet.test.ts` | jsdom | README snippet を文字列のまま評価し DOM mutation を assert + `.season` regression test | 9 |
| **合計** | | | **49** |

### VRT

不要 — Provider / snippet は視覚契約を持たない ([vrt-spec-guideline](.claude/rules/vrt-spec-guideline.md) は視覚固定が責務)。

## Storybook

`Providers/ThemeProvider` を新設:

- `Playground` — Controls で全 props を切替可能
- `WithControls` — `useTheme()` で取得した setter を呼ぶ UI
- `SystemModeFollows` — `defaultMode="system"` の OS 追従デモ
- `AutoSeasonal` — `defaultSpecial="auto-seasonal"` の解決結果表示
- `PaintWithoutReactReRender` — Schatten lv1 が **React reconciliation なしで再ペイントされる** ことを random id で可視化

## スコープ外 (v1+ で別 issue)

- [#258](https://github.com/yasmro/schatten/issues/258) — `examples/nextjs-app-router/` + `next build` CI smoke
- [#259](https://github.com/yasmro/schatten/issues/259) — Playwright E2E (FOUC / hydration / theme-switch を実ブラウザで検証)

`prefers-reduced-motion` への明示対応は本 PR スコープ外（別 issue 化推奨）。

## チェックリスト

### #128

- [x] 実装 (`src/providers/ThemeProvider/*` 計 9 ファイル)
- [x] `src/providers/index.ts` barrel
- [x] `package.json#exports` に `./providers` 追加
- [x] `tsup.config.ts` 3 グループに `providers/index` 追加
- [x] `scripts/check-use-client-banner.mjs` を `dist/providers/` 対象に拡張
- [x] Unit / SSR / hydration テスト 計 40 ケース (DOM mutation pull-in + 多 Provider 同期含む)
- [x] `vitest.setup.ts` に `matchMedia` mock 追加
- [x] Storybook stories 5 種
- [x] `.storybook/preview.tsx` の decorator 干渉回避
- [x] changeset (`minor`)

### #129

- [x] README "Theme switching" 節を実装内容に置換
- [x] README "FOUC avoidance" 節を実装内容に置換 (Next.js / Vite / Remix 各環境)
- [x] 厳格 CSP 環境での代替パターン (nonce / 外部 .js fallback) 記載
- [x] `localStorage` 失敗時の挙動明記
- [x] snippet の anti-regression test (`fouc-snippet.test.ts`、9 ケース、`.season` 旧名チェック含む)
- [x] storage shape `{ mode, special }` を Provider 側と契約として固定

### 共通

- [x] typecheck / lint / build / 全 524 テスト green
- [x] `'use client'` banner 検査 (24 React bundles 通過)
- [x] lefthook pre-commit (biome + typecheck) 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)

