### PR TITLE
feat(skill): add-lv1-component に parity 区分 (A/B/C/D) 選択ステップを追加 (closes #306)

### DIFF
--- a/.claude/skills/add-lv1-component/SKILL.md
+++ b/.claude/skills/add-lv1-component/SKILL.md
@@ -4,11 +4,12 @@ description: >-
   Scaffold a new lv1 primitive component for the Schatten design system.
   Use whenever the user wants to add, create, or generate a new lv1 / primitive
   component (e.g. "add a new lv1 component", "新しいコンポーネントを追加して",
-  "lv1 に Alert を作って", "Banner コンポーネントを新設"). Generates the full
+  "lv1 に Alert を作って", "Banner コンポーネントを新設"). Generates the core
   7-file set — variants CVA / tsx / css / stories / unit test / VRT spec /
-  index — in a form that complies with every .claude/rules/ guideline, and
-  registers the component in src/components/lv1/index.ts. Prevents test-less,
-  VRT-less, or css-less component additions structurally.
+  index — plus a parity story + VRT spec for 区分 A / B components, in a form
+  that complies with every .claude/rules/ guideline, and registers the
+  component in src/components/lv1/index.ts. Prevents test-less, VRT-less, or
+  css-less component additions structurally.
 ---
 
 # add-lv1-component
@@ -19,7 +20,8 @@ project's API conventions — no test-less or convention-drifting additions.
 
 ## What it generates
 
-For a component named `Foo`:
+For a component named `Foo`, the **core 7-file set** ships for every new lv1
+regardless of classification:
 
 | File | Purpose |
 |---|---|
@@ -30,6 +32,21 @@ For a component named `Foo`:
 | `src/components/lv1/Foo/Foo.test.tsx` | Vitest unit test |
 | `src/components/lv1/Foo/Foo.vrt.spec.ts` | Playwright VRT spec |
 | `src/components/lv1/Foo/index.ts` | Folder barrel re-export |
+
+The **parity 2-file set** ships *only for 区分 A / B* components (Step 2's
+classification step decides):
+
+| File | Purpose |
+|---|---|
+| `src/components/lv1/Foo/Foo.parity.stories.tsx` | Storybook — React vs vanilla-HTML side-by-side, proving the `.st-*` class chain reproduces the React render |
+| `src/components/lv1/Foo/Foo.parity.vrt.spec.ts` | Playwright VRT spec pinning that parity pixel-identically |
+
+For 区分 C / D components the parity pair is **not** generated; instead the
+component name is added to `PARITY_EXEMPT` in
+[`scripts/audit-coverage.mjs`](../../../scripts/audit-coverage.mjs) so the
+coverage audit does not flag the missing parity files. See
+`.claude/rules/vrt-spec-guideline.md` §"Parity stories — when to write one,
+when to skip" for the classification.
 
 Plus an edit to **`src/components/lv1/index.ts`** adding the public re-export,
 and to **`src/variants/index.ts`** adding the variants re-export, and an
@@ -63,7 +80,9 @@ Rules drift; never scaffold from memory. Read these before generating anything:
 - `.claude/rules/storybook-guideline.md` — `Playground` first, group by prop,
   TSDoc as source of truth
 - `.claude/rules/testing-guideline.md` — required test cases per component type
-- `.claude/rules/vrt-spec-guideline.md` — VRT spec template, story-id mapping
+- `.claude/rules/vrt-spec-guideline.md` — VRT spec template, story-id mapping,
+  and especially §"Parity stories — when to write one, when to skip" (the
+  区分 A/B/C/D classification that Step 2 asks for)
 - `.claude/rules/state-token-guideline.md` — semantic tokens only, never
   primitive color classes (`bg-red-500` is banned by a lint plugin)
 - `.claude/rules/component-testid-guideline.md` — `...props` pass-through
@@ -89,6 +108,35 @@ choices are closed.
 5. **Root element / role** — interactive components MUST render a native
    interactive element or a Radix primitive (a11y contract §8). A plain
    `<div>` is only for non-interactive display content.
