### PR TITLE
feat(storybook): addon-a11y を導入し dev 時 a11y パネルを追加 (closes #148)

### DIFF
--- a/.changeset/storybook-addon-a11y-148-b3f1.md
+++ b/.changeset/storybook-addon-a11y-148-b3f1.md
@@ -1,0 +1,7 @@
+---
+'@yasmro/schatten': patch
+---
+
+Storybook に `@storybook/addon-a11y` を導入し、dev 時に各 story の a11y 違反を
+パネル表示する。axe の scan 面は VRT (`@axe-core/playwright`, #147) と同じ
+WCAG 2.1 A/AA タグに pin し、Phase 1 は observe-only (`test: 'todo'`)。

--- a/.claude/rules/storybook-guideline.md
+++ b/.claude/rules/storybook-guideline.md
@@ -120,6 +120,66 @@ When you change a prop's description, **update TSDoc first**, then sync
 - Always include `tags: ['autodocs']` to enable auto-generated documentation.
 - Set `parameters: { layout: 'centered' }` unless the component requires full-width layout.
 
+## a11y (addon-a11y)
+
+`@storybook/addon-a11y` runs an [axe-core](https://github.com/dequelabs/axe-core)
+scan against the rendered story and surfaces violations / passes / incomplete
+in the **Accessibility** panel. It is the **dev-time companion** to the
+`@axe-core/playwright` VRT assertions ([#147](https://github.com/yasmro/schatten/issues/147)):
+the panel lets you catch an a11y regression *while editing*, the VRT specs gate
+it in CI. The two are deliberately the same axe surface — see below.
+
+### Configuration is global, in `.storybook/preview.tsx`
+
+The addon is registered in [`.storybook/main.ts`](../../.storybook/main.ts)
+(`addons: ['@storybook/addon-docs', '@storybook/addon-a11y']`) and configured
+once via `parameters.a11y` in [`.storybook/preview.tsx`](../../.storybook/preview.tsx):
+
+```tsx
+a11y: {
+  options: {
+    runOnly: { type: 'tag', values: ['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa'] },
+  },
+  test: 'todo',
+}
+```
+
+- **`options.runOnly` MUST pin the same WCAG tag set the VRT specs use**
+  (`.withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa'])` — see
+  [vrt-spec-guideline §a11y assertions](vrt-spec-guideline.md#a11y-assertions-axe--paired-with-every-vrt-test)).
+  Without it, axe also runs *best-practice* rules (`region` /
+  `landmark-one-main` / `page-has-heading-one`) that flag the Storybook iframe
+  itself on every story — pure noise. Keeping the tag set identical means
+  "green in the dev panel" maps to the same contract CI enforces.
+- **`test: 'todo'`** keeps the addon observe-only. The `test` flag only bites
+  through the test addon (`@storybook/addon-vitest`), which is not wired up
+  today, so it is inert — but it documents the Phase-1 stance. Promotion to
+  `'error'` rides with the CI blocking-gate work
+  ([#346](https://github.com/yasmro/schatten/issues/346)).
+- **Dark mode / seasonal violations come for free.** The addon scans the
+  rendered DOM *after* the global theme decorator applies `.dark` /
+  `data-theme` to `<html>`, so toggling the Theme toolbar surfaces dark-mode
+  contrast issues in the panel with no extra config.
+
+### Per-story rule disable — last resort, with a reason
+
+A known false positive or an intentionally-bare control story can disable a
+rule locally:
+
+```tsx
+export const SomeStory: Story = {
+  parameters: { a11y: { config: { rules: [{ id: 'color-contrast', enabled: false }] } } },
+}
+```
+
+Treat this like a `// biome-ignore` — **never silent**. The panel's whole
+value during the Phase-1 backlog cleanup (state-token contrast
+[#344](https://github.com/yasmro/schatten/issues/344), bare-control stories
+[#345](https://github.com/yasmro/schatten/issues/345)) is making pre-existing
+violations visible, so do not blanket-disable a rule globally. When a per-story
+disable is genuinely warranted, leave a one-line comment naming the reason and,
+if it tracks a backlog item, the issue.
+
 ## Story title taxonomy (IA)
 
 The Storybook sidebar's **top level is a fixed set of 7 groups** (depth ≤ 2),

--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -2,7 +2,7 @@ import type { StorybookConfig } from '@storybook/react-vite'
 
 const config: StorybookConfig = {
   stories: ['../src/**/*.stories.@(js|jsx|mjs|ts|tsx)'],
-  addons: ['@storybook/addon-docs'],
+  addons: ['@storybook/addon-docs', '@storybook/addon-a11y'],
   framework: {
     name: '@storybook/react-vite',
     options: {},

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -70,6 +70,26 @@ const preview: Preview = {
     },
     backgrounds: { disabled: true },
     layout: 'fullscreen',
+    a11y: {
+      // Pin the dev-time a11y panel (addon-a11y) to the SAME WCAG 2.1 A/AA
+      // surface the VRT axe assertions use (`.withTags([...])` in every
+      // *.vrt.spec.ts, #147). Without `runOnly`, axe also runs best-practice
+      // rules (`region` / `landmark-one-main` / `page-has-heading-one`) that
+      // flag the Storybook iframe itself (no landmarks, no <h1>) on every
+      // story — pure noise. Keeping the tag set identical means "green in the
+      // dev panel" maps to the same contract CI enforces.
+      options: {
+        runOnly: {
+          type: 'tag',
+          values: ['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa'],
+        },
+      },
+      // Phase 1 (observe-only): surface violations in the panel, block nothing.
+      // `test` only bites once the test addon (@storybook/addon-vitest) is
+      // wired up — unused today, so 'todo' is inert but documents the stance.
+      // Promotion to 'error' rides with the CI blocking work (#346).
+      test: 'todo',
+    },
     options: {
       storySort: {
         order: [

--- a/package.json
+++ b/package.json
@@ -148,6 +148,7 @@
     "@playwright/test": "^1.58.2",
     "@radix-ui/react-dialog": "^1.1.4",
     "@size-limit/preset-small-lib": "^12.1.0",
+    "@storybook/addon-a11y": "10.4.1",
     "@storybook/addon-docs": "10.4.1",
     "@storybook/react-vite": "10.4.1",
     "@tailwindcss/cli": "^4.2.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -66,6 +66,9 @@ importers:
       '@size-limit/preset-small-lib':
         specifier: ^12.1.0
         version: 12.1.0(size-limit@12.1.0(jiti@2.7.0))
+      '@storybook/addon-a11y':
+        specifier: 10.4.1
+        version: 10.4.1(storybook@10.4.1(@testing-library/dom@10.4.1)(@types/react@19.2.15)(prettier@2.8.8)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))
       '@storybook/addon-docs':
         specifier: 10.4.1
         version: 10.4.1(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(esbuild@0.27.4)(rollup@4.60.0)(storybook@10.4.1(@testing-library/dom@10.4.1)(@types/react@19.2.15)(prettier@2.8.8)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(vite@7.3.3(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0))
@@ -1861,6 +1864,11 @@ packages:
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
+  '@storybook/addon-a11y@10.4.1':
+    resolution: {integrity: sha512-MGft/IXjJ20a9KbaSVG9bHTAAoanbucKrgEiJJRNqpim8DsXA01+XTdSk17LmiOCB203Rrq9mWgdQ6+79cc8iA==}
+    peerDependencies:
+      storybook: ^10.4.1
 
   '@storybook/addon-docs@10.4.1':
     resolution: {integrity: sha512-IYqUdjoZe4VO2LFZlKL/gwy7DsQSWCq6hX+zc1MBmZo04yycDASk1tte57n9pdlW3ajw9yYMF/+lVBi+xQjyvw==}
@@ -4977,6 +4985,12 @@ snapshots:
       size-limit: 12.1.0(jiti@2.7.0)
 
   '@standard-schema/spec@1.1.0': {}
+
+  '@storybook/addon-a11y@10.4.1(storybook@10.4.1(@testing-library/dom@10.4.1)(@types/react@19.2.15)(prettier@2.8.8)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))':
+    dependencies:
+      '@storybook/global': 5.0.0
+      axe-core: 4.11.4
+      storybook: 10.4.1(@testing-library/dom@10.4.1)(@types/react@19.2.15)(prettier@2.8.8)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
 
   '@storybook/addon-docs@10.4.1(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(esbuild@0.27.4)(rollup@4.60.0)(storybook@10.4.1(@testing-library/dom@10.4.1)(@types/react@19.2.15)(prettier@2.8.8)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(vite@7.3.3(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0))':
     dependencies:

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -2,6 +2,8 @@
   "extends": "./tsconfig.json",
   "include": [
     "src/**/*",
+    ".storybook/**/*.ts",
+    ".storybook/**/*.tsx",
     "biome-plugins/**/*.ts",
     "scripts/**/*.test.ts",
     "scripts/**/*.d.mts",


### PR DESCRIPTION
## What

`@storybook/addon-a11y@10.4.1`（exact pin）を導入。`.storybook/main.ts` に addon
登録、`.storybook/preview.tsx` に `parameters.a11y` を追加し、各 story の axe
scan 結果を Accessibility パネルに表示する。

## Why

dev 時に即座に a11y 違反へ気づける手段が無かった。VRT の axe assertion (#147)
が CI gate を担う一方、本 PR はその dev-time の対（開発者が Storybook で気づく
→ CI で gate）。

## Key decisions

- `options.runOnly` を VRT の `.withTags([...])` と同一の WCAG 2.1 A/AA タグに
  pin。`runOnly` 無しだと best-practice ルール（`region` / `landmark-one-main`
  / `page-has-heading-one`）が Storybook iframe 自体を毎 story 誤検出してノイズ
  になるため。dev パネルと CI が同じ契約面を見る。
- `test: 'todo'`（observe-only）。test addon 未導入で今は inert だが Phase 1 の
  立場を明示。`'error'` 昇格は CI blocking 作業 (#346) と並走。
- contrast ルールは ON 継続（global 無効化しない）— 既存バックログ #344/#345 の
  可視化と、開発中の新規退行検出を優先。

## Related rules

- [.claude/rules/storybook-guideline.md](.claude/rules/storybook-guideline.md) に `## a11y (addon-a11y)` セクション追加
- [.claude/rules/vrt-spec-guideline.md](.claude/rules/vrt-spec-guideline.md)（VRT axe と同一タグ面の根拠）

## Test plan

- [x] `pnpm lint` 緑
- [x] `pnpm test --run` 緑 (679 passed)
- [x] `pnpm typecheck` 緑
- [ ] **手動 (要レビュアー確認)**: `pnpm dev` → 任意 story 右パネルに Accessibility
      タブ表示 / Theme を Dark に切替えて dark contrast 違反が反映 / best-practice
      ノイズ（`region` 等）が出ないこと
- [ ] Docs タブのレンダリング遅延が許容範囲か（パフォーマンス確認）

closes #148

🤖 Generated with [Claude Code](https://claude.com/claude-code)
