### PR TITLE
docs(storybook): Welcome に Patterns 節を新設し全 6 Patterns ページをリンク (closes #364)

### DIFF
--- a/.changeset/welcome-patterns-section-4e7b.md
+++ b/.changeset/welcome-patterns-section-4e7b.md
@@ -1,0 +1,12 @@
+---
+'@yasmro/schatten': patch
+---
+
+docs(storybook): Welcome に Patterns 節を新設し、全 6 Patterns ページ
+(Accessibility / Composition with asChild / Form Composition / Form States /
+Layout / Testing) へのリンクカードを追加 (closes #364)。7 グループ IA (#320 /
+#332) の入口が Welcome から完結する。あわせて `navigateToStory` に `viewMode`
+引数を追加し、autodocs を持たない Canvas ストーリーへの既存 deep link 5 本
+(CSS API / Theme Audit / Patterns Accessibility / Tokens Color / Typography)
+が「No Preview」になる不具合を修正。公開 API (React props / CSS class /
+CSS variable / types) の変更なし。

--- a/src/docs/Welcome.stories.tsx
+++ b/src/docs/Welcome.stories.tsx
@@ -31,9 +31,20 @@ const meta: Meta = {
 export default meta
 type Story = StoryObj
 
-const navigateToStory = (e: React.MouseEvent, storyPath: string, suffix = 'docs') => {
+/**
+ * `viewMode` must match the target entry's type in the Storybook index:
+ * `'docs'` for autodocs pages (the lv1 component catalog), `'story'` for
+ * Canvas-only stories (Tokens / Theming / CSS API / Patterns). Sending a
+ * story entry through `/docs/` renders "No Preview".
+ */
+const navigateToStory = (
+  e: React.MouseEvent,
+  storyPath: string,
+  suffix = 'docs',
+  viewMode: 'docs' | 'story' = 'docs',
+) => {
   e.preventDefault()
-  const targetPath = `/docs/${storyPath}--${suffix}`
+  const targetPath = `/${viewMode}/${storyPath}--${suffix}`
   const top = window.parent !== window ? window.parent : window
   const url = new URL(top.location.href)
   url.searchParams.set('path', targetPath)
@@ -208,20 +219,20 @@ export const Overview: Story = {
           <DisciplineCard
             title="Framework-agnostic CSS API"
             description="Components ship a .st-* BEM class API and a prebuilt stylesheet, so they render with plain HTML — no React, no Tailwind, no build step required on the consumer side."
-            href="/docs/css-api-overview--reference"
-            onClick={(e) => navigateToStory(e, 'css-api-overview', 'reference')}
+            href="/story/css-api-overview--reference"
+            onClick={(e) => navigateToStory(e, 'css-api-overview', 'reference', 'story')}
           />
           <DisciplineCard
             title="Mode × Special theming"
             description="Two independent theme axes — light/dark Mode × an exclusive seasonal Special — compose at runtime through CSS variables. See all 16 combinations verified side by side."
-            href="/docs/theming-theme-audit--overview"
-            onClick={(e) => navigateToStory(e, 'theming-theme-audit', 'overview')}
+            href="/story/theming-theme-audit--overview"
+            onClick={(e) => navigateToStory(e, 'theming-theme-audit', 'overview', 'story')}
           />
           <DisciplineCard
             title="Accessibility contract"
             description="Every primitive guarantees a role, an accessible name, keyboard support, and aria-* wiring — asserted with axe-core in CI alongside the visual regression suite."
-            href="/docs/patterns-accessibility--overview"
-            onClick={(e) => navigateToStory(e, 'patterns-accessibility', 'overview')}
+            href="/story/patterns-accessibility--overview"
+            onClick={(e) => navigateToStory(e, 'patterns-accessibility', 'overview', 'story')}
           />
         </div>
       </div>
@@ -409,12 +420,12 @@ export const Overview: Story = {
       </div>
 
       {/* 6. Tokens (was "Foundation" — renamed to the new IA vocabulary, #336 deferred) */}
-      <div>
+      <div className="mb-12">
         <h2 className="text-xl font-bold text-foreground mb-4">Tokens</h2>
         <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-4">
           <a
-            href="/docs/tokens-color--colors"
-            onClick={(e) => navigateToStory(e, 'tokens-color', 'colors')}
+            href="/story/tokens-color--colors"
+            onClick={(e) => navigateToStory(e, 'tokens-color', 'colors', 'story')}
             className="group block border border-border rounded-xl overflow-hidden no-underline transition-shadow duration-200 hover:shadow-md"
           >
             <div className="flex items-center justify-center h-40 bg-surface">
@@ -431,8 +442,8 @@ export const Overview: Story = {
           </a>
 
           <a
-            href="/docs/tokens-typography--typography"
-            onClick={(e) => navigateToStory(e, 'tokens-typography', 'typography')}
+            href="/story/tokens-typography--typography"
+            onClick={(e) => navigateToStory(e, 'tokens-typography', 'typography', 'story')}
             className="group block border border-border rounded-xl overflow-hidden no-underline transition-shadow duration-200 hover:shadow-md"
           >
             <div className="flex items-center justify-center h-40 bg-surface">
@@ -448,6 +459,54 @@ export const Overview: Story = {
               <p className="text-xs text-foreground-muted mt-0.5">Font scales and text styles.</p>
             </div>
           </a>
+        </div>
+      </div>
+
+      {/* 7. Patterns */}
+      <div>
+        <h2 className="text-xl font-bold text-foreground mb-2">Patterns</h2>
+        <p className="text-sm text-foreground-muted leading-relaxed mb-6">
+          Cross-component recipes and principles — how the primitives compose in practice.
+        </p>
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+          <DisciplineCard
+            title="Accessibility"
+            description="Focus visibility, ARIA conventions, contrast, and keyboard support — the contract every primitive satisfies."
+            href="/story/patterns-accessibility--overview"
+            onClick={(e) => navigateToStory(e, 'patterns-accessibility', 'overview', 'story')}
+          />
+          <DisciplineCard
+            title="Composition with asChild"
+            description="Rendering Button as a link, buttonVariants() on your own element, and Text polymorphism."
+            href="/story/patterns-composition-with-aschild--button-as-link"
+            onClick={(e) =>
+              navigateToStory(e, 'patterns-composition-with-aschild', 'button-as-link', 'story')
+            }
+          />
+          <DisciplineCard
+            title="Form Composition"
+            description="Wiring Field and FieldSet: labels, descriptions, and error messages."
+            href="/story/patterns-form-composition--basic-field"
+            onClick={(e) => navigateToStory(e, 'patterns-form-composition', 'basic-field', 'story')}
+          />
+          <DisciplineCard
+            title="Form States"
+            description="disabled / readOnly / error across every form control, audited side by side."
+            href="/story/patterns-form-states--audit"
+            onClick={(e) => navigateToStory(e, 'patterns-form-states', 'audit', 'story')}
+          />
+          <DisciplineCard
+            title="Layout"
+            description="Flex and grid recipes for arranging primitives on the page."
+            href="/story/patterns-layout--flex-recipes"
+            onClick={(e) => navigateToStory(e, 'patterns-layout', 'flex-recipes', 'story')}
+          />
+          <DisciplineCard
+            title="Testing"
+            description="data-testid pass-through and role-first queries for consumer test suites."
+            href="/story/patterns-testing--overview"
+            onClick={(e) => navigateToStory(e, 'patterns-testing', 'overview', 'story')}
+          />
         </div>
       </div>
     </div>

--- a/src/docs/Welcome.stories.tsx
+++ b/src/docs/Welcome.stories.tsx
@@ -86,12 +86,12 @@ const ComponentCard = ({
 )
 
 /**
- * Card for the "Engineering discipline" section. Unlike `ComponentCard` it has
- * no interactive preview, so it is a plain text link — internal links route
- * through `navigateToStory`, the external `.claude/rules/` link opens GitHub in
- * a new tab.
+ * Text-only link card — unlike `ComponentCard` it has no interactive preview.
+ * Used by the "Engineering discipline" and "Patterns" sections — internal
+ * links route through `navigateToStory`, the external `.claude/rules/` link
+ * opens GitHub in a new tab.
  */
-const DisciplineCard = ({
+const TextLinkCard = ({
   title,
   description,
   href,
@@ -210,25 +210,25 @@ export const Overview: Story = {
           Four places to look:
         </p>
         <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
-          <DisciplineCard
+          <TextLinkCard
             title="Rule-driven operation"
             description="Every architectural decision lives in a versioned contract under .claude/rules/ that both human and AI contributors follow — component API shapes, the token hierarchy, the a11y contract."
             href="https://github.com/yasmro/schatten/tree/main/.claude/rules"
             external
           />
-          <DisciplineCard
+          <TextLinkCard
             title="Framework-agnostic CSS API"
             description="Components ship a .st-* BEM class API and a prebuilt stylesheet, so they render with plain HTML — no React, no Tailwind, no build step required on the consumer side."
             href="/story/css-api-overview--reference"
             onClick={(e) => navigateToStory(e, 'css-api-overview', 'reference', 'story')}
           />
-          <DisciplineCard
+          <TextLinkCard
             title="Mode × Special theming"
             description="Two independent theme axes — light/dark Mode × an exclusive seasonal Special — compose at runtime through CSS variables. See all 16 combinations verified side by side."
             href="/story/theming-theme-audit--overview"
             onClick={(e) => navigateToStory(e, 'theming-theme-audit', 'overview', 'story')}
           />
-          <DisciplineCard
+          <TextLinkCard
             title="Accessibility contract"
             description="Every primitive guarantees a role, an accessible name, keyboard support, and aria-* wiring — asserted with axe-core in CI alongside the visual regression suite."
             href="/story/patterns-accessibility--overview"
@@ -469,13 +469,13 @@ export const Overview: Story = {
           Cross-component recipes and principles — how the primitives compose in practice.
         </p>
         <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
-          <DisciplineCard
+          <TextLinkCard
             title="Accessibility"
             description="Focus visibility, ARIA conventions, contrast, and keyboard support — the contract every primitive satisfies."
             href="/story/patterns-accessibility--overview"
             onClick={(e) => navigateToStory(e, 'patterns-accessibility', 'overview', 'story')}
           />
-          <DisciplineCard
+          <TextLinkCard
             title="Composition with asChild"
             description="Rendering Button as a link, buttonVariants() on your own element, and Text polymorphism."
             href="/story/patterns-composition-with-aschild--button-as-link"
@@ -483,25 +483,25 @@ export const Overview: Story = {
               navigateToStory(e, 'patterns-composition-with-aschild', 'button-as-link', 'story')
             }
           />
-          <DisciplineCard
+          <TextLinkCard
             title="Form Composition"
             description="Wiring Field and FieldSet: labels, descriptions, and error messages."
             href="/story/patterns-form-composition--basic-field"
             onClick={(e) => navigateToStory(e, 'patterns-form-composition', 'basic-field', 'story')}
           />
-          <DisciplineCard
+          <TextLinkCard
             title="Form States"
             description="disabled / readOnly / error across every form control, audited side by side."
             href="/story/patterns-form-states--audit"
             onClick={(e) => navigateToStory(e, 'patterns-form-states', 'audit', 'story')}
           />
-          <DisciplineCard
+          <TextLinkCard
             title="Layout"
             description="Flex and grid recipes for arranging primitives on the page."
             href="/story/patterns-layout--flex-recipes"
             onClick={(e) => navigateToStory(e, 'patterns-layout', 'flex-recipes', 'story')}
           />
-          <DisciplineCard
+          <TextLinkCard
             title="Testing"
             description="data-testid pass-through and role-first queries for consumer test suites."
             href="/story/patterns-testing--overview"


### PR DESCRIPTION
## What

- Welcome 末尾に「Patterns」節を新設し、全 6 Patterns ページ (Accessibility / Composition with asChild / Form Composition / Form States / Layout / Testing) への `TextLinkCard` リンクを追加
- `navigateToStory` に `viewMode: 'docs' | 'story'` 引数を追加し、autodocs を持たない Canvas ストーリーへの既存 deep link 5 本 (`css-api-overview` / `theming-theme-audit` / `patterns-accessibility` / `tokens-color` / `tokens-typography`) が「No Preview」を描画する #373 由来の既存バグを修正
- review-pr P2 反映: `DisciplineCard` を汎用 `TextLinkCard` に改名 (Engineering discipline + Patterns の 2 節で使う汎用カードになったため。レンダリング出力は不変)

## Why

7 グループ IA (#320 / #332) の Patterns 入口が Welcome から辿れなかった (#364)。実装中の preview 検証で、`/docs/<id>` 形式の deep link は対象が autodocs entry でないと "No Preview" になることが判明 — 新設 6 本と同根のため既存 5 本も同 PR で修正した (承認済み)。

## Related rules

- [.claude/rules/storybook-guideline.md](../blob/develop/.claude/rules/storybook-guideline.md) — deep-link 同期 / 英語 surface / 7 グループ IA
- 詳細設計は #364 本文 (refinement-issue session で全面改訂済み)

## Test plan

- [x] `pnpm lint` 緑
- [x] `pnpm test --run` 緑 (41 files / 777 tests)
- [x] `pnpm typecheck` 緑
- [x] Storybook preview で検証:
  - 6 story ID すべて `index.json` に実在 (`type: 'story'`)
  - 実クリック 4 系統: Layout (新規) / Theme Audit (修正) / Tokens Color (修正) / Button autodocs (対照・無変更) — すべて正しく遷移・描画
  - axe (wcag2a/2aa/21a/21aa) を新設 Patterns 節に対して実行 → **violations 0** (ページ全体の color-contrast 11 + button-name 1 は既存コンポーネントプレビュー由来で #345 が追跡)
  - console error 0

## Follow-up

- #375 — Welcome deep-link の drift test。本 PR で判明した「slug 実在だけでなく viewMode × entry type の一致も検証が必要」という知見を反映予定

closes #364

🤖 Generated with [Claude Code](https://claude.com/claude-code)