+6. **Parity classification — 区分 A / B / C / D**
+   (`vrt-spec-guideline.md` §"Parity stories"). This decides whether the
+   parity story + VRT spec are generated (A / B) or the component is added
+   to `PARITY_EXEMPT` (C / D). Ask with `AskUserQuestion`, four options:
+   - **A — 完全 vanilla 可** — renders + behaves fully in vanilla HTML from
+     the `.st-*` chain + HTML/ARIA attributes (Button / Badge / Callout /
+     Text / Icon / Separator / Spinner). → parity generated.
+   - **B — ブラウザがハンドル** — vanilla-renderable; the browser supplies the
+     interactivity (form controls: Input / Textarea / Checkbox / Switch /
+     Radio). → parity generated.
+   - **C — 静的描画のみ / JS 位置決め要** — static markup is renderable but
+     positioning / trigger needs JS (Tooltip). → PARITY_EXEMPT, no parity.
+   - **D — JS 必須 / compound / imperative** — open/close/select/focus-trap
+     needs Radix-equivalent JS Schatten doesn't ship (Select / Dialog /
+     Toast). → PARITY_EXEMPT, no parity.
+
+   **Auto-suggest a default from the earlier answers, but let the user
+   confirm.** Heuristic for the pre-selected option:
+   - Form pattern (item 2) → suggest **B**.
+   - Compound (item 4) or imperative API → suggest **D**.
+   - Portal-positioned single surface (Tooltip-like) → suggest **C**.
+   - Otherwise (Role-based / Display, flat, fully static) → suggest **A**.
+
+   **⚠️ Do not conflate this 区分 with the prop-API Pattern from item 2.**
+   Both vocabularies use the letters A / B but they are orthogonal: Badge is
+   prop-Pattern **B** (Tone × Shape) yet parity-区分 **A**; Input is the
+   **Form** pattern yet parity-区分 **B**. Always state the 区分 in full
+   ("parity 区分 A") when confirming, so the answer can't be misread as the
+   prop pattern.
 
 Do not invent variant vocabulary — subset the canonical lists; extending them
 requires a discussion per `component-api-conventions.md`.
@@ -126,12 +174,31 @@ requires a discussion per `component-api-conventions.md`.
    `@import "../components/lv1/<Name>/<Name>.css";` in the
    "Component CSS" block so the new rules land in the integrated
    `dist/schatten.css` alongside the per-component subpath.
+7. **Branch on the parity 区分 from Step 2 item 6:**
+   - **区分 A / B** — also copy the two parity templates
+     (`Component.parity.stories.tsx.template` →
+     `src/components/lv1/<Name>/<Name>.parity.stories.tsx`,
+     `Component.parity.vrt.spec.ts.template` →
+     `src/components/lv1/<Name>/<Name>.parity.vrt.spec.ts`), substitute the
+     placeholder tokens, and fill in the `TODO(<Name>)` markers: mirror every
+     variant × size of the React component with the hand-written vanilla
+     `.st-*` chain, inlining any icon SVG and copying the same a11y
+     attributes (`aria-hidden` on decorative SVG, `aria-busy` / `disabled` on
+     state). `Button.parity.stories.tsx` is the reference.
+   - **区分 C / D** — do **not** copy the parity templates. Instead edit
+     [`scripts/audit-coverage.mjs`](../../../scripts/audit-coverage.mjs):
+     insert `<Name>` into the `PARITY_EXEMPT` set **in alphabetical order**
+     (the set is `new Set(['Dialog', 'Select', 'Toast', 'Tooltip'])` today —
+     e.g. adding `Popover` yields
+     `new Set(['Dialog', 'Popover', 'Select', 'Toast', 'Tooltip'])`). This is
+     the only edit to that file — the audit logic is unchanged.
 
 ### Step 4 — Strip the scaffold residue
 
 The templates carry placeholders that are **not** meant to survive into a
 finished component. After Step 3, grep the generated files and make sure none
