### PR TITLE
docs(storybook): Patterns/Form Composition ストーリーを追加 (#140)

### DIFF
--- a/.claude/rules/storybook-guideline.md
+++ b/.claude/rules/storybook-guideline.md
@@ -120,6 +120,40 @@ When you change a prop's description, **update TSDoc first**, then sync
 - Always include `tags: ['autodocs']` to enable auto-generated documentation.
 - Set `parameters: { layout: 'centered' }` unless the component requires full-width layout.
 
+## Hand-built docs pages (Patterns / Tokens) — render prose inline
+
+Component stories carry `tags: ['autodocs']`, so Storybook generates an
+autodocs **Docs page** for them — and that Docs page is the only surface on
+which `parameters.docs.description.component` / `.story` render.
+
+The hand-built pages under `Patterns/*` and `Tokens/*` (e.g.
+[`FormStates.stories.tsx`](../../src/docs/FormStates.stories.tsx),
+[`FormComposition.stories.tsx`](../../src/docs/FormComposition.stories.tsx))
+are **different**: they are authored as full-bleed Canvas pages
+(`parameters: { layout: 'fullscreen' }`) and **must NOT** carry
+`tags: ['autodocs']`. Consequently **no Docs page is generated for them**, so
+anything placed in `parameters.docs.description.*` renders **nowhere** — it is
+silently dormant.
+
+The rule for these pages:
+
+- **Render every piece of prose inline as JSX** inside the story `render` —
+  page intro, per-recipe captions, a11y notes, and code snippets. Use the
+  shared [`docs-ui.tsx`](../../src/docs/docs-ui.tsx) helpers (`PageTitle` /
+  `SectionTitle` / `SubsectionTitle` / `Lead` / `Note`) so the typography
+  matches the other docs pages.
+- **Do NOT** put narrative in `parameters.docs.description.component` /
+  `.story` on a `fullscreen` / no-`autodocs` page and assume it shows. It does
+  not. A note that reads "see the code in the Docs panel above" on such a page
+  is a dangling reference — there is no Docs panel.
+- Show code samples with an inline `<pre><code>{`…`}</code></pre>` block, not a
+  `description.story` markdown fence.
+
+If a page genuinely needs the autodocs Docs surface, add `tags: ['autodocs']`
+deliberately and drop `layout: 'fullscreen'` — but for narrative recipe pages
+the inline-prose Canvas pattern is preferred (the args table autodocs injects
+adds noise a recipe page doesn't want).
+
 ## a11y (addon-a11y)
 
 `@storybook/addon-a11y` runs an [axe-core](https://github.com/dequelabs/axe-core)

--- a/src/docs/FormComposition.stories.tsx
+++ b/src/docs/FormComposition.stories.tsx
@@ -17,36 +17,25 @@ import {
 import { Switch } from '../components/lv1/Switch/Switch'
 import { Note, SectionTitle } from './docs-ui'
 
-/**
+/*
  * Canonical recipes for composing forms out of Field / FieldSet plus the lv1
  * form controls. Third page under the `Patterns/` group (after `Form States`
- * and `Composition with asChild`); follows the #141 shape — multiple named
- * exports in one CSF file, narrative in `meta.parameters.docs.description`.
+ * and `Composition with asChild`).
  *
- * No VRT spec by design: this page is a composition of components whose visual
- * contract is already pinned by their own VRT, and the closest sibling
- * (`Patterns/Form States`) ships without VRT too. See vrt-spec-guideline.md
- * "docs / token stories — VRT only when there's a genuine visual contract".
+ * Prose is rendered INLINE in each story (the `Patterns/Form States` pattern),
+ * NOT via `parameters.docs.description.*`. These hand-built docs pages are
+ * consumed in Canvas with `layout: 'fullscreen'` and carry no `autodocs` tag,
+ * so there is no Docs page for `description.*` to render on — inline JSX is the
+ * only reliably-visible surface. See storybook-guideline.md "Hand-built docs
+ * pages (Patterns / Tokens) — render prose inline".
+ *
+ * No VRT spec by design: this page composes components whose visual contract is
+ * already pinned by their own VRT, and the closest sibling (`Form States`)
+ * ships without VRT too. See vrt-spec-guideline.md.
  */
 const meta: Meta = {
   title: 'Patterns/Form Composition',
-  parameters: {
-    layout: 'fullscreen',
-    docs: {
-      description: {
-        component: [
-          'Recipes for composing forms with Field and FieldSet.',
-          'Every section is written so the code can be copy-pasted as-is.',
-          '',
-          '- **Field** — flat API wrapping a single input with label / description / error',
-          '- **FieldSet** — groups multiple Fields with a group-level legend / error',
-          '- **Checkbox / Radio / Switch** — carry their own label, so they are not wrapped in Field',
-          '',
-          'The lv2 `FormField` short form is planned for v1+ (#123).',
-        ].join('\n'),
-      },
-    },
-  },
+  parameters: { layout: 'fullscreen' },
 }
 
 export default meta
@@ -54,16 +43,16 @@ type Story = StoryObj
 
 export const BasicField: Story = {
   name: '1. Field basics',
-  parameters: {
-    docs: {
-      description: {
-        story:
-          "The `<label htmlFor>` is wired to the input through Field's `useId()`, so `getByRole('textbox', { name: 'Email' })` resolves it. Note: `required` only renders a visual `*` — it does **not** propagate `aria-required` to the input (a known gap documented in component-architecture §8). For now, set `required` on the input element yourself.",
-      },
-    },
-  },
   render: () => (
-    <div className="w-96 mx-auto mt-12">
+    <div className="mx-auto mt-12 flex w-96 flex-col gap-4">
+      <Note>
+        A single Field wires the label, description, and required marker to the input. Note:{' '}
+        <code className="text-xs">required</code> renders the visual{' '}
+        <code className="text-xs">*</code> but does <strong>not</strong> set{' '}
+        <code className="text-xs">aria-required</code> on the input — add{' '}
+        <code className="text-xs">required</code> to the input element yourself (known gap,
+        component-architecture §8).
+      </Note>
       <Field label="Email" description="Used when you sign in" required>
         <Input type="email" placeholder="you@example.com" />
       </Field>
@@ -73,16 +62,15 @@ export const BasicField: Story = {
 
 export const FieldWithError: Story = {
   name: '2. Error state',
-  parameters: {
-    docs: {
-      description: {
-        story:
-          'Setting `error` automatically derives `isError: true`, which wires `aria-invalid="true"` + `aria-describedby` on the input pointing at the message. Meaning is carried by the error text, not colour alone (see css-api.md "Color alone is not enough").',
-      },
-    },
-  },
   render: () => (
-    <div className="w-96 mx-auto mt-12">
+    <div className="mx-auto mt-12 flex w-96 flex-col gap-4">
+      <Note>
+        Passing <code className="text-xs">error</code> auto-derives{' '}
+        <code className="text-xs">isError</code>, which wires{' '}
+        <code className="text-xs">aria-invalid="true"</code> +{' '}
+        <code className="text-xs">aria-describedby</code> on the input. Meaning comes from the error
+        text, not colour alone.
+      </Note>
       <Field label="Email" error="Enter a valid email address" required>
         <Input type="email" defaultValue="invalid-email" />
       </Field>
@@ -92,93 +80,82 @@ export const FieldWithError: Story = {
 
 export const FieldSetGrouping: Story = {
   name: '3. Grouping with FieldSet',
-  parameters: {
-    docs: {
-      description: {
-        story:
-          'FieldSet renders a native `<fieldset>` + `<legend>` for built-in a11y, and `disabled` propagates to every descendant control through the native fieldset. A nested `direction="row"` FieldSet lays two Fields side by side; `flexGrow` / `flexShrink` tune how each one stretches.',
-      },
-    },
-  },
   render: () => (
-    <FieldSet
-      legend="Shipping address"
-      description="Where we deliver"
-      className="w-96 mx-auto mt-12"
-    >
-      <Field label="Street" required>
-        <Input placeholder="1-2-3 Minato" />
-      </Field>
-      <FieldSet direction="row">
-        <Field label="City" required flexGrow={1}>
-          <Input placeholder="Minato" />
+    <div className="mx-auto mt-12 w-96">
+      <Note>
+        FieldSet renders a native <code className="text-xs">&lt;fieldset&gt;</code> +{' '}
+        <code className="text-xs">&lt;legend&gt;</code>, and{' '}
+        <code className="text-xs">disabled</code> propagates to every descendant control. A nested{' '}
+        <code className="text-xs">direction="row"</code> FieldSet lays two fields side by side,
+        tuned with <code className="text-xs">flexGrow</code> /{' '}
+        <code className="text-xs">flexShrink</code>.
+      </Note>
+      <FieldSet legend="Shipping address" description="Where we deliver">
+        <Field label="Street" required>
+          <Input placeholder="1-2-3 Minato" />
         </Field>
-        <Field label="Postal code" required flexShrink={0}>
-          <Input placeholder="100-0001" className="w-32" />
+        <FieldSet direction="row">
+          <Field label="City" required flexGrow={1}>
+            <Input placeholder="Minato" />
+          </Field>
+          <Field label="Postal code" required flexShrink={0}>
+            <Input placeholder="100-0001" className="w-32" />
+          </Field>
+        </FieldSet>
+        <Field label="Country">
+          <Select defaultValue="jp">
+            <SelectTrigger>
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="jp">Japan</SelectItem>
+              <SelectItem value="us">United States</SelectItem>
+            </SelectContent>
+          </Select>
         </Field>
       </FieldSet>
-      <Field label="Country">
-        <Select defaultValue="jp">
-          <SelectTrigger>
-            <SelectValue />
-          </SelectTrigger>
-          <SelectContent>
-            <SelectItem value="jp">Japan</SelectItem>
-            <SelectItem value="us">United States</SelectItem>
-          </SelectContent>
-        </Select>
-      </Field>
-    </FieldSet>
+    </div>
   ),
 }
 
 export const CheckboxRadioSwitch: Story = {
   name: '4. Checkbox / Radio / Switch',
-  parameters: {
-    docs: {
-      description: {
-        story:
-          'Checkbox / Switch / Radio carry their own `<label>`, so they are **not** wrapped in Field (no id wiring needed — see field-context-guideline.md). To group them, drop them directly under a FieldSet. Radio is wrapped in a RadioGroup, and that group is wrapped by a single Field to give it a group label.',
-      },
-    },
-  },
   render: () => (
-    <div className="flex flex-col gap-8 w-96 mx-auto mt-12">
-      {/* Checkbox owns its label — place under FieldSet, not Field */}
-      <FieldSet legend="Notifications" description="Choose any">
-        <Checkbox label="Email" defaultChecked />
-        <Checkbox label="SMS" />
-        <Checkbox label="Push" defaultChecked />
-      </FieldSet>
+    <div className="mx-auto mt-12 w-96">
+      <Note>
+        Checkbox / Switch / Radio carry their own <code className="text-xs">&lt;label&gt;</code>, so
+        they are <strong>not</strong> wrapped in Field — group them directly under a FieldSet. Radio
+        is wrapped in a RadioGroup, and that group is wrapped by a single Field for its group label.
+      </Note>
+      <div className="flex flex-col gap-8">
+        {/* Checkbox owns its label — place under FieldSet, not Field */}
+        <FieldSet legend="Notifications" description="Choose any">
+          <Checkbox label="Email" defaultChecked />
+          <Checkbox label="SMS" />
+          <Checkbox label="Push" defaultChecked />
+        </FieldSet>
 
-      {/* Radio is wrapped in RadioGroup, then Field gives the group a label */}
-      <Field label="Plan" required>
-        <RadioGroup defaultValue="pro">
-          <Radio value="free" label="Free" />
-          <Radio value="pro" label="Pro" />
-          <Radio value="enterprise" label="Enterprise" />
-        </RadioGroup>
-      </Field>
+        {/* Radio is wrapped in RadioGroup, then Field gives the group a label */}
+        <Field label="Plan" required>
+          <RadioGroup defaultValue="pro">
+            <Radio value="free" label="Free" />
+            <Radio value="pro" label="Pro" />
+            <Radio value="enterprise" label="Enterprise" />
+          </RadioGroup>
+        </Field>
 
-      {/* Switch owns its label too */}
-      <FieldSet legend="Display">
-        <Switch label="Dark mode" />
-        <Switch label="High contrast" />
-      </FieldSet>
+        {/* Switch owns its label too */}
+        <FieldSet legend="Display">
+          <Switch label="Dark mode" />
+          <Switch label="High contrast" />
+        </FieldSet>
+      </div>
     </div>
   ),
 }
 
 export const CompleteSignUpForm: Story = {
   name: '5. Complete sign-up form',
-  parameters: {
-    docs: {
-      description: {
-        story:
-          'Manages every Field `error` in one state object and disables the controls with `disabled={submitting}` while in flight. Button\'s `isLoading` raises `aria-busy="true"` and keeps the form\'s disabled state consistent.',
-      },
-    },
-  },
   render: () => {
     const [submitting, setSubmitting] = useState(false)
     const [errors, setErrors] = useState<Record<string, string>>({})
@@ -186,72 +163,59 @@ export const CompleteSignUpForm: Story = {
     const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
       e.preventDefault()
       const data = new FormData(e.currentTarget)
+      const password = data.get('password')
       const next: Record<string, string> = {}
       if (!data.get('email')) next.email = 'Email is required'
-      if (!data.get('password')) next.password = 'Password is required'
+      if (!password) next.password = 'Password is required'
+      else if (password !== data.get('passwordConfirm'))
+        next.passwordConfirm = 'Passwords do not match'
       setErrors(next)
       if (Object.keys(next).length === 0) {
         setSubmitting(true)
-        // In a real form this would call an API; reset immediately for the demo.
-        setSubmitting(false)
+        // Simulate an async request so the loading / disabled state is visible.
+        setTimeout(() => setSubmitting(false), 1200)
       }
     }
 
     return (
-      <form onSubmit={handleSubmit} className="w-96 mx-auto mt-12 flex flex-col gap-4">
-        <Field label="Email" required error={errors.email}>
-          <Input type="email" name="email" disabled={submitting} />
-        </Field>
-        <Field label="Password" required error={errors.password}>
-          <Input type="password" name="password" disabled={submitting} />
-        </Field>
-        <Field label="Password (confirm)" required error={errors.passwordConfirm}>
-          <Input type="password" name="passwordConfirm" disabled={submitting} />
-        </Field>
-        <Checkbox label="I agree to the terms" name="agree" disabled={submitting} />
-        <Button type="submit" isLoading={submitting}>
-          Sign up
-        </Button>
-      </form>
+      <div className="mx-auto mt-12 w-96">
+        <Note>
+          Errors live in one state object;{' '}
+          <code className="text-xs">disabled={'{submitting}'}</code> plus Button{' '}
+          <code className="text-xs">isLoading</code> (which sets{' '}
+          <code className="text-xs">aria-busy="true"</code>) keep the form consistent while the
+          simulated request runs.
+        </Note>
+        <form onSubmit={handleSubmit} className="flex flex-col gap-4">
+          <Field label="Email" required error={errors.email}>
+            <Input type="email" name="email" disabled={submitting} />
+          </Field>
+          <Field label="Password" required error={errors.password}>
+            <Input type="password" name="password" disabled={submitting} />
+          </Field>
+          <Field label="Password (confirm)" required error={errors.passwordConfirm}>
+            <Input type="password" name="passwordConfirm" disabled={submitting} />
+          </Field>
+          <Checkbox label="I agree to the terms" name="agree" disabled={submitting} />
+          <Button type="submit" isLoading={submitting}>
+            Sign up
+          </Button>
+        </form>
+      </div>
     )
   },
 }
 
 export const WithReactHookForm: Story = {
   name: '6. react-hook-form integration',
-  parameters: {
-    docs: {
-      description: {
-        story: [
-          'Recommended pattern for pairing with `react-hook-form`:',
-          '',
-          '```tsx',
-          "import { useForm } from 'react-hook-form'",
-          '',
-          'function SignUpForm() {',
-          '  const { register, handleSubmit, formState: { errors } } = useForm()',
-          '  return (',
-          '    <form onSubmit={handleSubmit(onSubmit)}>',
-          '      <Field label="Email" required error={errors.email?.message}>',
-          "        <Input {...register('email', { required: 'Required' })} />",
-          '      </Field>',
-          '      <Button type="submit">Sign up</Button>',
-          '    </form>',
-          '  )',
-          '}',
-          '```',
-        ].join('\n'),
-      },
-    },
-  },
   render: () => (
-    <div className="max-w-2xl mx-auto px-8 py-12">
+    <div className="mx-auto max-w-2xl px-8 py-12">
       <SectionTitle>react-hook-form integration</SectionTitle>
       <Note>
-        The code in the Docs panel above works as-is. The three Schatten-side guarantees that make
-        it work:
+        Recommended pattern for pairing with <code className="text-xs">react-hook-form</code>. The
+        snippet below works as-is — the three Schatten-side guarantees that make it work:
       </Note>
-      <ul className="list-disc pl-6 text-sm text-foreground-muted flex flex-col gap-2">
+      <ul className="flex list-disc flex-col gap-2 pl-6 text-sm text-foreground-muted">
         <li>
           <code className="text-xs">Input</code> is <code className="text-xs">forwardRef</code>-ed,
           so spreading <code className="text-xs">{'{...register(...)}'}</code> alone delivers the
@@ -267,6 +231,21 @@ export const WithReactHookForm: Story = {
           <code className="text-xs">error</code> prop.
         </li>
       </ul>
+      <pre className="mt-4 overflow-x-auto rounded-md border border-border bg-surface-hover p-4 text-xs text-foreground">
+        <code>{`import { useForm } from 'react-hook-form'
+
+function SignUpForm() {
+  const { register, handleSubmit, formState: { errors } } = useForm()
+  return (
+    <form onSubmit={handleSubmit(onSubmit)}>
+      <Field label="Email" required error={errors.email?.message}>
+        <Input {...register('email', { required: 'Required' })} />
+      </Field>
+      <Button type="submit">Sign up</Button>
+    </form>
+  )
+}`}</code>
+      </pre>
       <Note>
         TanStack Form / Conform work the same way — wrap controlled components in their{' '}
         <code className="text-xs">Controller</code> equivalent.
@@ -277,16 +256,8 @@ export const WithReactHookForm: Story = {
 
 export const FormFieldComingSoon: Story = {
   name: '7. FormField (lv2) — coming in v1+',
-  parameters: {
-    docs: {
-      description: {
-        story:
-          'The lv2 `FormField` (a one-component short form of Field + label + description + error) is planned for v1+ as #123. Once it lands, it will be added here as a dedicated section.',
-      },
-    },
-  },
   render: () => (
-    <div className="max-w-lg mx-auto mt-12">
+    <div className="mx-auto mt-12 max-w-lg">
       <Callout variant="info" title="Coming soon">
         The lv2 <code>FormField</code> (a one-component short form of Field + label + description +
         error) is planned for the v1+ milestone as{' '}

--- a/src/docs/FormComposition.stories.tsx
+++ b/src/docs/FormComposition.stories.tsx
@@ -197,7 +197,7 @@ export const CompleteSignUpForm: Story = {
             <Input type="password" name="passwordConfirm" disabled={submitting} />
           </Field>
           <Checkbox label="I agree to the terms" name="agree" disabled={submitting} />
-          <Button type="submit" isLoading={submitting}>
+          <Button type="submit" isLoading={submitting} className="self-start">
             Sign up
           </Button>
         </form>

--- a/src/docs/FormComposition.stories.tsx
+++ b/src/docs/FormComposition.stories.tsx
@@ -1,0 +1,298 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { type FormEvent, useState } from 'react'
+import { Button } from '../components/lv1/Button/Button'
+import { Callout } from '../components/lv1/Callout/Callout'
+import { Checkbox } from '../components/lv1/Checkbox/Checkbox'
+import { Field } from '../components/lv1/Field/Field'
+import { FieldSet } from '../components/lv1/FieldSet/FieldSet'
+import { Input } from '../components/lv1/Input/Input'
+import { Radio, RadioGroup } from '../components/lv1/Radio/Radio'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '../components/lv1/Select/Select'
+import { Switch } from '../components/lv1/Switch/Switch'
+import { Note, SectionTitle } from './docs-ui'
+
+/**
+ * Canonical recipes for composing forms out of Field / FieldSet plus the lv1
+ * form controls. Third page under the `Patterns/` group (after `Form States`
+ * and `Composition with asChild`); follows the #141 shape — multiple named
+ * exports in one CSF file, narrative in `meta.parameters.docs.description`.
+ *
+ * No VRT spec by design: this page is a composition of components whose visual
+ * contract is already pinned by their own VRT, and the closest sibling
+ * (`Patterns/Form States`) ships without VRT too. See vrt-spec-guideline.md
+ * "docs / token stories — VRT only when there's a genuine visual contract".
+ */
+const meta: Meta = {
+  title: 'Patterns/Form Composition',
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component: [
+          'Recipes for composing forms with Field and FieldSet.',
+          'Every section is written so the code can be copy-pasted as-is.',
+          '',
+          '- **Field** — flat API wrapping a single input with label / description / error',
+          '- **FieldSet** — groups multiple Fields with a group-level legend / error',
+          '- **Checkbox / Radio / Switch** — carry their own label, so they are not wrapped in Field',
+          '',
+          'The lv2 `FormField` short form is planned for v1+ (#123).',
+        ].join('\n'),
+      },
+    },
+  },
+}
+
+export default meta
+type Story = StoryObj
+
+export const BasicField: Story = {
+  name: '1. Field basics',
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "The `<label htmlFor>` is wired to the input through Field's `useId()`, so `getByRole('textbox', { name: 'Email' })` resolves it. Note: `required` only renders a visual `*` — it does **not** propagate `aria-required` to the input (a known gap documented in component-architecture §8). For now, set `required` on the input element yourself.",
+      },
+    },
+  },
+  render: () => (
+    <div className="w-96 mx-auto mt-12">
+      <Field label="Email" description="Used when you sign in" required>
+        <Input type="email" placeholder="you@example.com" />
+      </Field>
+    </div>
+  ),
+}
+
+export const FieldWithError: Story = {
+  name: '2. Error state',
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Setting `error` automatically derives `isError: true`, which wires `aria-invalid="true"` + `aria-describedby` on the input pointing at the message. Meaning is carried by the error text, not colour alone (see css-api.md "Color alone is not enough").',
+      },
+    },
+  },
+  render: () => (
+    <div className="w-96 mx-auto mt-12">
+      <Field label="Email" error="Enter a valid email address" required>
+        <Input type="email" defaultValue="invalid-email" />
+      </Field>
+    </div>
+  ),
+}
+
+export const FieldSetGrouping: Story = {
+  name: '3. Grouping with FieldSet',
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'FieldSet renders a native `<fieldset>` + `<legend>` for built-in a11y, and `disabled` propagates to every descendant control through the native fieldset. A nested `direction="row"` FieldSet lays two Fields side by side; `flexGrow` / `flexShrink` tune how each one stretches.',
+      },
+    },
+  },
+  render: () => (
+    <FieldSet
+      legend="Shipping address"
+      description="Where we deliver"
+      className="w-96 mx-auto mt-12"
+    >
+      <Field label="Street" required>
+        <Input placeholder="1-2-3 Minato" />
+      </Field>
+      <FieldSet direction="row">
+        <Field label="City" required flexGrow={1}>
+          <Input placeholder="Minato" />
+        </Field>
+        <Field label="Postal code" required flexShrink={0}>
+          <Input placeholder="100-0001" className="w-32" />
+        </Field>
+      </FieldSet>
+      <Field label="Country">
+        <Select defaultValue="jp">
+          <SelectTrigger>
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="jp">Japan</SelectItem>
+            <SelectItem value="us">United States</SelectItem>
+          </SelectContent>
+        </Select>
+      </Field>
+    </FieldSet>
+  ),
+}
+
+export const CheckboxRadioSwitch: Story = {
+  name: '4. Checkbox / Radio / Switch',
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Checkbox / Switch / Radio carry their own `<label>`, so they are **not** wrapped in Field (no id wiring needed — see field-context-guideline.md). To group them, drop them directly under a FieldSet. Radio is wrapped in a RadioGroup, and that group is wrapped by a single Field to give it a group label.',
+      },
+    },
+  },
+  render: () => (
+    <div className="flex flex-col gap-8 w-96 mx-auto mt-12">
+      {/* Checkbox owns its label — place under FieldSet, not Field */}
+      <FieldSet legend="Notifications" description="Choose any">
+        <Checkbox label="Email" defaultChecked />
+        <Checkbox label="SMS" />
+        <Checkbox label="Push" defaultChecked />
+      </FieldSet>
+
+      {/* Radio is wrapped in RadioGroup, then Field gives the group a label */}
+      <Field label="Plan" required>
+        <RadioGroup defaultValue="pro">
+          <Radio value="free" label="Free" />
+          <Radio value="pro" label="Pro" />
+          <Radio value="enterprise" label="Enterprise" />
+        </RadioGroup>
+      </Field>
+
+      {/* Switch owns its label too */}
+      <FieldSet legend="Display">
+        <Switch label="Dark mode" />
+        <Switch label="High contrast" />
+      </FieldSet>
+    </div>
+  ),
+}
+
+export const CompleteSignUpForm: Story = {
+  name: '5. Complete sign-up form',
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Manages every Field `error` in one state object and disables the controls with `disabled={submitting}` while in flight. Button\'s `isLoading` raises `aria-busy="true"` and keeps the form\'s disabled state consistent.',
+      },
+    },
+  },
+  render: () => {
+    const [submitting, setSubmitting] = useState(false)
+    const [errors, setErrors] = useState<Record<string, string>>({})
+
+    const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
+      e.preventDefault()
+      const data = new FormData(e.currentTarget)
+      const next: Record<string, string> = {}
+      if (!data.get('email')) next.email = 'Email is required'
+      if (!data.get('password')) next.password = 'Password is required'
+      setErrors(next)
+      if (Object.keys(next).length === 0) {
+        setSubmitting(true)
+        // In a real form this would call an API; reset immediately for the demo.
+        setSubmitting(false)
+      }
+    }
+
+    return (
+      <form onSubmit={handleSubmit} className="w-96 mx-auto mt-12 flex flex-col gap-4">
+        <Field label="Email" required error={errors.email}>
+          <Input type="email" name="email" disabled={submitting} />
+        </Field>
+        <Field label="Password" required error={errors.password}>
+          <Input type="password" name="password" disabled={submitting} />
+        </Field>
+        <Field label="Password (confirm)" required error={errors.passwordConfirm}>
+          <Input type="password" name="passwordConfirm" disabled={submitting} />
+        </Field>
+        <Checkbox label="I agree to the terms" name="agree" disabled={submitting} />
+        <Button type="submit" isLoading={submitting}>
+          Sign up
+        </Button>
+      </form>
+    )
+  },
+}
+
+export const WithReactHookForm: Story = {
+  name: '6. react-hook-form integration',
+  parameters: {
+    docs: {
+      description: {
+        story: [
+          'Recommended pattern for pairing with `react-hook-form`:',
+          '',
+          '```tsx',
+          "import { useForm } from 'react-hook-form'",
+          '',
+          'function SignUpForm() {',
+          '  const { register, handleSubmit, formState: { errors } } = useForm()',
+          '  return (',
+          '    <form onSubmit={handleSubmit(onSubmit)}>',
+          '      <Field label="Email" required error={errors.email?.message}>',
+          "        <Input {...register('email', { required: 'Required' })} />",
+          '      </Field>',
+          '      <Button type="submit">Sign up</Button>',
+          '    </form>',
+          '  )',
+          '}',
+          '```',
+        ].join('\n'),
+      },
+    },
+  },
+  render: () => (
+    <div className="max-w-2xl mx-auto px-8 py-12">
+      <SectionTitle>react-hook-form integration</SectionTitle>
+      <Note>
+        The code in the Docs panel above works as-is. The three Schatten-side guarantees that make
+        it work:
+      </Note>
+      <ul className="list-disc pl-6 text-sm text-foreground-muted flex flex-col gap-2">
+        <li>
+          <code className="text-xs">Input</code> is <code className="text-xs">forwardRef</code>-ed,
+          so spreading <code className="text-xs">{'{...register(...)}'}</code> alone delivers the
+          ref / onChange.
+        </li>
+        <li>
+          <code className="text-xs">Select</code> / <code className="text-xs">RadioGroup</code> /{' '}
+          <code className="text-xs">Switch</code> are controlled, so wrap them in{' '}
+          <code className="text-xs">Controller</code>.
+        </li>
+        <li>
+          Pass <code className="text-xs">errors.&lt;name&gt;?.message</code> straight into the Field{' '}
+          <code className="text-xs">error</code> prop.
+        </li>
+      </ul>
+      <Note>
+        TanStack Form / Conform work the same way — wrap controlled components in their{' '}
+        <code className="text-xs">Controller</code> equivalent.
+      </Note>
+    </div>
+  ),
+}
+
+export const FormFieldComingSoon: Story = {
+  name: '7. FormField (lv2) — coming in v1+',
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The lv2 `FormField` (a one-component short form of Field + label + description + error) is planned for v1+ as #123. Once it lands, it will be added here as a dedicated section.',
+      },
+    },
+  },
+  render: () => (
+    <div className="max-w-lg mx-auto mt-12">
+      <Callout variant="info" title="Coming soon">
+        The lv2 <code>FormField</code> (a one-component short form of Field + label + description +
+        error) is planned for the v1+ milestone as{' '}
+        <a href="https://github.com/yasmro/schatten/issues/123">#123</a>. Once it lands, it will be
+        added to this page as a dedicated section.
+      </Callout>
+    </div>
+  ),
+}

