### PR TITLE
chore(tooling): /audit-coverage slash command と audit-coverage.mjs を追加 (closes #134)

### DIFF
--- a/.changeset/audit-coverage-command-9a4b.md
+++ b/.changeset/audit-coverage-command-9a4b.md
@@ -1,0 +1,25 @@
+---
+'@yasmro/schatten': patch
+---
+
+chore(tooling): `/audit-coverage` slash command と `scripts/audit-coverage.mjs`
+を新設。lv1 全体で test / VRT / class-API CSS (`.st-*` SSOT) /
+`__snapshots__/` baseline / `index.ts` re-export の過不足を一括スキャンする。
+
+`scripts/check-lv1-companions.mjs` (PostToolUse, single component) と
+`scripts/check-lv1-export-integrity.mjs` (Stop, export integrity only) が
+**編集 / セッション単位**で動くのに対し、本コマンドは**任意タイミングで全
+lv1** の充足度を markdown 表として出す。区分 A/B のコンポーネントは
+`*.parity.stories.tsx` / `*.parity.vrt.spec.ts` も判定対象に含み、区分 C/D
+(`Dialog` / `Select` / `Toast` / `Tooltip`) は `vrt-spec-guideline.md`
+§"Parity stories — when to write one, when to skip" に従って parity 列を
+`—` 表示で除外する。
+
+CLI:
+
+- `pnpm audit:coverage` — markdown 表
+- `pnpm audit:coverage --check` — 不足検出時 exit 1 (CI 向け)
+- `pnpm audit:coverage --json` — `$schemaVersion: 1` の JSON 出力
+
+公開 API (React props / CSS class / CSS variables / TypeScript types) に
+変更なし — 内部 tooling のみ。

--- a/.claude/commands/audit-coverage.md
+++ b/.claude/commands/audit-coverage.md
@@ -1,0 +1,83 @@
+# audit-coverage
+
+lv1 全コンポーネントについて、必須 companion ファイル (test / VRT spec /
+class-API CSS / `__snapshots__/` baseline / `index.ts` re-export、区分 A/B
+ならさらに `*.parity.stories.tsx` / `*.parity.vrt.spec.ts`) の過不足を
+一括スキャンする。
+
+既存の hook (`scripts/check-lv1-companions.mjs` の編集トリガー、
+`scripts/check-lv1-export-integrity.mjs` のセッション終了トリガー) は
+**当該 1 件のみ** を警告ベースで見ているのに対し、本コマンドは **任意の
+タイミングで全 lv1** の充足度をまとめて可視化する。
+
+## Usage
+
+```
+/project:audit-coverage
+```
+
+引数なし。
+
+## Flow
+
+1. `pnpm audit:coverage` を Bash で実行し、`stdout` を取得する。
+2. 受け取ったレポート (markdown) をそのままユーザに渡す。
+   - レポートは「集計ヘッダ → 全 lv1 のテーブル → 不足ファイル一覧 → 推奨
+     アクション」の順で並んでいる。**順序を変えたり、要約に圧縮したりしない**
+     — ユーザはテーブルを直接読みたいケースが多い。
+3. 不足が **あった** 場合のみ、末尾で「次にやること」を 1〜3 行に絞って
+   案内する。判断分岐:
+   - 新規 lv1 を追加して companion を忘れた → `/add-lv1-component` のスキャ
+     フォールドを案内、または `scripts/check-lv1-companions.mjs` の
+     hook 出力を再確認するよう示唆。
+   - 既存 lv1 に VRT が抜けた → `/add-vrt-spec` を案内し、その後の
+     baseline 生成は **必ず手動** ([vrt-spec-guideline](../rules/vrt-spec-guideline.md)
+     "Re-baselining" 参照) と添える。
+   - `__snapshots__/` baseline が無い → `pnpm test:vrt -- --grep "{Name}"`
+     を一度回して `__snapshots__/*.png` を作る (ただし「blind update
+     禁止」の前提を必ず注意する)。
+   - barrel export drift → `src/components/lv1/index.ts` への `export
+     { ... } from './{Name}'` 追記を案内。
+   - `Orphaned exports` セクションがあれば、`index.ts` 側の export 行を
+     消すか、消えたディレクトリを復活させるかをユーザに尋ねる。
+4. **新規ブランチ作成や `pnpm test:vrt:update` を勝手に走らせない**。本
+   コマンドは「現状把握」までで終わる。
+
+## Bash で走らせる正規ルート
+
+```bash
+pnpm audit:coverage          # markdown 表 (人間向け、既定)
+pnpm audit:coverage --check  # 不足検出時 exit 1 (CI 用)
+pnpm audit:coverage --json   # AuditReport の JSON (machine-readable)
+```
+
+`--format=plain` も対応 (tab 区切り)。JSON schema は
+[scripts/audit-coverage.mjs](../../scripts/audit-coverage.mjs) のヘッダ
+コメント参照。
+
+## 出力の読み方
+
+各セルの意味:
+
+| 記号 | 意味 |
+|---|---|
+| ✓ | 期待されるファイル / re-export が存在する |
+| ✗ | 期待されるが不在 — action required |
+| — | 期待されない (区分 C/D の `Dialog` / `Select` / `Toast` / `Tooltip` の parity 列) |
+| n/a | 上位列 (`tsx`) が `✗` のため判定不能 |
+
+`tsx` が無いディレクトリは WIP scaffold か別用途の可能性が高いので、他列
+は cascade で `n/a` にして「真に欠落 = 1 セル」に絞っている。
+
+## Gotchas
+
+- **lv2 はスコープ外** (post-1.0 で再評価)。`src/components/lv2/` が存在
+  すれば「out of scope」と末尾に注意書きが出るだけで、ディレクトリ数
+  カウントすらしない。
+- **区分 A/B vs C/D** は [scripts/audit-coverage.mjs](../../scripts/audit-coverage.mjs)
+  冒頭の `PARITY_EXEMPT` で hard-code。新規 lv1 を追加するたびに、その
+  コンポが parity 不要 (区分 C/D) なら `PARITY_EXEMPT` を更新する必要が
+  ある。判定基準は [vrt-spec-guideline.md §"Parity stories — when to
+  write one, when to skip"](../rules/vrt-spec-guideline.md)。
+- **`pnpm audit:coverage` は read-only**。ファイル生成 / 編集 / VRT
+  baseline 更新は一切しない。

--- a/.claude/commands/audit-coverage.md
+++ b/.claude/commands/audit-coverage.md
@@ -1,14 +1,21 @@
 # audit-coverage
 
-lv1 全コンポーネントについて、必須 companion ファイル (test / VRT spec /
-class-API CSS / `__snapshots__/` baseline / `index.ts` re-export、区分 A/B
-ならさらに `*.parity.stories.tsx` / `*.parity.vrt.spec.ts`) の過不足を
-一括スキャンする。
+Scan every lv1 component for the required companion files (test / VRT spec /
+class-API CSS / `__snapshots__/` baseline / `index.ts` re-export, plus
+`*.parity.stories.tsx` / `*.parity.vrt.spec.ts` for classification A/B per
+[vrt-spec-guideline](../rules/vrt-spec-guideline.md)) and report any gaps.
 
-既存の hook (`scripts/check-lv1-companions.mjs` の編集トリガー、
-`scripts/check-lv1-export-integrity.mjs` のセッション終了トリガー) は
-**当該 1 件のみ** を警告ベースで見ているのに対し、本コマンドは **任意の
-タイミングで全 lv1** の充足度をまとめて可視化する。
+This is the **library-wide periodic** counterpart to the existing
+edit-trigger / session-end hooks:
+
+| Trigger | Scope | Behaviour |
+|---|---|---|
+| `scripts/check-lv1-companions.mjs` (PostToolUse hook) | a single edited component | non-blocking warning |
+| `scripts/check-lv1-export-integrity.mjs` (Stop hook) | barrel export integrity only | non-blocking warning |
+| `/audit-coverage` (this command) | all lv1 components, every required surface | report on demand |
+
+The edit-time hooks fire on a narrow signal; this command takes a snapshot of
+the *current* coverage state for the whole lv1 tree whenever the user asks.
 
 ## Usage
 
@@ -16,68 +23,72 @@ class-API CSS / `__snapshots__/` baseline / `index.ts` re-export、区分 A/B
 /project:audit-coverage
 ```
 
-引数なし。
+No arguments.
 
 ## Flow
 
-1. `pnpm audit:coverage` を Bash で実行し、`stdout` を取得する。
-2. 受け取ったレポート (markdown) をそのままユーザに渡す。
-   - レポートは「集計ヘッダ → 全 lv1 のテーブル → 不足ファイル一覧 → 推奨
-     アクション」の順で並んでいる。**順序を変えたり、要約に圧縮したりしない**
-     — ユーザはテーブルを直接読みたいケースが多い。
-3. 不足が **あった** 場合のみ、末尾で「次にやること」を 1〜3 行に絞って
-   案内する。判断分岐:
-   - 新規 lv1 を追加して companion を忘れた → `/add-lv1-component` のスキャ
-     フォールドを案内、または `scripts/check-lv1-companions.mjs` の
-     hook 出力を再確認するよう示唆。
-   - 既存 lv1 に VRT が抜けた → `/add-vrt-spec` を案内し、その後の
-     baseline 生成は **必ず手動** ([vrt-spec-guideline](../rules/vrt-spec-guideline.md)
-     "Re-baselining" 参照) と添える。
-   - `__snapshots__/` baseline が無い → `pnpm test:vrt -- --grep "{Name}"`
-     を一度回して `__snapshots__/*.png` を作る (ただし「blind update
-     禁止」の前提を必ず注意する)。
-   - barrel export drift → `src/components/lv1/index.ts` への `export
-     { ... } from './{Name}'` 追記を案内。
-   - `Orphaned exports` セクションがあれば、`index.ts` 側の export 行を
-     消すか、消えたディレクトリを復活させるかをユーザに尋ねる。
-4. **新規ブランチ作成や `pnpm test:vrt:update` を勝手に走らせない**。本
-   コマンドは「現状把握」までで終わる。
+1. Run `pnpm audit:coverage` in Bash and capture stdout.
+2. Pass the report (markdown) through to the user **verbatim** — do not
+   summarise it.
+   - The report layout is `summary header → per-component table → missing
+     files → recommended actions`. Keep that order; users frequently read
+     the table directly.
+3. **Only when gaps are present**, append 1–3 lines of "what to do next",
+   chosen from the matrix below:
+   - **New lv1 added without companions** → suggest `/add-lv1-component`,
+     or recheck `scripts/check-lv1-companions.mjs`'s hook output.
+   - **Existing lv1 missing the VRT spec** → suggest `/add-vrt-spec`, and
+     remind the user that baseline capture must be **manual** (see
+     [vrt-spec-guideline](../rules/vrt-spec-guideline.md) "Re-baselining").
+   - **No `__snapshots__/` baseline** → suggest
+     `pnpm test:vrt -- --grep "{Name}"` to generate `__snapshots__/*.png`
+     once, with the "blind update is forbidden" caveat applied.
+   - **Barrel export drift** → point at the missing line in
+     `src/components/lv1/index.ts` (`export { ... } from './{Name}'`).
+   - **`Orphaned exports` section present** → ask the user whether to
+     delete the export line or restore the missing directory.
+4. **Do not** branch off, run `pnpm test:vrt:update`, or edit files —
+   this command stops at "current state observed".
 
-## Bash で走らせる正規ルート
+## Direct CLI route
 
-```bash
-pnpm audit:coverage          # markdown 表 (人間向け、既定)
-pnpm audit:coverage --check  # 不足検出時 exit 1 (CI 用)
-pnpm audit:coverage --json   # AuditReport の JSON (machine-readable)
+```sh
+pnpm audit:coverage          # markdown table (default, human-readable)
+pnpm audit:coverage --check  # exit 1 when gaps are found (for CI)
+pnpm audit:coverage --json   # AuditReport JSON (machine-readable)
 ```
 
-`--format=plain` も対応 (tab 区切り)。JSON schema は
-[scripts/audit-coverage.mjs](../../scripts/audit-coverage.mjs) のヘッダ
-コメント参照。
+`--format=plain` (tab-separated) is also accepted. The JSON schema lives
+in [scripts/audit-coverage.d.mts](../../scripts/audit-coverage.d.mts)
+(`AuditRow` / `AuditFiles` / `CellState`) and is pinned by
+[scripts/__tests__/audit-coverage.test.ts](../../scripts/__tests__/audit-coverage.test.ts).
 
-## 出力の読み方
+## Reading the report
 
-各セルの意味:
-
-| 記号 | 意味 |
+| Glyph | Meaning |
 |---|---|
-| ✓ | 期待されるファイル / re-export が存在する |
-| ✗ | 期待されるが不在 — action required |
-| — | 期待されない (区分 C/D の `Dialog` / `Select` / `Toast` / `Tooltip` の parity 列) |
-| n/a | 上位列 (`tsx`) が `✗` のため判定不能 |
+| ✓ | The expected file / re-export exists |
+| ✗ | Expected but missing — action required |
+| — | Not expected (parity columns for classification C/D — `Dialog` / `Select` / `Toast` / `Tooltip`) |
+| n/a | Cannot be evaluated because the parent column (`tsx`) is `✗` |
 
-`tsx` が無いディレクトリは WIP scaffold か別用途の可能性が高いので、他列
-は cascade で `n/a` にして「真に欠落 = 1 セル」に絞っている。
+When a directory has no `{Name}.tsx`, every other column cascades to `n/a`
+to keep the signal-to-noise ratio sane — a WIP scaffold (or a non-component
+directory) shouldn't drown the report in red.
 
 ## Gotchas
 
-- **lv2 はスコープ外** (post-1.0 で再評価)。`src/components/lv2/` が存在
-  すれば「out of scope」と末尾に注意書きが出るだけで、ディレクトリ数
-  カウントすらしない。
-- **区分 A/B vs C/D** は [scripts/audit-coverage.mjs](../../scripts/audit-coverage.mjs)
-  冒頭の `PARITY_EXEMPT` で hard-code。新規 lv1 を追加するたびに、その
-  コンポが parity 不要 (区分 C/D) なら `PARITY_EXEMPT` を更新する必要が
-  ある。判定基準は [vrt-spec-guideline.md §"Parity stories — when to
-  write one, when to skip"](../rules/vrt-spec-guideline.md)。
-- **`pnpm audit:coverage` は read-only**。ファイル生成 / 編集 / VRT
-  baseline 更新は一切しない。
+- **lv2 is out of scope** (deferred until post-1.0). When
+  `src/components/lv2/` contains at least one component subdirectory, the
+  report prints a one-line reminder at the end — the empty placeholder
+  state is silent. The bootstrap work is tracked separately.
+- **Classification A/B vs C/D** is hard-coded in `PARITY_EXEMPT` at the
+  top of [scripts/audit-coverage.mjs](../../scripts/audit-coverage.mjs).
+  When a new lv1 is added that is classification C or D, `PARITY_EXEMPT`
+  must be updated; otherwise the audit will spuriously flag its parity
+  files as missing. The source of truth for the classification is
+  [vrt-spec-guideline.md §"Parity stories — when to write one, when to
+  skip"](../rules/vrt-spec-guideline.md). Automating this sync from the
+  `add-lv1-component` skill is tracked in #306.
+- **`pnpm audit:coverage` is read-only**. It never creates files, edits
+  files, or updates VRT baselines.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,6 +68,7 @@ pnpm lint              # Biome CI checks
 pnpm lint:fix          # Biome auto-fix
 pnpm typecheck         # tsc --noEmit
 pnpm changeset         # Create a changeset for user-facing changes
+pnpm audit:coverage    # Audit lv1 companion-file coverage (test / VRT / .css / __snapshots__ / barrel)
 ```
 
 ## Things you MUST NOT do

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,3 +68,12 @@ When adding or modifying components, follow shadcn/ui conventions (Radix UI + CV
 Both hooks are **non-blocking** — they print to `hookSpecificOutput.additionalContext` and always exit 0. They complement (do not replace) the lefthook pre-commit step.
 
 In addition to those hooks, the CI `lint` job runs **`pnpm check:readme`** ([scripts/sync-readme-components.mjs](scripts/sync-readme-components.mjs)) — verifies that the "Available components" list in [README.md](README.md) matches the lv1 directories on disk (filtered to those that ship a `.tsx` + `.css` pair). When a new lv1 is added but the README block is not regenerated, this gate fails the PR with a `current vs expected` diff. Run `pnpm sync:readme` locally to fix the drift.
+
+## Claude Code commands
+
+`.claude/commands/` holds project-level slash commands (team-shared, checked into git):
+
+- **[/audit-coverage](.claude/commands/audit-coverage.md)** — scans every lv1 component for the required companion files (test / VRT spec / class-API CSS / `__snapshots__/` baseline / `index.ts` re-export, plus `*.parity.stories.tsx` / `*.parity.vrt.spec.ts` for classification A/B per [vrt-spec-guideline](.claude/rules/vrt-spec-guideline.md)). Reports the per-component status as a markdown table plus a "missing files" action list, and lists orphaned exports (entries in `src/components/lv1/index.ts` without a matching directory). The library-wide periodic counterpart to the single-component / session-end hooks above; the script underneath is [scripts/audit-coverage.mjs](scripts/audit-coverage.mjs) and is also runnable as `pnpm audit:coverage` (CI flag `--check`, JSON output `--json`).
+- **[/review-pr](.claude/commands/review-pr.md)** — self-review the current branch's PR (or the local diff). Emits the canonical 3-section output (2 perspectives × ship verdict × prioritised improvements).
+- **[/implement-and-review](.claude/commands/implement-and-review.md)** — single-shot "implement → quality gates → PR → /review-pr" flow for a task or `#<issue>`. PR base is always `develop` (the repo's release flow is `develop → main`).
+- **[/release](.claude/commands/release.md)** — consume pending changesets, bump version, tag / npm publish / GitHub Release.

--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
     "sync:readme": "node scripts/sync-readme-components.mjs",
     "check:readme": "node scripts/sync-readme-components.mjs --check",
     "check:use-client": "node scripts/check-use-client-banner.mjs",
+    "audit:coverage": "node scripts/audit-coverage.mjs",
     "build:storybook": "storybook build",
     "test": "vitest",
     "test:ui": "vitest --ui",

--- a/scripts/__tests__/audit-coverage.test.ts
+++ b/scripts/__tests__/audit-coverage.test.ts
@@ -1,0 +1,388 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import {
+  auditComponent,
+  discoverComponents,
+  hasFailures,
+  parseExportedNames,
+  renderJson,
+  renderTable,
+  runAudit,
+} from '../audit-coverage.mjs'
+
+// Pure-function unit tests for scripts/audit-coverage.mjs. Filesystem
+// helpers below build the minimum directory shape each test needs so the
+// audit logic can be exercised end-to-end without depending on the live
+// repo state.
+
+let workDir: string
+
+beforeEach(() => {
+  workDir = mkdtempSync(join(tmpdir(), 'audit-coverage-'))
+})
+
+afterEach(() => {
+  rmSync(workDir, { recursive: true, force: true })
+})
+
+function makeLv1Dir() {
+  const dir = join(workDir, 'src/components/lv1')
+  mkdirSync(dir, { recursive: true })
+  return dir
+}
+
+function makeComponent(
+  lv1Dir: string,
+  name: string,
+  files: {
+    tsx?: boolean
+    css?: boolean
+    stories?: boolean
+    test?: boolean
+    vrt?: boolean
+    index?: boolean
+    snapshots?: string[]
+    parityStories?: boolean
+    parityVrt?: boolean
+  } = {},
+) {
+  const dir = join(lv1Dir, name)
+  mkdirSync(dir, { recursive: true })
+  const stamp = (filename: string) => writeFileSync(join(dir, filename), '')
+  if (files.tsx ?? true) stamp(`${name}.tsx`)
+  if (files.css ?? true) stamp(`${name}.css`)
+  if (files.stories ?? true) stamp(`${name}.stories.tsx`)
+  if (files.test ?? true) stamp(`${name}.test.tsx`)
+  if (files.vrt ?? true) stamp(`${name}.vrt.spec.ts`)
+  if (files.index ?? true) stamp('index.ts')
+  if (files.parityStories) stamp(`${name}.parity.stories.tsx`)
+  if (files.parityVrt) stamp(`${name}.parity.vrt.spec.ts`)
+  if (files.snapshots && files.snapshots.length > 0) {
+    const snapDir = join(dir, '__snapshots__')
+    mkdirSync(snapDir, { recursive: true })
+    for (const png of files.snapshots) writeFileSync(join(snapDir, png), '')
+  }
+  return dir
+}
+
+function writeBarrel(lv1Dir: string, exports: string[]) {
+  const lines = exports.map((name) => `export { ${name} } from './${name}'`)
+  writeFileSync(join(lv1Dir, 'index.ts'), `${lines.join('\n')}\n`)
+}
+
+describe('discoverComponents', () => {
+  it('enumerates direct subdirectories alphabetically', () => {
+    const lv1Dir = makeLv1Dir()
+    makeComponent(lv1Dir, 'Button')
+    makeComponent(lv1Dir, 'Alert')
+    expect(discoverComponents(lv1Dir)).toEqual(['Alert', 'Button'])
+  })
+
+  it('ignores non-directory entries like index.ts', () => {
+    const lv1Dir = makeLv1Dir()
+    makeComponent(lv1Dir, 'Button')
+    writeFileSync(join(lv1Dir, 'index.ts'), '')
+    expect(discoverComponents(lv1Dir)).toEqual(['Button'])
+  })
+
+  it('returns [] when the directory does not exist', () => {
+    expect(discoverComponents(join(workDir, 'missing'))).toEqual([])
+  })
+})
+
+describe('parseExportedNames', () => {
+  it("extracts every name from `from './Name'` specifiers", () => {
+    const lv1Dir = makeLv1Dir()
+    writeBarrel(lv1Dir, ['Button', 'Badge', 'Callout'])
+    const names = parseExportedNames(join(lv1Dir, 'index.ts'))
+    expect([...names].sort()).toEqual(['Badge', 'Button', 'Callout'])
+  })
+
+  it('ignores re-exports that point at external packages', () => {
+    const lv1Dir = makeLv1Dir()
+    writeFileSync(
+      join(lv1Dir, 'index.ts'),
+      [
+        "export { Button } from './Button'",
+        "export type { ComponentProps } from 'react'",
+        "// from './CommentedOut'",
+      ].join('\n'),
+    )
+    const names = parseExportedNames(join(lv1Dir, 'index.ts'))
+    // The regex matches the bare `from './...'` shape, so the comment
+    // case slips through — documented behaviour, mirrored from the
+    // existing check-lv1-export-integrity.mjs hook.
+    expect(names.has('Button')).toBe(true)
+    expect(names.has('react')).toBe(false)
+  })
+
+  it('returns an empty set when the index file is absent', () => {
+    expect(parseExportedNames(join(workDir, 'missing-index.ts')).size).toBe(0)
+  })
+})
+
+describe('auditComponent', () => {
+  it('marks every required file present when the directory is complete', () => {
+    const lv1Dir = makeLv1Dir()
+    const dir = makeComponent(lv1Dir, 'Button', {
+      snapshots: ['all-variants-light.png', 'parity-parity-light.png'],
+      parityStories: true,
+      parityVrt: true,
+    })
+    const row = auditComponent({
+      name: 'Button',
+      componentDir: dir,
+      exported: true,
+      exempt: false,
+    })
+    expect(row.missing).toEqual([])
+    expect(row.files.tsx).toBe('present')
+    expect(row.files.parityStories).toBe('present')
+    expect(row.files.paritySnap).toBe('present')
+  })
+
+  it('flags a missing test.tsx companion', () => {
+    const lv1Dir = makeLv1Dir()
+    const dir = makeComponent(lv1Dir, 'Button', {
+      test: false,
+      snapshots: ['x-light.png'],
+      parityStories: true,
+      parityVrt: true,
+    })
+    const row = auditComponent({
+      name: 'Button',
+      componentDir: dir,
+      exported: true,
+      exempt: false,
+    })
+    expect(row.files.test).toBe('missing')
+    expect(row.missing).toContain('Button.test.tsx')
+  })
+
+  it('flags a missing css companion (post-#154 requirement)', () => {
+    const lv1Dir = makeLv1Dir()
+    const dir = makeComponent(lv1Dir, 'Button', {
+      css: false,
+      snapshots: ['x-light.png'],
+      parityStories: true,
+      parityVrt: true,
+    })
+    const row = auditComponent({
+      name: 'Button',
+      componentDir: dir,
+      exported: true,
+      exempt: false,
+    })
+    expect(row.files.css).toBe('missing')
+    expect(row.missing).toContain('Button.css')
+  })
+
+  it('flags an empty __snapshots__ as missing baseline', () => {
+    const lv1Dir = makeLv1Dir()
+    const dir = makeComponent(lv1Dir, 'Button', {
+      parityStories: true,
+      parityVrt: true,
+      snapshots: ['parity-parity-light.png'], // only parity baseline
+    })
+    const row = auditComponent({
+      name: 'Button',
+      componentDir: dir,
+      exported: true,
+      exempt: false,
+    })
+    expect(row.files.snap).toBe('missing')
+    expect(row.missing).toContain('__snapshots__/*.png (no baseline captured)')
+  })
+
+  it('flags a missing barrel export', () => {
+    const lv1Dir = makeLv1Dir()
+    const dir = makeComponent(lv1Dir, 'Button', {
+      snapshots: ['x-light.png'],
+      parityStories: true,
+      parityVrt: true,
+    })
+    const row = auditComponent({
+      name: 'Button',
+      componentDir: dir,
+      exported: false,
+      exempt: false,
+    })
+    expect(row.files.export).toBe('missing')
+    expect(row.missing).toContain('src/components/lv1/index.ts re-export')
+  })
+
+  it('requires parity stories/spec/snap for classification A/B (exempt=false)', () => {
+    const lv1Dir = makeLv1Dir()
+    const dir = makeComponent(lv1Dir, 'Button', {
+      snapshots: ['x-light.png'],
+    })
+    const row = auditComponent({
+      name: 'Button',
+      componentDir: dir,
+      exported: true,
+      exempt: false,
+    })
+    expect(row.files.parityStories).toBe('missing')
+    expect(row.files.parityVrt).toBe('missing')
+    expect(row.files.paritySnap).toBe('missing')
+    expect(row.missing).toContain('Button.parity.stories.tsx')
+    expect(row.missing).toContain('Button.parity.vrt.spec.ts')
+  })
+
+  it('treats parity columns as exempt for classification C/D (exempt=true)', () => {
+    const lv1Dir = makeLv1Dir()
+    const dir = makeComponent(lv1Dir, 'Dialog', {
+      snapshots: ['x-light.png'],
+    })
+    const row = auditComponent({
+      name: 'Dialog',
+      componentDir: dir,
+      exported: true,
+      exempt: true,
+    })
+    expect(row.files.parityStories).toBe('exempt')
+    expect(row.files.parityVrt).toBe('exempt')
+    expect(row.files.paritySnap).toBe('exempt')
+    expect(row.missing).toEqual([])
+  })
+
+  it('cascades to na on every dependent column when tsx is missing', () => {
+    const lv1Dir = makeLv1Dir()
+    const dir = makeComponent(lv1Dir, 'Stub', { tsx: false })
+    const row = auditComponent({
+      name: 'Stub',
+      componentDir: dir,
+      exported: false,
+      exempt: false,
+    })
+    expect(row.files.tsx).toBe('missing')
+    expect(row.files.css).toBe('na')
+    expect(row.files.test).toBe('na')
+    expect(row.files.export).toBe('na')
+    expect(row.missing).toEqual(['Stub.tsx'])
+  })
+})
+
+describe('renderTable / renderJson', () => {
+  const fixedAt = '2026-05-25T00:00:00.000Z'
+
+  function sampleRows() {
+    const lv1Dir = makeLv1Dir()
+    const buttonDir = makeComponent(lv1Dir, 'Button', {
+      snapshots: ['all-variants-light.png', 'parity-parity-light.png'],
+      parityStories: true,
+      parityVrt: true,
+    })
+    const dialogDir = makeComponent(lv1Dir, 'Dialog', {
+      snapshots: ['default-light.png'],
+    })
+    return [
+      auditComponent({
+        name: 'Button',
+        componentDir: buttonDir,
+        exported: true,
+        exempt: false,
+      }),
+      auditComponent({
+        name: 'Dialog',
+        componentDir: dialogDir,
+        exported: true,
+        exempt: true,
+      }),
+    ]
+  }
+
+  it('produces a markdown table with the documented header and glyphs', () => {
+    const out = renderTable(sampleRows(), { generatedAt: fixedAt })
+    expect(out).toContain('## Coverage Audit Report (2026-05-25)')
+    expect(out).toContain(
+      '| Component | tsx | css | stories | test | vrt | index | snap | export | parity.stories | parity.vrt | parity.snap |',
+    )
+    expect(out).toContain('| Button | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |')
+    expect(out).toContain('| Dialog | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | — | — | — |')
+    expect(out).toContain('_All lv1 components have required companions._')
+  })
+
+  it('lists missing files per component when present', () => {
+    const lv1Dir = makeLv1Dir()
+    const dir = makeComponent(lv1Dir, 'NewLv1', {
+      test: false,
+      snapshots: [],
+      parityStories: false,
+      parityVrt: false,
+    })
+    const row = auditComponent({
+      name: 'NewLv1',
+      componentDir: dir,
+      exported: false,
+      exempt: false,
+    })
+    const out = renderTable([row], { generatedAt: fixedAt })
+    expect(out).toContain('### Missing files (action required)')
+    expect(out).toContain('NewLv1.test.tsx')
+    expect(out).toContain('src/components/lv1/index.ts re-export')
+    expect(out).toContain('### Recommended actions')
+  })
+
+  it('mentions orphaned exports separately', () => {
+    const rows = sampleRows()
+    const out = renderTable(rows, {
+      generatedAt: fixedAt,
+      orphanedExports: ['LegacyThing'],
+    })
+    expect(out).toContain('### Orphaned exports')
+    expect(out).toContain('LegacyThing')
+  })
+
+  it('notes the lv2 directory when present but defers it', () => {
+    const out = renderTable(sampleRows(), { generatedAt: fixedAt, lv2DirSeen: true })
+    expect(out).toContain('lv2/')
+    expect(out).toContain('post-1.0')
+  })
+
+  it('matches the documented JSON schema', () => {
+    const out = renderJson(sampleRows(), { generatedAt: fixedAt })
+    const parsed = JSON.parse(out)
+    expect(parsed.$schemaVersion).toBe(1)
+    expect(parsed.generatedAt).toBe(fixedAt)
+    expect(parsed.totals).toEqual({ components: 2, allRequiredPresent: 2, missingAny: 0 })
+    expect(parsed.lv1[0].name).toBe('Button')
+    expect(parsed.lv1[1].exempt).toBe(true)
+    expect(parsed.lv1[1].files.parityStories).toBe('exempt')
+  })
+})
+
+describe('runAudit', () => {
+  it('integrates discovery + barrel parse + per-component audit', () => {
+    const lv1Dir = makeLv1Dir()
+    makeComponent(lv1Dir, 'Button', {
+      snapshots: ['x-light.png', 'parity-parity-light.png'],
+      parityStories: true,
+      parityVrt: true,
+    })
+    makeComponent(lv1Dir, 'Dialog', { snapshots: ['x-light.png'] })
+    writeBarrel(lv1Dir, ['Button', 'Dialog', 'GoneAway'])
+    const result = runAudit(workDir)
+    expect(result.rows.map((r) => r.name)).toEqual(['Button', 'Dialog'])
+    expect(result.rows[1].exempt).toBe(true)
+    expect(result.orphanedExports).toEqual(['GoneAway'])
+    expect(result.lv2DirSeen).toBe(false)
+  })
+
+  it('hasFailures returns true on missing required files OR orphaned exports', () => {
+    const lv1Dir = makeLv1Dir()
+    makeComponent(lv1Dir, 'Button', {
+      snapshots: ['x-light.png', 'parity-parity-light.png'],
+      parityStories: true,
+      parityVrt: true,
+    })
+    writeBarrel(lv1Dir, ['Button'])
+    const ok = runAudit(workDir)
+    expect(hasFailures(ok)).toBe(false)
+
+    writeBarrel(lv1Dir, ['Button', 'PhantomDir'])
+    expect(hasFailures(runAudit(workDir))).toBe(true)
+  })
+})

--- a/scripts/__tests__/audit-coverage.test.ts
+++ b/scripts/__tests__/audit-coverage.test.ts
@@ -336,10 +336,15 @@ describe('renderTable / renderJson', () => {
     expect(out).toContain('LegacyThing')
   })
 
-  it('notes the lv2 directory when present but defers it', () => {
-    const out = renderTable(sampleRows(), { generatedAt: fixedAt, lv2DirSeen: true })
+  it('notes the lv2 directory only when it has actual components', () => {
+    const out = renderTable(sampleRows(), { generatedAt: fixedAt, lv2HasComponents: true })
     expect(out).toContain('lv2/')
     expect(out).toContain('post-1.0')
+  })
+
+  it('stays quiet about lv2 when the dir is empty (no note printed)', () => {
+    const out = renderTable(sampleRows(), { generatedAt: fixedAt, lv2HasComponents: false })
+    expect(out).not.toContain('lv2/')
   })
 
   it('matches the documented JSON schema', () => {
@@ -368,7 +373,21 @@ describe('runAudit', () => {
     expect(result.rows.map((r) => r.name)).toEqual(['Button', 'Dialog'])
     expect(result.rows[1].exempt).toBe(true)
     expect(result.orphanedExports).toEqual(['GoneAway'])
-    expect(result.lv2DirSeen).toBe(false)
+    expect(result.lv2HasComponents).toBe(false)
+  })
+
+  it('stays lv2HasComponents=false when the lv2 dir exists but is empty', () => {
+    makeLv1Dir()
+    mkdirSync(join(workDir, 'src/components/lv2'), { recursive: true })
+    const result = runAudit(workDir)
+    expect(result.lv2HasComponents).toBe(false)
+  })
+
+  it('flips lv2HasComponents=true when the lv2 dir contains a component subdir', () => {
+    makeLv1Dir()
+    mkdirSync(join(workDir, 'src/components/lv2/FormField'), { recursive: true })
+    const result = runAudit(workDir)
+    expect(result.lv2HasComponents).toBe(true)
   })
 
   it('hasFailures returns true on missing required files OR orphaned exports', () => {

--- a/scripts/audit-coverage.d.mts
+++ b/scripts/audit-coverage.d.mts
@@ -1,0 +1,63 @@
+// TypeScript declarations for scripts/audit-coverage.mjs. Mirrors the
+// pattern used by generate-manifest.d.mts — JSDoc lives in the .mjs file,
+// but the test imports symbols from a .ts module, so a strongly-typed view
+// is supplied here without forcing the script itself to .ts.
+
+export type CellState = 'present' | 'missing' | 'exempt' | 'na'
+
+export interface AuditFiles {
+  readonly tsx: CellState
+  readonly css: CellState
+  readonly stories: CellState
+  readonly test: CellState
+  readonly vrt: CellState
+  readonly index: CellState
+  readonly snap: CellState
+  readonly export: CellState
+  readonly parityStories: CellState
+  readonly parityVrt: CellState
+  readonly paritySnap: CellState
+}
+
+export interface AuditRow {
+  readonly name: string
+  readonly files: AuditFiles
+  readonly missing: readonly string[]
+  readonly exempt: boolean
+}
+
+export interface AuditResult {
+  readonly rows: readonly AuditRow[]
+  readonly orphanedExports: readonly string[]
+  readonly lv2DirSeen: boolean
+}
+
+export interface RenderTableOptions {
+  readonly format?: 'markdown' | 'plain'
+  readonly generatedAt?: string
+  readonly orphanedExports?: readonly string[]
+  readonly lv2DirSeen?: boolean
+}
+
+export interface RenderJsonOptions {
+  readonly generatedAt?: string
+}
+
+export function discoverComponents(lv1Dir: string): string[]
+
+export function parseExportedNames(indexPath: string): Set<string>
+
+export function auditComponent(opts: {
+  name: string
+  componentDir: string
+  exported: boolean
+  exempt: boolean
+}): AuditRow
+
+export function renderTable(rows: readonly AuditRow[], opts?: RenderTableOptions): string
+
+export function renderJson(rows: readonly AuditRow[], opts?: RenderJsonOptions): string
+
+export function runAudit(projectDir: string): AuditResult
+
+export function hasFailures(result: Pick<AuditResult, 'rows' | 'orphanedExports'>): boolean

--- a/scripts/audit-coverage.d.mts
+++ b/scripts/audit-coverage.d.mts
@@ -29,14 +29,20 @@ export interface AuditRow {
 export interface AuditResult {
   readonly rows: readonly AuditRow[]
   readonly orphanedExports: readonly string[]
-  readonly lv2DirSeen: boolean
+  /**
+   * True when `src/components/lv2/` contains at least one direct
+   * subdirectory (a real component, not just the empty placeholder).
+   * Stays false while the dir exists but is empty — see
+   * scripts/audit-coverage.mjs `runAudit` for the rationale.
+   */
+  readonly lv2HasComponents: boolean
 }
 
 export interface RenderTableOptions {
   readonly format?: 'markdown' | 'plain'
   readonly generatedAt?: string
   readonly orphanedExports?: readonly string[]
-  readonly lv2DirSeen?: boolean
+  readonly lv2HasComponents?: boolean
 }
 
 export interface RenderJsonOptions {

--- a/scripts/audit-coverage.mjs
+++ b/scripts/audit-coverage.mjs
@@ -1,0 +1,443 @@
+#!/usr/bin/env node
+// Scan every lv1 component and report the coverage of the required
+// companion files (tsx / css / stories / test / vrt / index / __snapshots__
+// baseline / barrel re-export, plus parity story+spec for the components
+// in classification A/B per .claude/rules/vrt-spec-guideline.md
+// §"Parity stories — when to write one, when to skip").
+//
+// This is the *library-wide periodic* counterpart to the existing
+// edit-trigger / session-end hooks:
+//   - scripts/check-lv1-companions.mjs (PostToolUse, single component)
+//   - scripts/check-lv1-export-integrity.mjs (Stop, export integrity only)
+// Those run automatically on a narrow signal; this script is invoked on
+// demand to surface the *current* coverage state for the whole lv1 tree.
+//
+// CLI:
+//   node scripts/audit-coverage.mjs                 # markdown table, exit 0
+//   node scripts/audit-coverage.mjs --check         # exit 1 on missing required file
+//   node scripts/audit-coverage.mjs --json          # machine-readable JSON
+//   node scripts/audit-coverage.mjs --format=plain  # plain text (no markdown)
+//
+// The pure functions below are exported so scripts/__tests__/audit-coverage.test.ts
+// can pin behaviour with fixture I/O.
+
+import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs'
+import path from 'node:path'
+
+const LV1_DIR_REL = 'src/components/lv1'
+const LV2_DIR_REL = 'src/components/lv2'
+const INDEX_FILE_REL = 'src/components/lv1/index.ts'
+
+// Components that intentionally do NOT ship parity stories/specs. The
+// canonical reasoning is in .claude/rules/vrt-spec-guideline.md
+// §"Parity stories — when to write one, when to skip": classification
+// C (Tooltip — static rendering but JS-driven positioning) and D
+// (Dialog / Select / Toast — JS-required compound behaviour) have no
+// realistic vanilla-HTML use case for the .st-* class chain alone, so
+// the parity story would be performative.
+//
+// MAINTENANCE: when a new lv1 lands that is classification C or D,
+// add it here. The hard-code is acceptable today because the set is
+// small (4 components) and the source of truth lives in the rule doc
+// next door. If lv1 count grows past ~30 and tracking gets noisy,
+// promote to a `// schatten-classification: B` header comment that
+// gets parsed.
+const PARITY_EXEMPT = new Set(['Dialog', 'Select', 'Toast', 'Tooltip'])
+
+// Match `from './<name>'` / `from "./<name>"`. Same shape as
+// scripts/check-lv1-export-integrity.mjs — kept in sync deliberately.
+const FROM_RE = /from\s+['"]\.\/([^'"/.]+)['"]/g
+
+const REQUIRED_KEYS = /** @type {const} */ ([
+  'tsx',
+  'css',
+  'stories',
+  'test',
+  'vrt',
+  'index',
+  'snap',
+  'export',
+])
+const PARITY_KEYS = /** @type {const} */ (['parityStories', 'parityVrt', 'paritySnap'])
+
+/**
+ * @typedef {'present' | 'missing' | 'exempt' | 'na'} CellState
+ *
+ * @typedef {{
+ *   tsx: CellState,
+ *   css: CellState,
+ *   stories: CellState,
+ *   test: CellState,
+ *   vrt: CellState,
+ *   index: CellState,
+ *   snap: CellState,
+ *   export: CellState,
+ *   parityStories: CellState,
+ *   parityVrt: CellState,
+ *   paritySnap: CellState,
+ * }} AuditFiles
+ *
+ * @typedef {{
+ *   name: string,
+ *   files: AuditFiles,
+ *   missing: string[],
+ *   exempt: boolean,
+ * }} AuditRow
+ */
+
+/**
+ * Enumerate direct subdirectories of `lv1Dir`. Files (`index.ts`, etc.)
+ * are skipped. A non-existent directory yields `[]`.
+ *
+ * @param {string} lv1Dir absolute path
+ * @returns {string[]} sorted directory names
+ */
+export function discoverComponents(lv1Dir) {
+  if (!existsSync(lv1Dir)) return []
+  return readdirSync(lv1Dir)
+    .filter((entry) => {
+      const full = path.join(lv1Dir, entry)
+      try {
+        return statSync(full).isDirectory()
+      } catch {
+        return false
+      }
+    })
+    .sort()
+}
+
+/**
+ * Parse `src/components/lv1/index.ts` and collect every `from './<name>'`
+ * specifier as a Set. Matches scripts/check-lv1-export-integrity.mjs's
+ * regex so the two views agree on what counts as "exported".
+ *
+ * @param {string} indexPath absolute path to index.ts
+ * @returns {Set<string>}
+ */
+export function parseExportedNames(indexPath) {
+  if (!existsSync(indexPath)) return new Set()
+  const source = readFileSync(indexPath, 'utf8')
+  /** @type {Set<string>} */
+  const names = new Set()
+  // Reset state on the shared regex before each call.
+  FROM_RE.lastIndex = 0
+  let m
+  while ((m = FROM_RE.exec(source)) !== null) names.add(m[1])
+  return names
+}
+
+/**
+ * Audit a single component directory. The I/O surface is small —
+ * callers wire `componentDir` (absolute path) and the `exported` /
+ * `exempt` booleans, so this function is straightforward to unit-test.
+ *
+ * @param {{
+ *   name: string,
+ *   componentDir: string,
+ *   exported: boolean,
+ *   exempt: boolean,
+ * }} opts
+ * @returns {AuditRow}
+ */
+export function auditComponent({ name, componentDir, exported, exempt }) {
+  const tsxPath = path.join(componentDir, `${name}.tsx`)
+  const tsxPresent = existsSync(tsxPath)
+
+  // Without {Name}.tsx the directory is not a complete component — every
+  // other column collapses to `na` rather than `missing`, to avoid
+  // drowning the report in cascading red entries for a WIP scaffold.
+  const present = (file) => existsSync(path.join(componentDir, file))
+  const cell = (p) => (p ? 'present' : 'missing')
+
+  /** @type {AuditFiles} */
+  const files = {
+    tsx: cell(tsxPresent),
+    css: 'na',
+    stories: 'na',
+    test: 'na',
+    vrt: 'na',
+    index: 'na',
+    snap: 'na',
+    export: 'na',
+    parityStories: 'na',
+    parityVrt: 'na',
+    paritySnap: 'na',
+  }
+
+  if (tsxPresent) {
+    files.css = cell(present(`${name}.css`))
+    files.stories = cell(present(`${name}.stories.tsx`))
+    files.test = cell(present(`${name}.test.tsx`))
+    files.vrt = cell(present(`${name}.vrt.spec.ts`))
+    files.index = cell(present('index.ts'))
+    files.snap = cell(countSnapshots(componentDir, (n) => !n.startsWith('parity-')) >= 1)
+    files.export = cell(exported)
+
+    if (exempt) {
+      files.parityStories = 'exempt'
+      files.parityVrt = 'exempt'
+      files.paritySnap = 'exempt'
+    } else {
+      files.parityStories = cell(present(`${name}.parity.stories.tsx`))
+      files.parityVrt = cell(present(`${name}.parity.vrt.spec.ts`))
+      files.paritySnap = cell(countSnapshots(componentDir, (n) => n.startsWith('parity-')) >= 1)
+    }
+  }
+
+  /** @type {string[]} */
+  const missing = []
+  if (files.tsx === 'missing') missing.push(`${name}.tsx`)
+  if (files.css === 'missing') missing.push(`${name}.css`)
+  if (files.stories === 'missing') missing.push(`${name}.stories.tsx`)
+  if (files.test === 'missing') missing.push(`${name}.test.tsx`)
+  if (files.vrt === 'missing') missing.push(`${name}.vrt.spec.ts`)
+  if (files.index === 'missing') missing.push('index.ts')
+  if (files.snap === 'missing') missing.push('__snapshots__/*.png (no baseline captured)')
+  if (files.export === 'missing') missing.push('src/components/lv1/index.ts re-export')
+  if (files.parityStories === 'missing') missing.push(`${name}.parity.stories.tsx`)
+  if (files.parityVrt === 'missing') missing.push(`${name}.parity.vrt.spec.ts`)
+  if (files.paritySnap === 'missing') missing.push('__snapshots__/parity-*.png (no parity baseline)')
+
+  return { name, files, missing, exempt }
+}
+
+/**
+ * Count PNG entries under `__snapshots__/` that match `pred(name)`. Used
+ * for the "baseline captured" and "parity baseline captured" checks.
+ *
+ * @param {string} componentDir
+ * @param {(name: string) => boolean} pred
+ */
+function countSnapshots(componentDir, pred) {
+  const snapDir = path.join(componentDir, '__snapshots__')
+  if (!existsSync(snapDir)) return 0
+  try {
+    return readdirSync(snapDir).filter((n) => n.endsWith('.png') && pred(n)).length
+  } catch {
+    return 0
+  }
+}
+
+const CELL_GLYPH = {
+  present: '✓',
+  missing: '✗',
+  exempt: '—',
+  na: 'n/a',
+}
+
+/**
+ * Render an audit as a markdown report (header + table + missing-files
+ * section + recommended-actions section). Returns a single string.
+ *
+ * @param {AuditRow[]} rows
+ * @param {{
+ *   format?: 'markdown' | 'plain',
+ *   generatedAt?: string,
+ *   orphanedExports?: string[],
+ *   lv2DirSeen?: boolean,
+ * }} [opts]
+ */
+export function renderTable(rows, opts = {}) {
+  const { format = 'markdown', generatedAt, orphanedExports = [], lv2DirSeen = false } = opts
+  const date = (generatedAt ?? new Date().toISOString()).slice(0, 10)
+
+  const total = rows.length
+  const allOk = rows.filter((r) => r.missing.length === 0).length
+  const broken = total - allOk
+
+  const lines = []
+  if (format === 'markdown') {
+    lines.push(`## Coverage Audit Report (${date})`)
+    lines.push('')
+    lines.push(`lv1 components: ${total} — required ✓ ${allOk} / missing ✗ ${broken}`)
+    lines.push('')
+    lines.push(
+      '| Component | tsx | css | stories | test | vrt | index | snap | export | parity.stories | parity.vrt | parity.snap |',
+    )
+    lines.push('|---|---|---|---|---|---|---|---|---|---|---|---|')
+    for (const row of rows) {
+      const cells = REQUIRED_KEYS.map((k) => CELL_GLYPH[row.files[k]])
+        .concat(PARITY_KEYS.map((k) => CELL_GLYPH[row.files[k]]))
+        .join(' | ')
+      lines.push(`| ${row.name} | ${cells} |`)
+    }
+    lines.push('')
+  } else {
+    lines.push(`Coverage Audit Report (${date})`)
+    lines.push(`lv1 components: ${total}  required: ${allOk}  missing: ${broken}`)
+    lines.push('')
+    const header = ['Component', ...REQUIRED_KEYS, ...PARITY_KEYS]
+    lines.push(header.join('\t'))
+    for (const row of rows) {
+      const cells = [...REQUIRED_KEYS, ...PARITY_KEYS].map((k) => CELL_GLYPH[row.files[k]])
+      lines.push([row.name, ...cells].join('\t'))
+    }
+    lines.push('')
+  }
+
+  // Per-component missing list. Quiet section header in plain mode.
+  const broken_rows = rows.filter((r) => r.missing.length > 0)
+  if (broken_rows.length > 0) {
+    lines.push(format === 'markdown' ? '### Missing files (action required)' : 'Missing files:')
+    for (const row of broken_rows) {
+      lines.push(`- \`${row.name}\`: missing ${row.missing.join(', ')}`)
+    }
+    lines.push('')
+    lines.push(
+      format === 'markdown' ? '### Recommended actions' : 'Recommended actions:',
+    )
+    lines.push('- Run `/add-lv1-component` to scaffold missing companions for a new lv1.')
+    lines.push(
+      '- For an existing lv1 missing only the VRT spec, run `/add-vrt-spec` then `pnpm test:vrt` to capture baselines.',
+    )
+    lines.push('- For barrel-export drift, add the matching `export { ... } from \'./{Name}\'` line to `src/components/lv1/index.ts`.')
+    lines.push('')
+  } else {
+    lines.push(format === 'markdown' ? '_All lv1 components have required companions._' : 'All lv1 components have required companions.')
+    lines.push('')
+  }
+
+  if (orphanedExports.length > 0) {
+    lines.push(
+      format === 'markdown' ? '### Orphaned exports' : 'Orphaned exports:',
+    )
+    lines.push(
+      `- src/components/lv1/index.ts re-exports the following with no matching directory: ${orphanedExports.join(', ')}`,
+    )
+    lines.push('')
+  }
+
+  if (lv2DirSeen) {
+    lines.push(
+      format === 'markdown'
+        ? '> Note: `src/components/lv2/` exists but is out of scope for this audit (lv2 deferred to post-1.0).'
+        : 'Note: src/components/lv2/ exists but is out of scope for this audit (lv2 deferred to post-1.0).',
+    )
+    lines.push('')
+  }
+
+  return lines.join('\n').replace(/\n+$/, '\n')
+}
+
+/**
+ * Render the audit as a JSON string matching the documented schema. The
+ * shape is pinned by Vitest so consumers (CI scripts, future lint
+ * plugins) can rely on stable keys.
+ *
+ * @param {AuditRow[]} rows
+ * @param {{ generatedAt?: string }} [opts]
+ */
+export function renderJson(rows, opts = {}) {
+  const generatedAt = opts.generatedAt ?? new Date().toISOString()
+  const total = rows.length
+  const allOk = rows.filter((r) => r.missing.length === 0).length
+  const payload = {
+    $schemaVersion: 1,
+    generatedAt,
+    lv1: rows.map((r) => ({
+      name: r.name,
+      files: r.files,
+      missing: r.missing,
+      exempt: r.exempt,
+    })),
+    totals: {
+      components: total,
+      allRequiredPresent: allOk,
+      missingAny: total - allOk,
+    },
+  }
+  return `${JSON.stringify(payload, null, 2)}\n`
+}
+
+/**
+ * Run the full audit against the project tree rooted at `projectDir`.
+ * Returns the rows plus auxiliary findings (orphaned exports, lv2 dir
+ * presence) for the renderers to consume.
+ *
+ * @param {string} projectDir
+ */
+export function runAudit(projectDir) {
+  const lv1Dir = path.join(projectDir, LV1_DIR_REL)
+  const indexPath = path.join(projectDir, INDEX_FILE_REL)
+  const names = discoverComponents(lv1Dir)
+  const exportedNames = parseExportedNames(indexPath)
+
+  const rows = names.map((name) =>
+    auditComponent({
+      name,
+      componentDir: path.join(lv1Dir, name),
+      exported: exportedNames.has(name),
+      exempt: PARITY_EXEMPT.has(name),
+    }),
+  )
+
+  const orphanedExports = [...exportedNames].filter((n) => !names.includes(n)).sort()
+  const lv2DirSeen = existsSync(path.join(projectDir, LV2_DIR_REL))
+
+  return { rows, orphanedExports, lv2DirSeen }
+}
+
+/** @returns {boolean} true when the audit found any required-file gap. */
+export function hasFailures({ rows, orphanedExports }) {
+  return rows.some((r) => r.missing.length > 0) || orphanedExports.length > 0
+}
+
+// ── CLI entry ────────────────────────────────────────────────────────
+function parseArgs(argv) {
+  const args = { check: false, json: false, format: 'markdown' }
+  for (const raw of argv) {
+    if (raw === '--check') args.check = true
+    else if (raw === '--json') args.json = true
+    else if (raw === '--format=plain') args.format = 'plain'
+    else if (raw === '--format=markdown') args.format = 'markdown'
+    else if (raw === '-h' || raw === '--help') args.help = true
+    else throw new Error(`audit-coverage: unknown flag "${raw}"`)
+  }
+  return args
+}
+
+function printHelp() {
+  process.stdout.write(
+    [
+      'Usage: node scripts/audit-coverage.mjs [options]',
+      '',
+      'Options:',
+      '  --check           Exit 1 when any required file is missing (for CI use)',
+      '  --json            Output machine-readable JSON instead of markdown',
+      '  --format=plain    Output plain text instead of markdown',
+      '  --format=markdown Output markdown (default)',
+      '  -h, --help        Show this message',
+      '',
+    ].join('\n'),
+  )
+}
+
+function main() {
+  let opts
+  try {
+    opts = parseArgs(process.argv.slice(2))
+  } catch (err) {
+    process.stderr.write(`${err instanceof Error ? err.message : err}\n`)
+    process.exit(2)
+  }
+  if (opts.help) {
+    printHelp()
+    return
+  }
+
+  const projectDir = process.cwd()
+  const audit = runAudit(projectDir)
+  const output = opts.json
+    ? renderJson(audit.rows)
+    : renderTable(audit.rows, {
+        format: opts.format,
+        orphanedExports: audit.orphanedExports,
+        lv2DirSeen: audit.lv2DirSeen,
+      })
+  process.stdout.write(output)
+
+  if (opts.check && hasFailures(audit)) process.exit(1)
+}
+
+const isCliEntry = import.meta.url === `file://${path.resolve(process.argv[1] ?? '')}`
+if (isCliEntry) main()

--- a/scripts/audit-coverage.mjs
+++ b/scripts/audit-coverage.mjs
@@ -238,7 +238,7 @@ const CELL_GLYPH = {
  * }} [opts]
  */
 export function renderTable(rows, opts = {}) {
-  const { format = 'markdown', generatedAt, orphanedExports = [], lv2DirSeen = false } = opts
+  const { format = 'markdown', generatedAt, orphanedExports = [], lv2HasComponents = false } = opts
   const date = (generatedAt ?? new Date().toISOString()).slice(0, 10)
 
   const total = rows.length
@@ -307,11 +307,11 @@ export function renderTable(rows, opts = {}) {
     lines.push('')
   }
 
-  if (lv2DirSeen) {
+  if (lv2HasComponents) {
     lines.push(
       format === 'markdown'
-        ? '> Note: `src/components/lv2/` exists but is out of scope for this audit (lv2 deferred to post-1.0).'
-        : 'Note: src/components/lv2/ exists but is out of scope for this audit (lv2 deferred to post-1.0).',
+        ? '> Note: `src/components/lv2/` now contains components but is out of scope for this audit (lv2 deferred to post-1.0). Update `scripts/audit-coverage.mjs` to audit lv2.'
+        : 'Note: src/components/lv2/ now contains components but is out of scope for this audit (lv2 deferred to post-1.0). Update scripts/audit-coverage.mjs to audit lv2.',
     )
     lines.push('')
   }
@@ -372,9 +372,14 @@ export function runAudit(projectDir) {
   )
 
   const orphanedExports = [...exportedNames].filter((n) => !names.includes(n)).sort()
-  const lv2DirSeen = existsSync(path.join(projectDir, LV2_DIR_REL))
+  // The lv2 directory itself ships as an empty placeholder today (lv2 is
+  // deferred to post-1.0). Only flag it once it actually contains a
+  // component directory — otherwise the note prints on every audit and
+  // becomes background noise, defeating its purpose as a reminder for
+  // when lv2 finally lands.
+  const lv2HasComponents = discoverComponents(path.join(projectDir, LV2_DIR_REL)).length > 0
 
-  return { rows, orphanedExports, lv2DirSeen }
+  return { rows, orphanedExports, lv2HasComponents }
 }
 
 /** @returns {boolean} true when the audit found any required-file gap. */
@@ -402,11 +407,20 @@ function printHelp() {
       'Usage: node scripts/audit-coverage.mjs [options]',
       '',
       'Options:',
-      '  --check           Exit 1 when any required file is missing (for CI use)',
-      '  --json            Output machine-readable JSON instead of markdown',
-      '  --format=plain    Output plain text instead of markdown',
-      '  --format=markdown Output markdown (default)',
-      '  -h, --help        Show this message',
+      '  --check           Exit 1 when any required companion file is missing or an',
+      '                    orphaned export is found; exit 0 otherwise (CI use).',
+      '  --json            Output machine-readable JSON instead of markdown.',
+      '                    Schema is documented in scripts/audit-coverage.d.mts',
+      '                    (AuditRow / AuditFiles / CellState) and pinned by',
+      '                    scripts/__tests__/audit-coverage.test.ts.',
+      '  --format=plain    Output plain text (tab-separated) instead of markdown.',
+      '  --format=markdown Output markdown (default).',
+      '  -h, --help        Show this message.',
+      '',
+      'Exit codes:',
+      '  0  Audit succeeded (or --check found no gaps).',
+      '  1  --check found a missing required file or an orphaned export.',
+      '  2  Argument parsing failed.',
       '',
     ].join('\n'),
   )
@@ -432,7 +446,7 @@ function main() {
     : renderTable(audit.rows, {
         format: opts.format,
         orphanedExports: audit.orphanedExports,
-        lv2DirSeen: audit.lv2DirSeen,
+        lv2HasComponents: audit.lv2HasComponents,
       })
   process.stdout.write(output)
 


### PR DESCRIPTION
## What

`/audit-coverage` slash command と `scripts/audit-coverage.mjs` を新設。
lv1 全コンポーネントについて、必須 companion ファイル (tsx / css / stories /
test / vrt / index / `__snapshots__/` baseline / barrel re-export、区分 A/B
ならさらに `*.parity.stories.tsx` / `*.parity.vrt.spec.ts`) の過不足を
markdown 表で可視化する。

## Why

既存の hook (`scripts/check-lv1-companions.mjs` / `check-lv1-export-integrity.mjs`)
は **編集 / セッション単位** で単一コンポを警告ベースに見ているが、
リポジトリ全体の現状を「いま」スナップショットする手段がなかった。本
PR はその穴を埋め、追加で CI 用 `--check` (exit 1) と machine-readable
`--json` (`$schemaVersion: 1`) を備える。

closes #134

## Related rules

- [.claude/rules/vrt-spec-guideline.md](.claude/rules/vrt-spec-guideline.md)
  §"Parity stories — when to write one, when to skip" — 区分 A/B vs C/D
  の SoT。`PARITY_EXEMPT = {Dialog, Select, Toast, Tooltip}` が
  `audit-coverage.mjs` 冒頭にハードコードされている根拠。
- [.claude/rules/css-api.md](.claude/rules/css-api.md) — `{Name}.css` を
  公開 `.st-*` クラス API の SSOT として必須化 (post-#154)、本 audit が
  反映する。

## Test plan

- [x] `pnpm lint` 緑
- [x] `pnpm test --run` 緑 (634/634、新規 24 含む)
- [x] `pnpm typecheck` 緑
- [x] 実機 smoke: 18/18 ✓ / `--check` exit 0 / `--json` schema 通り
- [x] Negative smoke: 故意の不足で `--check` exit 1 / 推奨アクション表示
- [x] lv2 dir が空なら note を抑制 (実機で確認)
- [x] `--help` の出力に exit code とスキーマ参照を含む

## レビュー反映 (本 PR 内)

- **P1** lv2 検出を「dir 存在」→「dir 内に component subdir が 1 件以上」
  に変更。lv2 dir は post-1.0 まで空のままなので、毎回 note が出ていたのを
  抑制 (commit 27c2a91)。
- **P2** `printHelp()` に exit codes セクションと `--json` スキーマ参照を
  追加 (commit 27c2a91)。

## レビュー反映 (フォロー issue として切り出し)

- **P0** `add-lv1-component` skill 統合 → #306
- **P0** `--check` の CI required 化 → #307

## Out of scope

- lv2 audit — post-1.0、初の lv2 が landed したタイミング

🤖 Generated with [Claude Code](https://claude.com/claude-code)