-of these remain:
+of these remain. The `src/components/lv1/<Name>` glob already covers the
+parity files when they were generated (区分 A / B):
 
 ```sh
 grep -rn 'it\.todo(\|describe each option here\|TODO(\|__ComponentName__\|__componentName__\|__component-name__' \

--- a/.claude/skills/add-lv1-component/SKILL.md
+++ b/.claude/skills/add-lv1-component/SKILL.md
@@ -131,6 +131,19 @@ choices are closed.
    - Portal-positioned single surface (Tooltip-like) → suggest **C**.
    - Otherwise (Role-based / Display, flat, fully static) → suggest **A**.
 
+   **When genuinely borderline, default to A / B (generate parity), not
+   C / D.** This is the *opposite* of `vrt-spec-guideline.md`'s "default to
+   skip" — that doc advises a maintainer auditing an *existing* component,
+   where adding parity later is non-breaking churn. Here you are scaffolding
+   a *new* lv1, and the failure mode is the expensive one: mis-routing a
+   区分 A / B component to C / D means it ships with **no parity VRT**, so a
+   React-vs-vanilla pixel drift goes uncaught (the #302 class of silent
+   bug). A wrongly-generated parity story is a one-line delete; a missing one
+   is an invisible gap. Reach for C / D only when the component genuinely
+   cannot render + behave in vanilla HTML (compound / imperative / JS-driven
+   positioning); if you can picture a consumer writing the `.st-*` chain by
+   hand and expecting it to work, it is A / B.
+
    **⚠️ Do not conflate this 区分 with the prop-API Pattern from item 2.**
    Both vocabularies use the letters A / B but they are orthogonal: Badge is
    prop-Pattern **B** (Tone × Shape) yet parity-区分 **A**; Input is the

--- a/.claude/skills/add-lv1-component/templates.test.ts
+++ b/.claude/skills/add-lv1-component/templates.test.ts
@@ -4,13 +4,18 @@ import { fileURLToPath } from 'node:url'
 import ts from 'typescript'
 import { describe, expect, it } from 'vitest'
 
-// The 7 placeholder templates in `templates/` are expanded by the
+// The 9 placeholder templates in `templates/` are expanded by the
 // add-lv1-component skill, but carry a `.template` extension so neither
 // `tsc` nor Biome inspects them during normal CI. This test is the standing
 // guard: it expands every template with a probe name and asserts the result
 // is syntactically valid TypeScript (or CSS — see the TS-skip branch below)
 // so a template that drifts into broken syntax is caught here, not the
 // next time someone runs the skill.
+//
+// The 9 split into a core-7 set (always generated, every classification)
+// and a parity-2 set (`*.parity.*`, generated only for 区分 A / B
+// components — 区分 C / D are PARITY_EXEMPT). See
+// `.claude/rules/vrt-spec-guideline.md` §"Parity stories".
 
 const here = dirname(fileURLToPath(import.meta.url))
 const templatesDir = join(here, 'templates')
@@ -32,8 +37,33 @@ function expand(source: string): string {
 const templates = readdirSync(templatesDir).filter((file) => file.endsWith('.template'))
 
 describe('add-lv1-component templates', () => {
-  it('ships exactly the documented 7-file set', () => {
+  it('ships exactly the documented 9-file set', () => {
     expect([...templates].sort()).toEqual([
+      'Component.css.template',
+      'Component.parity.stories.tsx.template',
+      'Component.parity.vrt.spec.ts.template',
+      'Component.stories.tsx.template',
+      'Component.test.tsx.template',
+      'Component.tsx.template',
+      'Component.vrt.spec.ts.template',
+      'index.ts.template',
+      'variants.ts.template',
+    ])
+  })
+
+  // The 9 templates split by *when* the skill emits them: the core-7 are
+  // generated for every new lv1 regardless of classification; the parity-2
+  // are emitted only for 区分 A / B components (区分 C / D are PARITY_EXEMPT
+  // in scripts/audit-coverage.mjs and ship no parity files).
+  it('classifies templates into the core-7 and parity-2 sets', () => {
+    const parity = templates.filter((file) => file.includes('.parity.')).sort()
+    const core = templates.filter((file) => !file.includes('.parity.')).sort()
+
+    expect(parity).toEqual([
+      'Component.parity.stories.tsx.template',
+      'Component.parity.vrt.spec.ts.template',
+    ])
+    expect(core).toEqual([
       'Component.css.template',
       'Component.stories.tsx.template',
       'Component.test.tsx.template',

--- a/.claude/skills/add-lv1-component/templates/Component.parity.stories.tsx.template
+++ b/.claude/skills/add-lv1-component/templates/Component.parity.stories.tsx.template
@@ -1,0 +1,49 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { __ComponentName__ } from './__ComponentName__'
+
+/**
+ * Parity stories — the React `<__ComponentName__>` and a hand-written vanilla
+ * element carrying the matching `.st-*` class chain must render
+ * pixel-identical. Backs the VRT in `__ComponentName__.parity.vrt.spec.ts`.
+ *
+ * Only author this story for 区分 A / B components (per
+ * `.claude/rules/vrt-spec-guideline.md` §"Parity stories — when to write one,
+ * when to skip"). 区分 C / D components are PARITY_EXEMPT and ship no parity
+ * story at all.
+ *
+ * Authoring contract:
+ * - Mirror every variant × size the React side exposes on the vanilla side.
+ * - Inline any icon SVG so the vanilla column has no React dependency, and
+ *   carry the same a11y attributes (`aria-hidden="true"` on decorative SVG,
+ *   `aria-busy` / `disabled` on loading/disabled states, etc.).
+ * - `asChild` and other React-only APIs are out of parity scope.
+ */
+const meta: Meta<typeof __ComponentName__> = {
+  title: 'Components/lv1/__ComponentName__',
+  component: __ComponentName__,
+  parameters: {
+    layout: 'padded',
+  },
+}
+
+export default meta
+type Story = StoryObj<typeof __ComponentName__>
+
+export const Parity: Story = {
+  name: 'React vs Vanilla HTML',
+  render: () => (
+    <div className="grid grid-cols-2 gap-12 max-w-5xl">
+      <div className="space-y-4">
+        <p className="text-xs mb-2 text-foreground-muted">React</p>
+        {/* TODO(__ComponentName__): render every variant×size of the React component here */}
+        <__ComponentName__ />
+      </div>
+
+      <div className="space-y-4">
+        <p className="text-xs mb-2 text-foreground-muted">Vanilla HTML</p>
+        {/* TODO(__ComponentName__): mirror every variant×size with the .st-* class chain */}
+        <div className="st-__component-name__" />
+      </div>
+    </div>
+  ),
+}

--- a/.claude/skills/add-lv1-component/templates/Component.parity.vrt.spec.ts.template
+++ b/.claude/skills/add-lv1-component/templates/Component.parity.vrt.spec.ts.template
@@ -1,0 +1,44 @@
+import { expect, test } from '@playwright/test'
+
+const STORY_ID_PREFIX = 'components-lv1-__component-name__'
+
+const stories = ['parity'] as const
+
+const themes = ['light', 'dark'] as const
+
+function storyUrl(storyId: string, theme: string) {
+  return `/iframe.html?id=${STORY_ID_PREFIX}--${storyId}&globals=theme:${theme}&viewMode=story`
+}
+
+for (const story of stories) {
+  for (const theme of themes) {
+    test(`__ComponentName__ parity / ${story} / ${theme}`, async ({ page }) => {
+      await page.goto(storyUrl(story, theme))
+      await page.waitForLoadState('networkidle')
+
+      const root = page.locator('#storybook-root')
+      await root.waitFor({ state: 'visible', timeout: 10_000 })
+      await page.waitForFunction(
+        () => {
+          const el = document.querySelector('#storybook-root')
+          return el && el.children.length > 0
+        },
+        { timeout: 10_000 },
+      )
+
+      // Pause animations and freeze transitions so the React side and the
+      // vanilla side settle to the same still frame before the screenshot.
+      await page.addStyleTag({
+        content: `
+          *, *::before, *::after {
+            animation-play-state: paused !important;
+            animation-delay: -0.0001s !important;
+            transition: none !important;
+          }
+        `,
+      })
+
+      await expect(root).toHaveScreenshot(`parity-${story}-${theme}.png`)
+    })
+  }
+}

--- a/scripts/__tests__/audit-coverage.test.ts
+++ b/scripts/__tests__/audit-coverage.test.ts
@@ -1,11 +1,13 @@
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { existsSync, mkdirSync, mkdtempSync, rmSync, statSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
-import { join } from 'node:path'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import {
   auditComponent,
   discoverComponents,
   hasFailures,
+  PARITY_EXEMPT,
   parseExportedNames,
   renderJson,
   renderTable,
@@ -403,5 +405,29 @@ describe('runAudit', () => {
 
     writeBarrel(lv1Dir, ['Button', 'PhantomDir'])
     expect(hasFailures(runAudit(workDir))).toBe(true)
+  })
+})
+
+describe('PARITY_EXEMPT', () => {
+  // The set is hand-maintained (see the MAINTENANCE comment in
+  // audit-coverage.mjs) — the add-lv1-component skill inserts a C/D
+  // component alphabetically rather than generating a parity story+spec.
+  // These guards turn "inserted in the wrong order" / "named a directory
+  // that doesn't exist" from a silent audit mis-classification into a CI
+  // failure, since nothing else pins the contents of the set.
+  const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '../..')
+  const lv1Dir = join(repoRoot, 'src/components/lv1')
+
+  it('is declared in alphabetical order', () => {
+    const entries = [...PARITY_EXEMPT]
+    expect(entries).toEqual([...entries].sort())
+  })
+
+  it('lists only real lv1 component directories', () => {
+    for (const name of PARITY_EXEMPT) {
+      const dir = join(lv1Dir, name)
+      expect(existsSync(dir), `${name} is in PARITY_EXEMPT but ${dir} does not exist`).toBe(true)
+      expect(statSync(dir).isDirectory(), `${dir} is not a directory`).toBe(true)
+    }
   })
 })

--- a/scripts/audit-coverage.d.mts
+++ b/scripts/audit-coverage.d.mts
@@ -49,6 +49,14 @@ export interface RenderJsonOptions {
   readonly generatedAt?: string
 }
 
+/**
+ * Components in parity classification C / D (per
+ * .claude/rules/vrt-spec-guideline.md) that intentionally ship no parity
+ * story+spec. Hand-maintained in alphabetical order; the contents are
+ * pinned by scripts/__tests__/audit-coverage.test.ts.
+ */
+export const PARITY_EXEMPT: ReadonlySet<string>
+
 export function discoverComponents(lv1Dir: string): string[]
 
 export function parseExportedNames(indexPath: string): Set<string>

--- a/scripts/audit-coverage.mjs
+++ b/scripts/audit-coverage.mjs
@@ -46,7 +46,7 @@ const INDEX_FILE_REL = 'src/components/lv1/index.ts'
 // next door. If lv1 count grows past ~30 and tracking gets noisy,
 // promote to a `// schatten-classification: B` header comment that
 // gets parsed.
