### PR TITLE
ci(audit): audit:coverage --check を専用 audit job として CI に追加 (closes #307)

### DIFF
--- a/.claude/commands/audit-coverage.md
+++ b/.claude/commands/audit-coverage.md
@@ -63,6 +63,12 @@ in [scripts/audit-coverage.d.mts](../../scripts/audit-coverage.d.mts)
 (`AuditRow` / `AuditFiles` / `CellState`) and is pinned by
 [scripts/__tests__/audit-coverage.test.ts](../../scripts/__tests__/audit-coverage.test.ts).
 
+`--check` also runs in CI as the `audit` job
+([.github/workflows/ci.yml](../../.github/workflows/ci.yml)), which pipes the
+report into the PR's job summary. This command is the *on-demand display*
+counterpart; CI is the *blocking PR gate* — see the hook-vs-CI-gate
+responsibility split in [CLAUDE.md](../../CLAUDE.md).
+
 ## Reading the report
 
 | Glyph | Meaning |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,10 +179,14 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: 22
-          cache: pnpm
 
-      - run: pnpm install --frozen-lockfile
-
+      # No `pnpm install` step: scripts/audit-coverage.mjs imports only
+      # `node:fs` / `node:path` (zero external deps, no compile step), so
+      # `pnpm audit:coverage` resolves to a bare `node` run that needs no
+      # node_modules. Skipping install (and the `cache: pnpm` it would feed)
+      # keeps this the cheapest job in CI. pnpm/action-setup is still needed
+      # to provide the `pnpm` binary that runs the package.json script.
+      #
       # `audit:coverage` reads the lv1 tree only — no build, no git history
       # needed (unlike `manifest` / `changeset`), and no dependabot / base=main
       # skip because the result is deterministic on source: a dep bump or the

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,3 +163,37 @@ jobs:
         # branch — otherwise a develop-targeted PR is diffed against main and
         # picks up unrelated already-merged changesets once the two diverge.
         run: pnpm exec changeset status --since=origin/${{ github.base_ref }}
+
+  audit:
+    runs-on: ubuntu-latest
+    # Phase 1: observe-only. continue-on-error keeps the check from blocking
+    # merges while we watch the real-world failure rate over ~1 week of PRs
+    # (see #307 staged rollout). Phase 2 removes this line and adds `audit`
+    # to develop's required checks.
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: pnpm/action-setup@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      # `audit:coverage` reads the lv1 tree only — no build, no git history
+      # needed (unlike `manifest` / `changeset`), and no dependabot / base=main
+      # skip because the result is deterministic on source: a dep bump or the
+      # release PR leaves lv1 dirs untouched, so the gate just passes. The
+      # script writes the full markdown report to stdout *before* exiting 1 on
+      # a gap, so piping into $GITHUB_STEP_SUMMARY surfaces the "Missing files"
+      # + "Recommended actions" sections directly in the PR's checks summary.
+      # `set -o pipefail` is REQUIRED — without it the pipe's exit code is
+      # tee's (0) and a real gap is silently swallowed.
+      - name: lv1 companion coverage
+        shell: bash
+        run: |
+          set -o pipefail
+          pnpm audit:coverage --check | tee -a "$GITHUB_STEP_SUMMARY"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,6 +69,15 @@ When adding or modifying components, follow shadcn/ui conventions (Radix UI + CV
 
 Both hooks are **non-blocking** — they print to `hookSpecificOutput.additionalContext` and always exit 0. They complement (do not replace) the lefthook pre-commit step.
 
+### Hook (non-blocking) vs CI gate (blocking) — responsibility split
+
+The companion-coverage concern is defended at **two timings**, deliberately overlapping:
+
+- **Edit / session unit (the two hooks above) — non-blocking, immediate feedback.** `check-lv1-companions.mjs` (per edited component) and `check-lv1-export-integrity.mjs` (export integrity) warn only. They are **kept, not retired** — their value is catching a gap *while you are editing*, before a PR even exists.
+- **PR unit (the CI `audit` job) — blocking, whole-tree integrity gate.** The `audit` job in [.github/workflows/ci.yml](.github/workflows/ci.yml) runs **`pnpm audit:coverage --check`** ([scripts/audit-coverage.mjs](scripts/audit-coverage.mjs)) across every lv1 and fails the PR when a required companion (test / VRT spec / class-API CSS / `__snapshots__/` baseline / `index.ts` re-export, plus parity series for classification A/B) is missing or an export is orphaned. The full report (including "Recommended actions") is written to the PR's job summary. Currently `continue-on-error: true` (Phase 1 observation, see [#307](https://github.com/yasmro/schatten/issues/307)); Phase 2 removes that and adds `audit` to `develop`'s required checks.
+
+The two layers **intentionally report the same gap at different timings** — this is multi-layer defense, not redundancy. Reproduce the CI gate locally with `pnpm audit:coverage` (no `--check`); the output is identical.
+
 In addition to those hooks, the CI `lint` job runs **`pnpm check:readme`** ([scripts/sync-readme-components.mjs](scripts/sync-readme-components.mjs)) — verifies that the "Available components" list in [README.md](README.md) matches the lv1 directories on disk (filtered to those that ship a `.tsx` + `.css` pair). When a new lv1 is added but the README block is not regenerated, this gate fails the PR with a `current vs expected` diff. Run `pnpm sync:readme` locally to fix the drift.
 
 ## Claude Code commands


### PR DESCRIPTION
## What

`pnpm audit:coverage --check` ([scripts/audit-coverage.mjs](scripts/audit-coverage.mjs)) を
専用 `audit` job として [.github/workflows/ci.yml](.github/workflows/ci.yml) に追加。
lv1 の必須 companion (test / VRT spec / class-API CSS / `__snapshots__/` baseline /
`index.ts` re-export、区分 A/B は parity 系列) の過不足と orphaned export を PR 段階で検出する。

Phase 1 は `continue-on-error: true` で観察のみ。report は `$GITHUB_STEP_SUMMARY` に
配線し、`set -o pipefail` で tee 経由の exit code 握り潰しを防ぐ。

`audit-coverage.mjs` は `node:fs` / `node:path` のみの純 Node スクリプトなので
`pnpm install` を省略し、CI 最軽量の job にしている。

hook (非ブロック) と CI gate (ブロック) の責務整理を [CLAUDE.md](CLAUDE.md) に追記。

## Why

PR #305 で ship した `/audit-coverage` の CI 統合は意図的に scope 外だった (#134)。
edit/session 単位の既存 hook (警告のみ) に対し、本 job は PR 単位で blocking する最終層。
test-less / vrt-less / css-less / export-less な lv1 を構造的に防ぐ。

## Related rules

- [vrt-spec-guideline.md](.claude/rules/vrt-spec-guideline.md) — 区分 A/B の parity 系列
- 案B (専用 job) 採用理由: このリポの「1 gate = 1 job」規約 (manifest/changeset/size と同粒度)

## 段階ロールアウト

- **Phase 1 (本 PR)**: `continue-on-error: true` で 1 週間観察。
- **Phase 2 (#326)**: `continue-on-error` 削除 + `develop` 保護の required check に追加。
- 観察フェーズの締めと Phase 2 移行は **#326** で追跡する (マージ後 ~1 週間 / 2026-06-06 頃に誤検出率を評価)。

## Test plan

- [x] `pnpm lint` 緑 (224 files)
- [x] `pnpm typecheck` 緑
- [x] `pnpm test --run` 緑 (33 files / 652 tests)
- [x] `pnpm audit:coverage --check` ローカルで exit 0 (18/18 components)
- [x] bare `node scripts/audit-coverage.mjs --check` も exit 0 (install 省略の裏付け)
- [x] `set -o pipefail` 検証: pipefail 無し → exit 0 (bug)、有り → exit 1 (fix)

closes #307

🤖 Generated with [Claude Code](https://claude.com/claude-code)
