### PR TITLE
refactor(tokens): brand vermillion (朱) を真朱 #E73121 系へ retune (closes #322)

### DIFF
--- a/.changeset/vermillion-shu-retune-30c8.md
+++ b/.changeset/vermillion-shu-retune-30c8.md
@@ -1,0 +1,5 @@
+---
+'@yasmro/schatten': patch
+---
+
+ブランド朱 `vermillion-*` の hue/彩度を伝統的な真朱（Figma vermilion `#E73121` 系）へ retune。hue 22（crimson 寄り）→ hue 30（橙寄り・高彩度）に全 shade を引き直した。鮮やかなブランドアンカーは `-500`（≈ `#ed3726`）、実表示の brand solid 面は AA 安全な `-600`（≈ `#d02718`）。solid AA は light `#fafafa`×600 = 5.04:1 / dark `#1a1a1a`×400 = 6.53:1 で両方 PASS、全 shade sRGB gamut 内。semantic 名（`--color-vermillion` / `--color-vermillion-foreground`）は不変で値のみ変更（非破壊）。危険色 `red-*`（`--color-error` / `--color-destructive`）は #239 の結論どおり hue 22 据え置きで無影響。VRT 再ベースラインを伴う。

--- a/src/core/tokens/primitives.css
+++ b/src/core/tokens/primitives.css
@@ -55,24 +55,31 @@
   --paper-warm-inverted: #1e1e1c;
   --paper-cream-inverted: #44403a;
 
-  /* Brand: Vermillion (朱) — Japanese traditional vermillion, brand anchor: 600 ≈ #c53d43.
-   * The first brand color; backs the --color-vermillion semantic only. Danger colors
-   * (--color-error / --color-destructive) reference the separate `red` scale below. */
-  --vermillion-50: oklch(0.98 0.02 22);
-  --vermillion-100: oklch(0.96 0.04 22);
-  --vermillion-200: oklch(0.91 0.08 22);
-  --vermillion-300: oklch(0.83 0.13 22);
-  --vermillion-400: oklch(0.74 0.17 22);
-  --vermillion-500: oklch(0.64 0.18 22);
-  --vermillion-600: oklch(0.56 0.17 22);
-  --vermillion-700: oklch(0.46 0.14 22);
-  --vermillion-800: oklch(0.36 0.11 22);
-  --vermillion-900: oklch(0.27 0.07 22);
-  --vermillion-950: oklch(0.15 0.05 22);
+  /* Brand: Vermillion (朱) — Japanese traditional 真朱, retuned toward Figma vermilion
+   * #E73121 (hue 30, more orange / higher chroma than the former crimson-leaning hue 22).
+   * The vivid brand anchor lives at 500 (≈ #ed3726, ≈ #E73121); the displayed brand solid
+   * surface uses 600 (≈ #d02718) because #E73121 itself sits in an AA dead zone (white text
+   * 4.14:1 / dark text 4.03:1 — both fail). --color-vermillion-foreground = paper-white, so
+   * solid AA passes: light fafafa × 600 = 5.04:1, dark 1a1a1a × 400 = 6.53:1. All shades are
+   * inside the sRGB gamut at hue 30. Backs the --color-vermillion semantic only; danger colors
+   * (--color-error / --color-destructive) reference the separate `red` scale below, which is
+   * deliberately NOT retuned (see #239 / #322). */
+  --vermillion-50: oklch(0.975 0.012 30);
+  --vermillion-100: oklch(0.95 0.025 30);
+  --vermillion-200: oklch(0.9 0.05 30);
+  --vermillion-300: oklch(0.82 0.1 30);
+  --vermillion-400: oklch(0.72 0.172 30);
+  --vermillion-500: oklch(0.62 0.22 30);
+  --vermillion-600: oklch(0.555 0.205 30);
+  --vermillion-700: oklch(0.46 0.165 30);
+  --vermillion-800: oklch(0.36 0.125 30);
+  --vermillion-900: oklch(0.27 0.085 30);
+  --vermillion-950: oklch(0.155 0.05 30);
 