-const PARITY_EXEMPT = new Set(['Dialog', 'Select', 'Toast', 'Tooltip'])
+export const PARITY_EXEMPT = new Set(['Dialog', 'Select', 'Toast', 'Tooltip'])
 
 // Match `from './<name>'` / `from "./<name>"`. Same shape as
 // scripts/check-lv1-export-integrity.mjs — kept in sync deliberately.

--- a/scripts/audit-coverage.mjs
+++ b/scripts/audit-coverage.mjs
@@ -37,7 +37,11 @@ const INDEX_FILE_REL = 'src/components/lv1/index.ts'
 // the parity story would be performative.
 //
 // MAINTENANCE: when a new lv1 lands that is classification C or D,
-// add it here. The hard-code is acceptable today because the set is
+// add it here (alphabetically). The add-lv1-component skill keeps this
+// set in sync automatically — its Step 2 区分 question routes a C/D
+// component to an alphabetical insert here instead of generating the
+// parity story+spec (see .claude/skills/add-lv1-component/SKILL.md
+// Step 3 item 7). The hard-code is acceptable today because the set is
 // small (4 components) and the source of truth lives in the rule doc
 // next door. If lv1 count grows past ~30 and tracking gets noisy,
 // promote to a `// schatten-classification: B` header comment that


### PR DESCRIPTION
## What

`add-lv1-component` skill に parity 区分 (A/B/C/D) の選択ステップを追加。
- 区分 A/B → parity story + VRT spec を生成 (新規 2 template)
- 区分 C/D → `scripts/audit-coverage.mjs` の `PARITY_EXEMPT` へ昇順挿入し parity をスキップ
- Step 2 で prop-API Pattern との A/B 文字衝突を警告、earlier answers から区分を自動推定して既定提示

## Why

skill は今まで parity 系列ファイルを一切生成しておらず、区分 A/B コンポーネント
追加時に手動で parity を足す/区分 C/D で PARITY_EXEMPT を手で更新する必要があった。
分類を skill 内に取り込み、audit-coverage の exempt セットを構造的に同期させる。

## Related rules

- `.claude/rules/vrt-spec-guideline.md` §"Parity stories — when to write one, when to skip"
- `.claude/rules/component-api-conventions.md` (prop Pattern と parity 区分 の直交性)

## Test plan

- [x] `pnpm lint` 緑
- [x] `pnpm test --run` 緑 (templates.test.ts 7→9 ファイルセット検証含む)
- [x] `pnpm typecheck` 緑

closes #306

🤖 Generated with [Claude Code](https://claude.com/claude-code)
