### PR TITLE
docs(storybook): Tokens/Motion ストーリーを追加 (closes #137)

### DIFF
--- a/.changeset/tokens-motion-story-7b3e.md
+++ b/.changeset/tokens-motion-story-7b3e.md
@@ -1,0 +1,12 @@
+---
+'@yasmro/schatten': patch
+---
+
+docs(storybook): `Tokens/Motion` ストーリーを追加。共有 duration scale
+(`--st-duration-fast/base/slow` = 100/150/200ms) を用途名・semantic alias
+(`--motion-*`)・消費 component 付きで可視化し、各値を体感できるインタラクティブ
+demo (prefers-reduced-motion 自己対応) を載せた。`--motion-*` は applied 0 の
+define-only として明示し、用途別ガイドと設計原則 (reduced-motion 必須 / loop は
+component CSS / 不要 animation 禁止) を整理。時間 token は静止 PNG に写らないため
+VRT は付けず、値は `Motion.drift.test.ts` + `resolution.test.ts` で pin。可視化
+対象 token は #145 で追加済のため公開 API は不変。

--- a/src/docs/Motion.drift.test.ts
+++ b/src/docs/Motion.drift.test.ts
@@ -1,0 +1,50 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+/*
+ * Motion docs drift guard.
+ *
+ * `Motion.stories.tsx` renders the duration scale two ways:
+ *   - the demo knobs use `var(--st-duration-*)`, so they always track the source;
+ *   - the value table prints the *literal* duration string for documentation.
+ *
+ * That printed literal is a hand-copy of `src/core/tokens/animation.css`. The
+ * semantic side (`--motion-* → --st-duration-*`) is covered by the var()
+ * reference + resolution.test.ts, but the literal primitive durations have no
+ * other source of truth, so a future re-tune of `--st-duration-*` would leave
+ * the docs table showing a stale value with nothing to catch it. This test pins
+ * the two together by parsing both files as text (same regex-over-source
+ * approach as Elevation.drift.test.ts / Radius.drift.test.ts).
+ */
+
+const ANIMATION_CSS = readFileSync(resolve(__dirname, '../core/tokens/animation.css'), 'utf8')
+const STORY_SRC = readFileSync(resolve(__dirname, 'Motion.stories.tsx'), 'utf8')
+
+/** Literal `--st-duration-{token}: <value>;` declarations from animation.css. */
+function cssDuration(token: string): string {
+  const match = ANIMATION_CSS.match(new RegExp(`--st-duration-${token}:\\s*([^;]+);`))
+  if (!match) throw new Error(`--st-duration-${token} not declared in animation.css`)
+  return match[1].trim()
+}
+
+/** The `{ token: '…', value: '…', … }` entries from the story's DURATION_SCALE. */
+const storyDurations = new Map(
+  [...STORY_SRC.matchAll(/\{ token: '(\w+)', value: '([^']+)'/g)].map(
+    ([, token, value]) => [token, value] as const,
+  ),
+)
+
+const DURATION_TOKENS = ['fast', 'base', 'slow'] as const
+
+describe('Motion story ↔ animation.css --st-duration-* values', () => {
+  it('lists every duration step (fast/base/slow)', () => {
+    expect([...storyDurations.keys()].sort()).toEqual([...DURATION_TOKENS].sort())
+  })
+
+  for (const token of DURATION_TOKENS) {
+    it(`--st-duration-${token} matches the value printed in the docs table`, () => {
+      expect(storyDurations.get(token)).toBe(cssDuration(token))
+    })
+  }
+})

--- a/src/docs/Motion.stories.tsx
+++ b/src/docs/Motion.stories.tsx
@@ -1,0 +1,308 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { useEffect, useState } from 'react'
+import { Lead, Note, PageTitle, SectionTitle } from './docs-ui'
+
+const meta: Meta = {
+  title: 'Tokens/Motion',
+  parameters: {
+    layout: 'fullscreen',
+  },
+}
+
+export default meta
+type Story = StoryObj
+
+/**
+ * The shared enter/exit duration scale, sourced verbatim from
+ * `src/core/tokens/animation.css`. Three perceptually-distinct steps
+ * (fast 100ms / base 150ms / slow 200ms) registered in the `@theme` block of
+ * `base.css` and listed in the public manifest.
+ *
+ * `motion` is the semantic alias (`--motion-*`) layered over each step; `use`
+ * is the intent the step is reached for. The literal `value` is pinned against
+ * `animation.css` by `Motion.drift.test.ts` (the tiles below resolve `var()`,
+ * but the printed table is a hand-copy with no other source of truth).
+ */
+const DURATION_SCALE = [
+  { token: 'fast', value: '100ms', motion: 'quick', use: 'Hover, exit transitions' },
+  { token: 'base', value: '150ms', motion: 'base', use: 'Default, enter transitions' },
+  { token: 'slow', value: '200ms', motion: 'expressive', use: 'Dialog / drawer enter' },
+] as const
+
+/**
+ * The semantic (用途別) motion tokens, sourced verbatim from
+ * `src/core/tokens/animation.css`. Each is a value-preserving alias over a
+ * `--st-duration-*` step — no new timing, just an intent-named handle. The
+ * alias mapping is pinned by `resolution.test.ts`.
+ *
+ * All three are `defined-only`: no component references `--motion-*` yet
+ * (hover transitions are still hardcoded). This is an accepted, visualized
+ * state — see css-api.md "Define-only single-value semantic tokens are
+ * allowed" and the same treatment of `--radius-control` / `--shadow-card`.
+ */
+const SEMANTIC_MOTION = [
+  {
+    name: 'quick',
+    alias: 'fast',
+    status: 'defined-only',
+    usedBy: '— (future: hover feedback — hardcoded today)',
+  },
+  {
+    name: 'base',
+    alias: 'base',
+    status: 'defined-only',
+    usedBy: '— (future: default interactions — hardcoded today)',
+  },
+  {
+    name: 'expressive',
+    alias: 'slow',
+    status: 'defined-only',
+    usedBy: '— (future: dialog / drawer — enter uses --st-duration-slow today)',
+  },
+] as const
+
+const StatusBadge = ({ status }: { status: 'applied' | 'defined-only' }) =>
+  status === 'applied' ? (
+    <span className="rounded-full bg-success-subtle px-2 py-0.5 text-xs font-medium text-success">
+      applied
+    </span>
+  ) : (
+    <span className="rounded-full bg-warning-subtle px-2 py-0.5 text-xs font-medium text-warning">
+      defined only
+    </span>
+  )
+
+/**
+ * Interactive timing demo. A single toggle drives all three knobs at once, so
+ * the faster step settles visibly before the slower one — the difference a
+ * still screenshot can't convey (which is why this page ships no VRT spec).
+ *
+ * Honours `prefers-reduced-motion` itself: under `reduce` the transition is
+ * dropped and a notice is shown, practising design principle #1 below.
+ */
+const DurationDemo = () => {
+  const [on, setOn] = useState(false)
+  const [reduced, setReduced] = useState(false)
+
+  useEffect(() => {
+    const mq = window.matchMedia('(prefers-reduced-motion: reduce)')
+    setReduced(mq.matches)
+    const handler = (e: MediaQueryListEvent) => setReduced(e.matches)
+    mq.addEventListener('change', handler)
+    return () => mq.removeEventListener('change', handler)
+  }, [])
+
+  return (
+    <div className="rounded-xl border border-border p-6">
+      <button
+        type="button"
+        onClick={() => setOn((v) => !v)}
+        className="rounded-md bg-foreground px-4 py-2 text-sm font-medium text-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+      >
+        {on ? 'Reset knobs' : 'Run transition'}
+      </button>
+
+      {reduced && (
+        <Note>
+          <code>prefers-reduced-motion: reduce</code> is active — the demo runs without a
+          transition, so motion is never forced on you.
+        </Note>
+      )}
+
+      <div className="mt-5 flex flex-col gap-4">
+        {DURATION_SCALE.map((d) => (
+          <div key={d.token} className="flex items-center gap-4">
+            <span className="w-40 shrink-0 text-xs font-mono text-foreground">
+              --st-duration-{d.token}
+            </span>
+            <div className="relative h-8 flex-1 overflow-hidden rounded-lg border border-border bg-surface">
+              <div
+                aria-hidden="true"
+                className="absolute top-1 h-6 w-6 rounded bg-theme-500"
+                style={{
+                  left: on ? 'calc(100% - 1.75rem)' : '0.25rem',
+                  transition: reduced ? 'none' : `left var(--st-duration-${d.token}) ease`,
+                }}
+              />
+            </div>
+            <span className="w-16 shrink-0 text-right text-xs font-mono text-foreground-muted tabular-nums">
+              {d.value}
+            </span>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+export const DurationScale: Story = {
+  name: 'Duration Scale',
+  render: () => (
+    <div className="max-w-3xl mx-auto px-8 py-12">
+      <PageTitle>Motion</PageTitle>
+      <Lead>
+        Schatten centralizes enter/exit timing in a three-step duration scale, defined in{' '}
+        <code>src/core/tokens/animation.css</code> and registered as part of the public token
+        surface via the <code>@theme</code> block in <code>base.css</code>. Components reference the
+        scale — or its semantic <code>--motion-*</code> aliases (see{' '}
+        <strong>Semantic Tokens</strong>) — never a hardcoded millisecond value.
+      </Lead>
+
+      <SectionTitle>Duration scale</SectionTitle>
+      <Note>
+        The raw <code>--st-duration-*</code> steps. <code>fast</code> / <code>base</code> /{' '}
+        <code>slow</code> are perceptually distinct; reach for a semantic <code>--motion-*</code>{' '}
+        alias in usage. Press <strong>Run transition</strong> to feel the difference — the faster
+        knob settles before the slower one.
+      </Note>
+
+      <DurationDemo />
+
+      <div className="mt-6 border border-border rounded-xl px-5">
+        {DURATION_SCALE.map((d) => (
+          <div
+            key={d.token}
+            className="flex items-center gap-4 py-3 border-b border-border last:border-b-0"
+          >
+            <p className="w-44 shrink-0 text-sm font-medium text-foreground font-mono">
+              --st-duration-{d.token}
+            </p>
+            <code className="w-16 shrink-0 text-xs text-foreground-muted tabular-nums">
+              {d.value}
+            </code>
+            <code className="w-32 shrink-0 text-xs text-foreground-muted">
+              → --motion-{d.motion}
+            </code>
+            <p className="flex-1 text-sm text-foreground-muted">{d.use}</p>
+          </div>
+        ))}
+      </div>
+    </div>
+  ),
+}
+
+export const SemanticTokens: Story = {
+  name: 'Semantic Tokens',
+  render: () => (
+    <div className="max-w-3xl mx-auto px-8 py-12">
+      <PageTitle>Semantic tokens</PageTitle>
+      <Lead>
+        Components reference these intent-named tokens, not the raw scale. Each is a
+        value-preserving alias over a <code>--st-duration-*</code> step — the table reads as{' '}
+        <strong>purpose → which duration step → which component uses it</strong>. All three are{' '}
+        <em>defined only</em> today: nothing references <code>--motion-*</code> yet.
+      </Lead>
+
+      <div className="border border-border rounded-xl px-5">
+        {SEMANTIC_MOTION.map((m) => (
+          <div
+            key={m.name}
+            className="flex items-center gap-4 py-4 border-b border-border last:border-b-0"
+          >
+            <div className="flex-1">
+              <p className="text-sm font-medium text-foreground font-mono">--motion-{m.name}</p>
+              <p className="text-xs text-foreground-muted font-mono">= --st-duration-{m.alias}</p>
+              <p className="text-xs text-foreground-muted mt-1">{m.usedBy}</p>
+            </div>
+            <div className="w-28 shrink-0">
+              <StatusBadge status={m.status} />
+            </div>
+          </div>
+        ))}
+      </div>
+
+      <SectionTitle>Define-only is intentional</SectionTitle>
+      <Note>
+        The <code>--motion-*</code> aliases are <strong>defined but not yet applied</strong>:
+        component hover transitions are still hardcoded, and unifying them onto the motion scale is
+        a separate spike. The tokens wait for that consumer rather than being wired in piecemeal.
+        This mirrors <code>--radius-control</code> in <strong>Tokens/Radius</strong> and{' '}
+        <code>--shadow-card</code> in <strong>Tokens/Elevation</strong> — a single-value semantic
+        token may sit define-only until its natural consumer lands (see css-api.md).
+      </Note>
+    </div>
+  ),
+}
+
+const GuideRow = ({ surface, token, note }: { surface: string; token: string; note: string }) => (
+  <div className="flex items-start gap-4 py-3 border-b border-border last:border-b-0">
+    <p className="w-28 shrink-0 text-sm font-medium text-foreground">{surface}</p>
+    <code className="w-44 shrink-0 text-xs text-foreground-muted">{token}</code>
+    <p className="flex-1 text-sm text-foreground-muted">{note}</p>
+  </div>
+)
+
+export const UsageGuide: Story = {
+  name: 'Usage Guide',
+  render: () => (
+    <div className="max-w-3xl mx-auto px-8 py-12">
+      <PageTitle>Usage guide</PageTitle>
+      <Lead>
+        Pick a duration by what the motion is <em>for</em>, not by an absolute millisecond count.
+        The named step already encodes the right pace.
+      </Lead>
+
+      <SectionTitle>By intent</SectionTitle>
+      <div className="border border-border rounded-xl px-5 mb-8">
+        <GuideRow
+          surface="Hover / exit"
+          token="--motion-quick"
+          note="Lightweight feedback that should feel near-instant. (Alias of --st-duration-fast.)"
+        />
+        <GuideRow
+          surface="Default / enter"
+          token="--motion-base"
+          note="The default for most enter transitions and focus rings. (Alias of --st-duration-base.)"
+        />
+        <GuideRow
+          surface="Dialog / drawer"
+          token="--motion-expressive"
+          note="Larger surfaces sliding in; slightly slower reads as deliberate. (Alias of --st-duration-slow.)"
+        />
+        <GuideRow
+          surface="Looping"
+          token="--st-spinner-*"
+          note="Continuous loops (spinner ripple) use component-scoped timing, distinct from the enter/exit scale."
+        />
+      </div>
+
+      <SectionTitle>Design principles</SectionTitle>
+      <Note>
+        <strong>Respect prefers-reduced-motion.</strong> Every animated component disables motion
+        under <code>@media (prefers-reduced-motion: reduce)</code> — see <code>Toast.css</code>,{' '}
+        <code>Dialog.css</code>, <code>Tooltip.css</code>. New motion must do the same; the demo on
+        the <strong>Duration Scale</strong> page does it too.
+      </Note>
+      <Note>
+        <strong>Loop animations live in component CSS.</strong> Continuous loops (spinner) are
+        authored as <code>@keyframes</code> in the component's own <code>.css</code>, not as a
+        transition token — see component-architecture §7.
+      </Note>
+      <Note>
+        <strong>Interactive feedback uses transition; enter/exit uses the scale.</strong> Reach for
+        a <code>transition</code> on hover/focus state; reach for <code>--st-duration-*</code> on
+        the mount/unmount keyframes.
+      </Note>
+      <Note>
+        <strong>Don't animate without a reason.</strong> Motion should communicate a state change.
+        If a transition doesn't help the user understand what changed, leave it out.
+      </Note>
+
+      <SectionTitle>Not yet tokenized</SectionTitle>
+      <Note>
+        Component <em>hover</em> transitions are still <strong>hardcoded</strong> today (e.g. Badge
+        at 150ms, others at 200ms) and do not yet reference <code>--motion-*</code>. Folding them
+        onto the motion scale is a separate spike. <em>Enter/exit</em> animations (Tooltip / Dialog
+        / Toast) already consume <code>--st-duration-*</code>.
+      </Note>
+
+      <SectionTitle>Deprecated: --transition-*</SectionTitle>
+      <Note>
+        The older <code>--transition-fast</code> / <code>-normal</code> / <code>-slow</code> (in{' '}
+        <code>spacing.css</code>) and <code>tokens.transition.*</code> are{' '}
+        <strong>deprecated</strong> and unreferenced. Use <code>--motion-*</code> (or{' '}
+        <code>tokens.motion.*</code>) for new work.
+      </Note>
+    </div>
+  ),
+}


### PR DESCRIPTION
## What

#137 を実装。`--st-duration-*` (enter/exit 共有 duration scale, 100/150/200ms)
と用途別 semantic alias `--motion-*` を可視化する `Tokens/Motion` ストーリーを新設。

3 story:
- **Duration Scale** — 値テーブル + インタラクティブ demo（トグルで 3 段を同時遷移、`prefers-reduced-motion` 自己対応）
- **Semantic Tokens** — `--motion-quick/base/expressive` を **defined only** バッジ付きで提示（alias は `resolution.test.ts` が pin）
- **Usage Guide** — 用途別ガイド + 設計原則（reduced-motion 必須 / loop は component CSS / 不要 animation 禁止）+「未 token 化」「deprecated `--transition-*`」の正直 note

## Why

`--motion-*` は #145 で land 済だが docs 未整備だった。アニメーション設計の DS
としての立場を明文化する（評価レポート §1.1 / §1.5）。token は追加せず可視化のみ。

## Related rules

- `storybook-guideline` — Tokens IA / English prose / Playground を持たない docs story
- `vrt-spec-guideline` — 時間 token は静止 PNG に不可視 → Z-Index と同じく **VRT skip**
- `css-api.md` — define-only single-value semantic token は許容（Radius / Elevation と同型）

## Test plan

- [x] `pnpm lint` 緑
- [x] `pnpm test --run` 緑（711 passed、`Motion.drift.test.ts` 4 ケース含む）
- [x] `pnpm typecheck` 緑
- [x] Storybook で 3 story を手動確認（light/dark）、demo 動作 + console error なし
- [ ] VRT: 付けない（Z-Index と同じ skip — 値は drift + resolution test で pin）

closes #137

🤖 Generated with [Claude Code](https://claude.com/claude-code)