-  /* red — danger/error 専用スケール。現状 vermillion と同値だが、ブランド朱と
-     危険赤を独立に retune できるよう意図的に分離した継ぎ目。error/destructive のみが参照する。
-     色味を分岐させるかは #239 (design spike) で扱う。統合しないこと。 */
+  /* red — danger/error 専用スケール。ブランド朱と危険赤を独立に retune できるよう
+     意図的に分離した継ぎ目。error/destructive のみが参照する。#239 (design spike) の結論で
+     危険赤は hue 22 据え置きとし、色味の分岐は vermillion 側 (#322, 真朱 #E73121 系へ) で
+     発生させた。よって以下は #238 時点の旧 vermillion と同値のまま。統合しないこと。 */
   --red-50: oklch(0.98 0.02 22);
   --red-100: oklch(0.96 0.04 22);
   --red-200: oklch(0.91 0.08 22);

--- a/src/core/tokens/primitives.test.ts
+++ b/src/core/tokens/primitives.test.ts
@@ -5,14 +5,34 @@ import { describe, expect, it } from 'vitest'
 /**
  * Guards the `red` ⇄ `vermillion` governance seam introduced in #238.
  *
- * `red` (danger/error) and `vermillion` (brand 朱) are deliberately
- * separate primitives, but until design spike #239 decides whether danger
- * red should diverge in hue, the two scales MUST hold identical values.
- * Nothing else enforces that — this test fails if one scale is edited
- * without the other, so the seam can't silently drift.
+ * `red` (danger/error) and `vermillion` (brand 朱) are deliberately separate
+ * primitives. They shipped value-identical in #238 as a pure structural seam;
+ * #239 (design spike) then concluded that danger `red` stays put (hue 22) and
+ * that the brand should diverge instead, which #322 did by retuning
+ * `vermillion` toward 真朱 `#E73121` (hue 30). The two scales are therefore now
+ * intentionally different.
+ *
+ * This test pins `red` to its frozen hue-22 danger ramp so the danger color
+ * can't silently drift now that it's the stable side, and asserts the seam has
+ * actually diverged so a future accidental "re-sync" of the scales is caught.
  */
 
 const SHADES = ['50', '100', '200', '300', '400', '500', '600', '700', '800', '900', '950'] as const
+
+/** Frozen danger-red ramp (hue 22). #239 concluded this stays put. */
+const FROZEN_RED: Record<(typeof SHADES)[number], string> = {
+  '50': 'oklch(0.98 0.02 22)',
+  '100': 'oklch(0.96 0.04 22)',
+  '200': 'oklch(0.91 0.08 22)',
+  '300': 'oklch(0.83 0.13 22)',
+  '400': 'oklch(0.74 0.17 22)',
+  '500': 'oklch(0.64 0.18 22)',
+  '600': 'oklch(0.56 0.17 22)',
+  '700': 'oklch(0.46 0.14 22)',
+  '800': 'oklch(0.36 0.11 22)',
+  '900': 'oklch(0.27 0.07 22)',
+  '950': 'oklch(0.15 0.05 22)',
+}
 
 const primitivesCss = readFileSync(resolve(process.cwd(), 'src/core/tokens/primitives.css'), 'utf8')
 
@@ -31,12 +51,25 @@ describe('red / vermillion primitive seam (#238)', () => {
     }
   })
 
-  it('keeps --red-* value-identical to --vermillion-* until #239', () => {
+  it('keeps --red-* pinned to the frozen hue-22 danger ramp (#239 据え置き)', () => {
     for (const shade of SHADES) {
       expect(
         readPrimitive('red', shade),
-        `--red-${shade} must equal --vermillion-${shade} until #239 — do not diverge the scales here`,
-      ).toBe(readPrimitive('vermillion', shade))
+        `--red-${shade} must stay on the frozen hue-22 danger ramp — #239 concluded danger red does not diverge`,
+      ).toBe(FROZEN_RED[shade])
     }
+  })
+
+  it('has diverged from --vermillion-* (#322 retuned the brand to 真朱 #E73121)', () => {
+    // The brand retune moved vermillion to hue 30; the seam exists precisely so
+    // this can happen without dragging danger red along. If the two scales ever
+    // become value-identical again, the seam has been accidentally collapsed.
+    const sameEverywhere = SHADES.every(
+      (shade) => readPrimitive('red', shade) === readPrimitive('vermillion', shade),
+    )
+    expect(
+      sameEverywhere,
+      'red and vermillion must not be re-synced — they diverged intentionally in #322',
+    ).toBe(false)
   })
 })

