### PR TITLE
docs(csp): strict-CSP setup guide + schatten:csp-hash CLI + snippet byte contract (closes #262)

### DIFF
--- a/.changeset/csp-setup-guide-and-hash-cli-d7e1.md
+++ b/.changeset/csp-setup-guide-and-hash-cli-d7e1.md
@@ -1,0 +1,27 @@
+---
+'@yasmro/schatten': patch
+---
+
+Document how to run the FOUC-avoidance snippet under a strict Content-Security-Policy,
+and pin its byte stability as a contract (#262).
+
+- **README `### CSP setup guide`** — promotes the former inline "Strict CSP
+  environments" note into a full section: nonce recipes for Next.js / Astro /
+  Remix (with the CSPRNG-per-response requirement and the Next.js
+  nonce × static-cache footgun called out), the hash-pin recipe with the
+  published `sha256-…` and a standalone Node one-liner for custom `storageKey`,
+  the externalized-`.js` fallback, recommended baseline directives
+  (`object-src 'none'` / `base-uri 'self'`), and the anti-patterns to avoid
+  (never `'unsafe-inline'`, never a static/`Math.random()` nonce).
+- **`pnpm schatten:csp-hash`** (`scripts/print-csp-hash.mjs`) — a maintainer
+  CLI that prints the `script-src` source expression for the snippet, reading
+  the shipped `dist/theme-init/index.js`. Pass `--key=<storageKey>` for a
+  custom key. Not consumer-facing.
+- **API stability contract** — `.claude/rules/api-stability.md` now records the
+  FOUC snippet bytes (`THEME_INIT_SCRIPT` / `buildThemeInitScript()`) as public
+  surface: changing them is a `major`, and such a changeset must include the
+  regenerated `sha256-…` so CSP consumers can re-pin.
+
+Docs + maintainer tooling only — no component / lv1 / lv2 / CSS API change.
+The `<ThemeInitScript>` component and `@yasmro/schatten/theme-init` entry
+themselves shipped in #261.

--- a/.claude/rules/api-stability.md
+++ b/.claude/rules/api-stability.md
@@ -35,7 +35,8 @@ CHANGELOG:
 | CVA output strings | The class string returned by `buttonVariants({ variant: 'primary' })` |
 | Multi-entry exports | `@yasmro/schatten/components/lv1`, `/tokens`, `/variants`, `/themes/default`, `/themes/seasonal`, `/providers` |
 | Theme contract | Which CSS variables a custom theme must define to be valid |
-| Provider runtime contract | The `localStorage` key (`'schatten-theme'`) and JSON shape (`{ mode, special }`) that `<ThemeProvider>` reads/writes. This is the contract the FOUC inline snippet ([#129](https://github.com/yasmro/schatten/issues/129)) and any consumer-side persistence code depends on. Renaming the key, adding/removing a field, or changing field semantics is a breaking change. See [#262](https://github.com/yasmro/schatten/issues/262) for the upcoming SHA-256 hash publication that further pins the inline snippet body. |
+| Provider runtime contract | The `localStorage` key (`'schatten-theme'`) and JSON shape (`{ mode, special }`) that `<ThemeProvider>` reads/writes. This is the contract the FOUC inline snippet ([#129](https://github.com/yasmro/schatten/issues/129)) and any consumer-side persistence code depends on. Renaming the key, adding/removing a field, or changing field semantics is a breaking change. |
+| FOUC snippet bytes | The exact byte sequence of `THEME_INIT_SCRIPT` (and the output of `buildThemeInitScript()`). Consumers paste its SHA-256 into a `script-src 'sha256-…'` CSP directive, so the bytes themselves are public surface. See [FOUC snippet byte stability](#fouc-snippet-byte-stability-theme_init_script) below. |
 
 ## What is **not** public API
 
@@ -117,6 +118,12 @@ notes in the changeset body so they end up in the rendered CHANGELOG; for
 large migrations, also publish a standalone guide under `docs/migrations/`
 and link to it from the changeset.
 
+When the FOUC snippet bytes change (a `major` — see
+[FOUC snippet byte stability](#fouc-snippet-byte-stability-theme_init_script)),
+the changeset description **must** include the new `sha256-…` so CSP consumers
+can re-pin without rebuilding the package themselves. Regenerate it with
+`pnpm schatten:csp-hash`.
+
 Example (illustrative — uses a hypothetical rename):
 
 ```md
@@ -158,6 +165,42 @@ The implications:
   `major`.
 - Adding a new variant option to an existing prop (e.g. `<Button variant="ghost">`
   when only `primary | secondary` existed) is `minor` — additive.
+
+## FOUC snippet byte stability (`THEME_INIT_SCRIPT`)
+
+The FOUC-avoidance snippet shipped from `@yasmro/schatten/theme-init`
+(`THEME_INIT_SCRIPT`, and the output of `buildThemeInitScript(storageKey)`)
+is an **inline `<script>` body** consumers drop into their document `<head>`
+to set the theme before first paint. In a strict Content-Security-Policy
+environment, an inline script only runs if its SHA-256 is allow-listed via a
+`script-src 'sha256-…'` source expression. That makes the *exact bytes* of
+the snippet public API — analogous to [CVA output stability](#cva-output-stability):
+the value a consumer pins is derived from the string we emit, so we can't
+change the string without breaking their pin.
+
+The contract:
+
+- **The byte sequence of `THEME_INIT_SCRIPT` is frozen across non-major
+  releases.** Any change — even a semantically-neutral whitespace or
+  identifier tweak — shifts the SHA-256 and silently breaks every
+  hash-pinning consumer's CSP (the snippet stops executing, FOUC returns).
+  Changing it is a `major`.
+- **`buildThemeInitScript()`'s output shape is equally frozen.** Consumers on
+  a custom `storageKey` recompute their own hash from it, so the template
+  around the key is contract; only the interpolated key differs.
+- **The published default-key hash is
+  `sha256-YKmfjVUKTYOL4QdVTkV/AUzMrHhhfPw//OthidDmEEE=`.** It is byte-pinned
+  in CI by [`src/theme-init.test.ts`](../../src/theme-init.test.ts) (the
+  snippet → hash direction) and
+  [`scripts/__tests__/print-csp-hash.test.ts`](../../scripts/__tests__/print-csp-hash.test.ts)
+  (the maintainer CLI emits the same string a consumer pastes). A snippet
+  edit fails both tests, so the breaking change cannot land silently — the
+  red test is the forcing function that routes it through the `major` +
+  changeset process below.
+- **Regenerate the hash with `pnpm schatten:csp-hash`** (reads the built
+  `dist/theme-init/index.js`; pass `--key=<storageKey>` for a custom key).
+  This is a maintainer command, not consumer-facing — see the script header
+  in [`scripts/print-csp-hash.mjs`](../../scripts/print-csp-hash.mjs).
 
 ## Peer dependency ranges
 

--- a/README.md
+++ b/README.md
@@ -368,16 +368,11 @@ export default function App() {
 
 #### Strict CSP environments
 
-If your CSP forbids inline scripts, either (a) pass `nonce` to
-`<ThemeInitScript nonce={cspNonce} />` (or set it on your own inline
-`<script>`) matching your `script-src 'nonce-…'` directive, (b) move
-the snippet into a standalone `.js` file served from your own origin and
-reference it with `<script src="/theme-init.js">`, or (c) pin the
-default-key snippet by hash with
-`script-src 'sha256-YKmfjVUKTYOL4QdVTkV/AUzMrHhhfPw//OthidDmEEE='`
-(the digest of `THEME_INIT_SCRIPT`; pinned by `theme-init.test.ts` so a byte
-change fails CI — [#262](https://github.com/yasmro/schatten/issues/262) will
-publish it as a documented constant).
+If your Content-Security-Policy forbids inline scripts, the snippet needs an
+explicit allowance — by `nonce`, by `hash`, or by externalizing it. See the
+dedicated [CSP setup guide](#csp-setup-guide) below for copy-paste recipes
+(Next.js / Astro / Remix), the security must-fixes, and the anti-patterns to
+avoid.
 
 The snippet runs **synchronously** and **must not be deferred** — `defer`
 / `async` / loading from a delayed CDN re-introduces the flash this
@@ -397,6 +392,176 @@ If you customize `storageKey` on the Provider, pass the same key to
 `buildThemeInitScript('my-key')` from `@yasmro/schatten/theme-init` for the
 string form). The two values are a public contract: a mismatch silently
 breaks FOUC avoidance with no error.
+
+### CSP setup guide
+
+The FOUC snippet is an **inline `<script>`**. Under a strict
+Content-Security-Policy (one without `'unsafe-inline'` in `script-src`) the
+browser blocks it unless you explicitly allow it. There are three ways, in
+descending order of preference.
+
+> **Schatten never requires `'unsafe-inline'`.** If a guide tells you to add
+> `'unsafe-inline'` to `script-src` to make the snippet run, stop — that
+> disables the protection your CSP exists to provide and is never necessary
+> here. Use a nonce or a hash instead. (Schatten also does **not** require
+> `style-src 'unsafe-inline'`: the stylesheet is a static `<link>`, not an
+> inline `<style>`.)
+
+#### Option A — nonce (recommended for SSR)
+
+A nonce is a per-response random token. You generate it on the server, put it
+in both the CSP header and the `<script nonce>`, and the browser runs only
+scripts carrying the matching token. `<ThemeInitScript nonce={…} />` forwards
+the value onto the emitted `<script>`.
+
+**The nonce must be cryptographically random and regenerated on every
+response.** Use a CSPRNG (`crypto.randomBytes` in Node, `crypto.getRandomValues`
+in the Edge/Web runtime) — **never** `Math.random()`, a build-time constant, or
+a reused value. A predictable or static nonce is equivalent to no nonce at all.
+
+**Next.js App Router** — generate the nonce in `middleware.ts`, set the CSP
+header, and read it back in the layout:
+
+```ts
+// middleware.ts
+import { NextResponse } from 'next/server'
+
+export function middleware() {
+  const nonce = Buffer.from(crypto.randomUUID()).toString('base64')
+  const csp = [
+    `script-src 'self' 'nonce-${nonce}'`,
+    `style-src 'self'`,
+    `object-src 'none'`,
+    `base-uri 'self'`,
+  ].join('; ')
+
+  const requestHeaders = new Headers()
+  requestHeaders.set('x-nonce', nonce)
+  const res = NextResponse.next({ request: { headers: requestHeaders } })
+  res.headers.set('Content-Security-Policy', csp)
+  return res
+}
+```
+
+```tsx
+// app/layout.tsx
+import { headers } from 'next/headers'
+import { ThemeInitScript, ThemeProvider } from '@yasmro/schatten/providers'
+
+export default async function RootLayout({ children }: { children: React.ReactNode }) {
+  const nonce = (await headers()).get('x-nonce') ?? undefined
+  return (
+    <html lang="en" suppressHydrationWarning>
+      <head>
+        <ThemeInitScript nonce={nonce} />
+      </head>
+      <body>
+        <ThemeProvider defaultMode="system">{children}</ThemeProvider>
+      </body>
+    </html>
+  )
+}
+```
+
+> **Next.js nonce × static caching footgun.** Reading the nonce via
+> `headers()` opts the route into dynamic rendering. If you instead try to
+> nonce a *statically cached* page, every visitor is served the same cached
+> nonce — which defeats the nonce entirely. Either keep the page dynamic (as
+> above) or pin the snippet by hash (Option B) for static pages. Do **not**
+> reach for `'strict-dynamic'` to paper over this; it changes how the rest of
+> your `script-src` is interpreted and is unrelated to running this one inline
+> snippet.
+
+**Astro** — Astro exposes a per-request nonce when CSP is enabled; pass it to
+your own inline `<script>` (Astro islands don't render `<ThemeInitScript />`
+directly, so use the string form):
+
+```astro
+---
+// src/layouts/Base.astro
+import { THEME_INIT_SCRIPT } from '@yasmro/schatten/theme-init'
+const nonce = Astro.locals.cspNonce // however your middleware exposes it
+---
+<head>
+  <script nonce={nonce} is:inline set:html={THEME_INIT_SCRIPT} />
+</head>
+```
+
+**Remix** — generate the nonce in your `entry.server.tsx`, thread it through
+the loader context, and pass it to `<ThemeInitScript nonce={nonce} />` in
+`root.tsx` (same shape as the Next.js layout above).
+
+#### Option B — hash (recommended for static pages)
+
+A hash pin allow-lists the snippet by the SHA-256 of its exact bytes — no
+per-response work, so it survives static caching. Add the published digest of
+the default-key snippet to `script-src`:
+
+```
+Content-Security-Policy: script-src 'self' 'sha256-YKmfjVUKTYOL4QdVTkV/AUzMrHhhfPw//OthidDmEEE='; object-src 'none'; base-uri 'self'
+```
+
+This digest is the hash of `THEME_INIT_SCRIPT` (default `storageKey`
+`'schatten-theme'`). It is byte-pinned in CI, so a snippet change can't drift
+the published value silently — and any such change ships as a `major` (see the
+[API stability contract](.claude/rules/api-stability.md)).
+
+**Availability trap — a custom `storageKey` changes the hash.** If you pass a
+non-default `storageKey`, the snippet bytes differ and the digest above no
+longer matches; the browser will block the script. Recompute the hash for your
+key with a tiny Node one-liner (no repo checkout needed — it uses the published
+`buildThemeInitScript`):
+
+```js
+import { createHash } from 'node:crypto'
+import { buildThemeInitScript } from '@yasmro/schatten/theme-init'
+
+const script = buildThemeInitScript('my-app-theme') // your storageKey
+const hash = createHash('sha256').update(script, 'utf8').digest('base64')
+console.log(`sha256-${hash}`)
+```
+
+(Maintainers of this repo can instead run `pnpm schatten:csp-hash`, or
+`pnpm schatten:csp-hash --key=my-app-theme` for a custom key — it reads the
+built `dist/` so the hash is taken from exactly the shipped bytes.)
+
+#### Option C — externalize the snippet
+
+If you'd rather not manage a nonce or a hash, copy the snippet into a static
+`.js` file served from your own origin and reference it:
+
+```html
+<head>
+  <script src="/theme-init.js"></script>
+  <link rel="stylesheet" href="/path/to/schatten.css" />
+</head>
+```
+
+`script-src 'self'` then covers it with no extra directive. The cost is that
+you now own a copy of the bytes and must re-sync it when you upgrade Schatten
+across a `major` that changes the snippet. Generate the file contents from
+`THEME_INIT_SCRIPT` / `buildThemeInitScript(key)` rather than hand-copying, so
+the copy can't drift.
+
+#### Recommended baseline directives
+
+Whichever option you choose, harden the surrounding policy:
+
+- `object-src 'none'` — there's no legitimate `<object>`/`<embed>` use here,
+  and it closes a common injection vector.
+- `base-uri 'self'` — stops an injected `<base>` tag from rewriting every
+  relative URL on the page.
+
+#### Anti-patterns to avoid
+
+- ❌ Adding `'unsafe-inline'` to `script-src` "to make it work" — use a nonce
+  or hash; `'unsafe-inline'` re-opens the hole the CSP closes.
+- ❌ A static or `Math.random()` nonce — it must be a fresh CSPRNG value per
+  response.
+- ❌ Nonce-ing a statically cached page — the nonce is cached and reused; pin
+  by hash (Option B) instead.
+- ❌ `defer` / `async` on the snippet — it must run synchronously before first
+  paint, or the flash returns.
 
 ### Remix
 

--- a/package.json
+++ b/package.json
@@ -102,6 +102,7 @@
     "check:readme": "node scripts/sync-readme-components.mjs --check",
     "check:use-client": "node scripts/check-use-client-banner.mjs",
     "audit:coverage": "node scripts/audit-coverage.mjs",
+    "schatten:csp-hash": "node scripts/print-csp-hash.mjs",
     "check:layer-order": "node scripts/check-layer-order.mjs",
     "build:storybook": "storybook build",
     "test": "vitest",

--- a/scripts/__tests__/print-csp-hash.test.ts
+++ b/scripts/__tests__/print-csp-hash.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest'
+import { buildThemeInitScript, THEME_INIT_SCRIPT } from '../../src/theme-init'
+import { computeCspHash } from '../csp-hash.mjs'
+
+// Pins the CLI's hashing logic against the published CSP source expression.
+// The byte-level pin lives in src/theme-init.test.ts; this test guards the
+// other half of the contract — that `pnpm schatten:csp-hash` emits the SAME
+// string a consumer pastes into `script-src`. It imports the snippet from
+// `src/` (not from `dist/`) so it runs without a build; the CLI's dist-reading
+// glue is trivial and exercised at release time by `pnpm build` + a manual run.
+
+describe('computeCspHash', () => {
+  it('reproduces the published default-key hash', () => {
+    expect(computeCspHash(THEME_INIT_SCRIPT)).toBe(
+      'sha256-YKmfjVUKTYOL4QdVTkV/AUzMrHhhfPw//OthidDmEEE=',
+    )
+  })
+
+  it('matches the default build of buildThemeInitScript', () => {
+    expect(computeCspHash(buildThemeInitScript('schatten-theme'))).toBe(
+      computeCspHash(THEME_INIT_SCRIPT),
+    )
+  })
+
+  it('produces a different hash for a custom storageKey', () => {
+    // The availability trap documented in the README: a custom key changes the
+    // bytes, so the default-key pin no longer matches and CSP would block the
+    // script. The hashes must differ for that warning to be real.
+    expect(computeCspHash(buildThemeInitScript('my-app-theme'))).not.toBe(
+      computeCspHash(THEME_INIT_SCRIPT),
+    )
+  })
+
+  it('emits the sha256- prefix CSP expects', () => {
+    expect(computeCspHash('anything')).toMatch(/^sha256-[A-Za-z0-9+/]+=*$/)
+  })
+})

--- a/scripts/csp-hash.d.mts
+++ b/scripts/csp-hash.d.mts
@@ -1,0 +1,6 @@
+// TypeScript declarations for scripts/csp-hash.mjs. The .mjs carries the
+// implementation; the test imports `computeCspHash` from a .ts module, so an
+// explicit .d.mts gives TypeScript a typed view of the export without
+// converting the script to .ts.
+
+export function computeCspHash(script: string): string

--- a/scripts/csp-hash.mjs
+++ b/scripts/csp-hash.mjs
@@ -1,0 +1,11 @@
+// The CSP `script-src` source expression (`sha256-<base64>`) for a snippet
+// string. Extracted into its own module — with no dynamic `import()` — so the
+// unit test (scripts/__tests__/print-csp-hash.test.ts) can pin the hashing
+// logic against the published value without Vite's import-analysis tripping
+// over the dist-loading dynamic import in print-csp-hash.mjs.
+
+import { createHash } from 'node:crypto'
+
+export function computeCspHash(script) {
+  return `sha256-${createHash('sha256').update(script, 'utf8').digest('base64')}`
+}

--- a/scripts/print-csp-hash.mjs
+++ b/scripts/print-csp-hash.mjs
@@ -1,0 +1,51 @@
+#!/usr/bin/env node
+// Maintainer tool — print the CSP `script-src` source expression
+// (`sha256-<base64>`) for the FOUC inline snippet.
+//
+// This is NOT a consumer-facing command (an npm consumer can't run a repo
+// `pnpm` script). It exists for the maintainer who intentionally changes the
+// snippet bytes — a `major` per `.claude/rules/api-stability.md` — and needs
+// the new hash to publish in the changeset and update the README pin.
+//
+// Default-key consumers read the published hash straight from the README /
+// `theme-init.test.ts`; consumers on a custom `storageKey` recompute it with
+// the standalone Node recipe in the README (which uses the published
+// `buildThemeInitScript` from `@yasmro/schatten/theme-init`), not this script.
+//
+// Reads from `dist/theme-init/index.js` — the built form of
+// `@yasmro/schatten/theme-init` — so the hash is taken from exactly the bytes
+// shipped to npm, never from un-built source that could drift. Run
+// `pnpm build` first.
+//
+// Usage:
+//   pnpm schatten:csp-hash                 # default storageKey ('schatten-theme')
+//   pnpm schatten:csp-hash --key=my-theme  # custom storageKey
+
+import { existsSync } from 'node:fs'
+import path from 'node:path'
+import { computeCspHash } from './csp-hash.mjs'
+
+// `computeCspHash` lives in ./csp-hash.mjs so the unit test can import the
+// hashing logic without pulling in the dist-loading dynamic `import()` below
+// (which Vite's import-analysis can't transform). See
+// scripts/__tests__/print-csp-hash.test.ts.
+
+async function main() {
+  const distEntry = new URL('../dist/theme-init/index.js', import.meta.url)
+  if (!existsSync(distEntry)) {
+    process.stderr.write('dist/theme-init/index.js not found — run `pnpm build` first.\n')
+    process.exit(1)
+  }
+  const { THEME_INIT_SCRIPT, buildThemeInitScript } = await import(distEntry.href)
+  const keyArg = process.argv.find((a) => a.startsWith('--key='))
+  const script = keyArg ? buildThemeInitScript(keyArg.slice('--key='.length)) : THEME_INIT_SCRIPT
+  process.stdout.write(`${computeCspHash(script)}\n`)
+}
+
+const isCliEntry = import.meta.url === `file://${path.resolve(process.argv[1] ?? '')}`
+if (isCliEntry) {
+  main().catch((err) => {
+    process.stderr.write(`${err}\n`)
+    process.exit(1)
+  })
+}


### PR DESCRIPTION
## What

- README に `### CSP setup guide` を新設 — FOUC snippet を strict CSP 下で
  動かす nonce / hash / externalize の 3 ルートと、推奨 directives・anti-pattern を文書化。
- `pnpm schatten:csp-hash` maintainer CLI を追加（`scripts/print-csp-hash.mjs`、
  hashing は `scripts/csp-hash.mjs` に分離 + unit test で公開ハッシュを pin）。
- `.claude/rules/api-stability.md` に FOUC snippet bytes の byte-stability 契約
  と「bytes 変更時は changeset に再生成 sha256 を含める」ルールを追記。

実装コード（`<ThemeInitScript>` / `@yasmro/schatten/theme-init`）は #261 で
landed 済み。本 PR に production code 変更はなし。

## Why

#262 は「strict CSP 環境で FOUC snippet をどう動かすか」を消費者に示し、
snippet のバイト列を安定性契約として固定するための docs + tooling タスク。
custom storageKey でバイト列が変わると default-key hash が一致せず CSP が
script を block する availability trap を、CLI と README で明示する。

## Related rules

- [.claude/rules/api-stability.md](.claude/rules/api-stability.md) — FOUC snippet byte-stability 契約を追記
- Provider runtime contract（`schatten-theme` key / `{ mode, special }`）に整合

## Test plan

- [x] `pnpm lint` 緑
- [x] `pnpm test --run` 緑（677 tests、うち print-csp-hash 4 件で公開ハッシュを pin）
- [x] `pnpm typecheck` 緑

closes #262

🤖 Generated with [Claude Code](https://claude.com/claude-code)
