### PR TITLE
fix(Button): prevent React.Children.only crash on asChild + link

### DIFF
--- a/.changeset/button-aschild-link-crash.md
+++ b/.changeset/button-aschild-link-crash.md
@@ -1,0 +1,11 @@
+---
+'@yasmro/schatten': patch
+---
+
+Fix: `<Button asChild variant="link">` no longer throws `React.Children.only
+expected to receive a single React element child`. The `link` branch wraps
+`children` with two icon-conditional siblings, so combining it with
+`asChild` handed Radix `Slot` more than one child. The `asChild` path is now
+resolved before the `link` branch, so a single child always reaches `Slot`.
+As with the other `asChild` paths, `icon` / `isLoading` are not projected
+onto the child — author the inner content yourself.

--- a/src/components/lv1/Button/Button.test.tsx
+++ b/src/components/lv1/Button/Button.test.tsx
@@ -125,6 +125,20 @@ describe('Button', () => {
       const svg = button.querySelector(':scope > svg')
       expect(svg).toBeInTheDocument()
     })
+
+    it('renders a single-child anchor when asChild is combined with link', () => {
+      // Regression: the link branch wrapped children with icon-conditional
+      // siblings, so `<Button asChild variant="link">` handed Slot >1 child
+      // and threw `React.Children.only`. asChild is now resolved before the
+      // link branch, so a single child reaches Slot.
+      render(
+        <Button asChild variant="link">
+          <a href="/docs">Docs</a>
+        </Button>,
+      )
+      const link = screen.getByRole('link', { name: 'Docs' })
+      expect(link).toHaveClass('st-btn', 'st-btn--link')
+    })
   })
 
   describe('isLoading', () => {

--- a/src/components/lv1/Button/Button.tsx
+++ b/src/components/lv1/Button/Button.tsx
@@ -73,26 +73,14 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
     // Matches the Badge precedent (#267 sweep-2).
     const isIconOnly = !children && !!icon
 
-    // Link variant — different DOM shape (inline, no spinner overlay, no
-    // content wrapper). Early-return here so .st-btn--link's CSS overrides
-    // (display: inline, height: auto, padding: 0) apply cleanly to a flat
-    // element tree. isLoading is not supported on link (mirrors the
-    // pre-sweep behaviour — link is a text affordance, not an async CTA).
-    if (variant === 'link') {
-      return (
-        <Comp
-          className={cn(buttonVariants({ variant, size }), className)}
-          ref={ref}
-          disabled={disabled}
-          {...props}
-        >
-          {IconComponent && iconPosition === 'start' && <IconComponent aria-hidden="true" />}
-          {children}
-          {IconComponent && iconPosition === 'end' && <IconComponent aria-hidden="true" />}
-        </Comp>
-      )
-    }
-
+    // asChild — delegate rendering to the single child via Radix Slot.
+    // Checked BEFORE the `link` branch on purpose: the link branch wraps
+    // children with icon-conditional siblings, which would hand Slot more
+    // than one child and trip `React.Children.only`. Routing every asChild
+    // case (including `variant="link"`) through here keeps Slot's
+    // single-child contract intact. Like the spinner path, `icon` /
+    // `isLoading` are not projected onto the child — author the inner
+    // content (including any icon) yourself.
     if (asChild) {
       if (process.env.NODE_ENV !== 'production' && isLoading) {
         console.warn('Button: `isLoading` prop is ignored when `asChild` is true.')
@@ -108,6 +96,27 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
           {...props}
         >
           {children}
+        </Comp>
+      )
+    }
+
+    // Link variant — different DOM shape (inline, no spinner overlay, no
+    // content wrapper). Early-return here so .st-btn--link's CSS overrides
+    // (display: inline, height: auto, padding: 0) apply cleanly to a flat
+    // element tree. isLoading is not supported on link (mirrors the
+    // pre-sweep behaviour — link is a text affordance, not an async CTA).
+    // `asChild` is handled above, so `Comp` is always `'button'` here.
+    if (variant === 'link') {
+      return (
+        <Comp
+          className={cn(buttonVariants({ variant, size }), className)}
+          ref={ref}
+          disabled={disabled}
+          {...props}
+        >
+          {IconComponent && iconPosition === 'start' && <IconComponent aria-hidden="true" />}
+          {children}
+          {IconComponent && iconPosition === 'end' && <IconComponent aria-hidden="true" />}
         </Comp>
       )
     }


### PR DESCRIPTION
## Summary

`<Button asChild variant="link">` threw at render time:
`React.Children.only expected to receive a single React element child`.

**Root cause:** the `variant === 'link'` branch in [`Button.tsx`](src/components/lv1/Button/Button.tsx) renders `{iconStart}{children}{iconEnd}` — three children even when the icon conditionals are falsy. With `asChild`, `Comp` is Radix `Slot`, which requires exactly one child, so `React.Children.only` throws. The non-link `asChild` branch renders only `{children}`, so `<Button asChild>` / `<Button asChild variant="secondary">` already worked.

**Fix:** resolve the `asChild` path **before** the `link` branch, so every `asChild` case (including `variant="link"`) hands `Slot` a single child. Pure control-flow reorder — output is identical for every previously-working path; only the previously-crashing asChild+link case changes (now renders the child anchor with the `st-btn st-btn--link` chain). As with the other asChild paths, `icon` / `isLoading` are not projected onto the child.

## Test plan

- [x] New regression test in `Button.test.tsx`: `<Button asChild variant="link"><a/></Button>` renders an `<a>` (link role) with the link class chain and does not throw.
- [x] `pnpm typecheck` / `pnpm lint`
- [x] `pnpm test --run` — 679 passed
- [x] Reorder is output-identical for existing paths; CI VRT re-confirms no Button baseline drift.

## Context

Discovered while authoring the `Patterns/Composition with asChild` docs page (#141 / #339), which intentionally omitted the link example because of this crash. With this fix, that example could be added back in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #341