--- a/src/core/tokens/semantic.css
+++ b/src/core/tokens/semantic.css
@@ -55,8 +55,8 @@
    *
    * Both brand colors share one shade rule: `-600` in light, `-400`
    * in dark. This is the only pair where every `*-foreground`-on-base
-   * solid pairing clears WCAG AA for both hues (vermillion light 4.86 /
-   * dark 6.84, indigo light 7.03 / dark 5.73). A 1-step shift (`-600`/
+   * solid pairing clears WCAG AA for both hues (vermillion light 5.04 /
+   * dark 6.53, indigo light 7.03 / dark 5.73). A 1-step shift (`-600`/
    * `-500`) would fail indigo dark; `-500`/`-400` would fail vermillion
    * light — the hue ramps differ, so the AA-safe shade is mode-driven,
    * not 1-step-driven.

--- a/src/docs/Color.stories.tsx
+++ b/src/docs/Color.stories.tsx
@@ -517,8 +517,12 @@ export const Colors: Story = {
 
       <SubsectionTitle>Vermillion (朱)</SubsectionTitle>
       <p className="text-sm text-foreground-muted mb-3">
-        Traditional Japanese vermillion red — the primary Schatten brand color, surfaced at the
-        semantic layer as <code>--color-vermillion</code>.
+        Traditional Japanese 真朱 (hue 30) — the primary Schatten brand color, surfaced at the
+        semantic layer as <code>--color-vermillion</code>. The vivid brand anchor is{' '}
+        <code>-500</code> (≈ <code>#ed3726</code>); the displayed solid surface (
+        <code>--color-vermillion</code>) uses <code>-600</code> in light / <code>-400</code> in
+        dark, which are the AA-safe shades — <code>#E73121</code> itself sits in an AA dead zone, so
+        the brand reference color is not used directly as a solid surface.
       </p>
       <ScaleRow
         shades={[
@@ -560,9 +564,10 @@ export const Colors: Story = {
 
       <SubsectionTitle>Red</SubsectionTitle>
       <p className="text-sm text-foreground-muted mb-3">
-        Danger scale — backs the <code>error</code> and <code>destructive</code> semantics. A
-        value-identical copy of <code>vermillion</code> today; kept as a separate primitive so brand
-        朱 and danger red can be retuned independently (see issue #239).
+        Danger scale (hue 22) — backs the <code>error</code> and <code>destructive</code> semantics.
+        A separate primitive from brand <code>vermillion</code> so the two can be retuned
+        independently; #239 concluded danger red stays put while #322 retuned brand 朱 toward 真朱
+        (hue 30), so the scales now hold intentionally different values.
       </p>
       <ScaleRow
         shades={[


### PR DESCRIPTION
## What

ブランド朱 `--vermillion-*` を hue 22 → hue 30 の真朱 (Figma vermilion
`#E73121` 系) へ全 shade retune。危険赤 `--red-*` は変更なし。

- vivid brand anchor: `-500` ≈ `#ed3726`
- 表示 brand solid 面: `-600` ≈ `#d02718` (AA 安全)
- `--color-vermillion` / `--color-vermillion-foreground` の semantic 名は不変

## Why

#238 の red/vermillion 分離 seam は「ブランド朱と危険赤を独立に retune
できる継ぎ目」として入れたもの。#239 (design spike) は危険赤を hue 22
据え置きと結論。本 PR はその結論に従い、divergence をブランド側だけに
発生させる — seam が初めて片側だけ動く実例。`#E73121` 自体は AA dead zone
(white 4.14:1 / dark 4.03:1) なので vivid anchor (-500) と表示 solid (-600)
を分離。

## Related rules

- [.claude/rules/state-token-guideline.md](.claude/rules/state-token-guideline.md) — three-layer hierarchy / red vs vermillion seam
- [.claude/rules/api-stability.md](.claude/rules/api-stability.md) — token 値 retune は非破壊 (patch)
- [.claude/rules/theme-architecture.md](.claude/rules/theme-architecture.md) — primitives は theme 非依存

## Test plan

- [x] `pnpm lint` 緑
- [x] `pnpm test --run` 緑 (666 tests; seam guard 書き換え済み)
- [x] `pnpm typecheck` 緑
- [x] Storybook `Foundation/Color` で primitive→semantic chain をライブ確認
- [ ] VRT baseline は CI で再生成 (`Foundation/Color` 等が drift)

closes #322

🤖 Generated with [Claude Code](https://claude.com/claude-code)