--- a/src/docs/FormComposition.stories.tsx
+++ b/src/docs/FormComposition.stories.tsx
@@ -50,8 +50,8 @@ export const BasicField: Story = {
         <code className="text-xs">required</code> renders the visual{' '}
         <code className="text-xs">*</code> but does <strong>not</strong> set{' '}
         <code className="text-xs">aria-required</code> on the input — add{' '}
-        <code className="text-xs">required</code> to the input element yourself (known gap,
-        component-architecture §8).
+        <code className="text-xs">required</code> to the input element yourself (a known
+        limitation).
       </Note>
       <Field label="Email" description="Used when you sign in" required>
         <Input type="email" placeholder="you@example.com" />


### PR DESCRIPTION
## What

Storybook に `Patterns/Form Composition` を追加（`Patterns/` 階層の 3 枚目 —
Form States / Composition with asChild に続く）。1 CSF ファイル + 7 story:

1. Field の基本（flat API / label 紐付け / description / required gap 注記）
2. エラー状態（error → isError 自動導出 / aria-invalid）
3. FieldSet グループ化（legend / ネスト `direction="row"` / `flexGrow`·`flexShrink`）
4. Checkbox / Radio / Switch（自前ラベル系の使い分け）
5. sign-up form 完全例（error 一括 state / password 一致検証 / `isLoading`）
6. react-hook-form 連携（Schatten の forwardRef / Controller 契約。inline コード snippet）
7. FormField (lv2) — v1+ placeholder（#123）

説明文（intro / 各 recipe の caption / a11y note / コード snippet）は **inline JSX** で
描画（`Patterns/Form States` と同じ方式）。fullscreen + autodocs 無しの hand-built
docs ページでは `parameters.docs.description.*` が Canvas に描画されないため。

## Why

「Schatten で form を組む正しい形」を一目で参照できる単一ソースを提供する（#140）。
各 story はコピペで動く。

## Self-review 反映（P0/P1/P2）

`/review-pr` のセルフレビューで検出した点を本 PR 内で対応:

- **P0** — prose を `description.*` から inline JSX 化（Story 6 のコード snippet を
  `<pre>` で表示、宙吊りの "Docs panel above" 参照を除去、Story 1 の aria-required
  gap note も Canvas に表示）。
- **P1** — Story 5 に password 一致検証を追加 + `setTimeout` で submitting を保持し
  `isLoading` / `disabled` を可視化。
- **P2** — `storybook-guideline.md` に "Hand-built docs pages — render prose inline"
  節を追加。#141 の同種 dormant narrative 追従は #368 に分離。

## Related rules

- `storybook-guideline.md` — Story title taxonomy（`Patterns/`）+ 本 PR で
  "Hand-built docs pages — render prose inline" 節を追加
- `field-context-guideline.md` — Field / FieldSet の「ラベル持ち / 持ちなし」区分
- `component-architecture.md` §8 — `required` の `aria-required` gap を Story 1 で明示
- `vrt-spec-guideline.md` — docs story の VRT default-skip 判断（本ページは VRT なし）

## Test plan

- [x] `pnpm lint` 緑
- [x] `pnpm test --run` 緑（711 passed）
- [x] `pnpm typecheck` 緑
- [ ] Storybook で手動確認（全 7 story が Canvas に prose 込みで render / addon-a11y 0 violation）

## Notes

- **changeset なし**（`no-changeset` ラベル）。Storybook は published package に
  含まれない（api-stability.md）ため。直前の同種 PR #339（#141）も `no-changeset`。
  ※ issue #140 本文の「changeset: patch」は要訂正（no-changeset）。
- **VRT spec なし**（docs default-skip）。新規 baseline 不要。
- follow-up: #368（#141 の dormant narrative inline 化）

closes #140

🤖 Generated with [Claude Code](https://claude.com/claude-code)
