### PR TITLE
fix(a11y): bare-control story の label/button-name 違反を解消 (closes #345)

### DIFF
--- a/.changeset/dialog-body-scroll-focus-345.md
+++ b/.changeset/dialog-body-scroll-focus-345.md
@@ -1,0 +1,7 @@
+---
+'@yasmro/schatten': patch
+---
+
+fix(lv1): Dialog の本文スクロール領域をキーボードフォーカス可能に (#345)
+
+`.st-dialog__body` は内容がオーバーフローした時のみ `tabIndex={0}` を持つようになり、focusable な子要素を含まない長文ダイアログでもキーボードでスクロールできます (WCAG 2.1.1 / axe `scrollable-region-focusable`)。オーバーフローしていない通常のダイアログには tab stop を追加しません。focus ring は Button と同じ ring トークンの 2 段 box-shadow です。CSS クラス・属性セレクタの増減はありません (manifest 不変)。

--- a/.changeset/field-labelid-naming-345.md
+++ b/.changeset/field-labelid-naming-345.md
@@ -1,0 +1,11 @@
+---
+'@yasmro/schatten': minor
+---
+
+feat(lv1): FieldContext に `labelId` を追加 — Field label が self-labelled / group コンポーネントの accessible name になるように (#345)
+
+- `FieldContextValue` に `labelId?: string` を追加 (additive)。`<Field label>` が描画する `<label>` 要素に id が付き、context 経由で参照できます。
+- `Checkbox` / `Switch` は自前の `label` prop が無く、`aria-label` / `aria-labelledby` の明示指定も無い場合に限り、Field の label を `aria-labelledby` で参照します。`<Field label="Notifications"><Switch /></Field>` がスクリーンリーダーで「Notifications」と読み上げられるようになります (従来は無名 — axe `button-name` 違反)。
+- `RadioGroup` は group root (`role="radiogroup"`) で Field label を `aria-labelledby` 参照します (radiogroup は `htmlFor` では命名できないため)。
+- 優先順位: 明示の `aria-label` / `aria-labelledby` > 自前 `label` > Field の `labelId`。既存の利用形 (自前 label あり / Field 外) の出力 DOM は不変です。
+- 既知の限界: Field label クリックでの focus / toggle 連動は self-labelled コンポーネントでは効きません (SR 名の配線のみ)。

--- a/.claude/rules/component-architecture.md
+++ b/.claude/rules/component-architecture.md
@@ -224,6 +224,26 @@ internal label:
 Components with internal labels generate their own per-instance id (each
 checkbox is its own field).
 
+### `labelId` (naming fallback for self-labelled / group components)
+
+`FieldContext.labelId` is the id of the `<label>` element Field renders
+(undefined when Field has no `label` prop). It exists because the `htmlFor`
+hookup above cannot name two classes of children:
+
+- **Self-labelled components without an own `label`** —
+  `<Field label="Notifications"><Switch /></Field>` would otherwise leave the
+  Switch unnamed (the Field label's `htmlFor` points at the unconsumed
+  `field.id`). `Checkbox` / `Switch` apply
+  `aria-labelledby={field?.labelId}` only when they have no own `label` and
+  the consumer passed no explicit naming prop.
+- **`RadioGroup`** — a `role="radiogroup"` div cannot be reached by
+  `htmlFor` at all; the group root always applies `aria-labelledby` unless
+  the consumer names it explicitly.
+
+Precedence: explicit `aria-label` / `aria-labelledby` prop > own `label`
+prop > `field?.labelId`. Full consumption table and known limitations in
+[field-context-guideline](field-context-guideline.md#naming-via-labelid-self-labelled--group-components).
+
 ### Group components
 
 `RadioGroup` consumes state at the group level and re-provides a group-scoped
@@ -394,6 +414,11 @@ fallback — that policy only holds if the contract below holds.
      [field-context-guideline](field-context-guideline.md).
    - **Internal `<label>` rendered by the component** — self-labelled
      form inputs (Checkbox, Switch, Radio).
+   - **`aria-labelledby` auto-wired from the Field label via
+     `FieldContext.labelId`** — self-labelled form inputs placed inside a
+     `<Field label>` without their own `label` (Checkbox, Switch), and
+     `RadioGroup` at the group root. See
+     [field-context-guideline](field-context-guideline.md#naming-via-labelid-self-labelled--group-components).
    - **`aria-label`** — icon-only or symbol-only triggers. Required
      where a button has no readable text content: Dialog close ✕
      ([Dialog.tsx:217](../../src/components/lv1/Dialog/Dialog.tsx:217)),

--- a/.claude/rules/field-context-guideline.md
+++ b/.claude/rules/field-context-guideline.md
@@ -9,6 +9,7 @@ The `FieldContext` (`src/contexts/field.ts`) provides form field state to child 
 ```typescript
 interface FieldContextValue {
   id: string           // Generated id for label association
+  labelId?: string     // Id of the Field-rendered <label> (undefined when Field has no label)
   isError: boolean     // Error state
   disabled: boolean    // Disabled state
   describedBy?: string // aria-describedby value (description/error ids)
@@ -39,6 +40,10 @@ const id = idProp ?? autoId  // Don't use field?.id
 const isError = field?.isError ?? isErrorProp
 const disabled = field?.disabled ?? disabledProp
 const ariaDescribedBy = field?.describedBy ?? ariaDescribedByProp
+// When no own `label` (and no explicit naming) is given, the Field-rendered
+// label names the control via aria-labelledby — see "Naming via labelId".
+const ariaLabelledBy =
+  ariaLabelledByProp ?? (label || props['aria-label'] ? undefined : field?.labelId)
 ```
 
 ### Group components (RadioGroup)
@@ -50,8 +55,40 @@ const field = useFieldContext()
 const isError = field?.isError ?? isErrorProp
 const disabled = field?.disabled ?? disabledProp
 const ariaDescribedBy = field?.describedBy ?? ariaDescribedByProp
-// Do NOT use field?.id - RadioGroup doesn't need label association
+// Do NOT use field?.id - RadioGroup doesn't need label association.
+// The group IS named by the Field label, via aria-labelledby — a
+// role="radiogroup" div cannot be reached by htmlFor.
+const ariaLabelledBy =
+  ariaLabelledByProp ?? (props['aria-label'] ? undefined : field?.labelId)
 ```
+
+## Naming via `labelId` (self-labelled / group components)
+
+`Field` renders its `<label>` with `id={labelId}` and exposes that id through
+context. This closes the gap where `<Field label="…"><Switch /></Field>` left
+the Switch unnamed: the Field label's `htmlFor` points at `field.id`, which
+self-labelled components deliberately do not consume, so without `labelId`
+the association dangled (axe `button-name`, found in #345).
+
+| Consumer | When `field?.labelId` is applied |
+|---|---|
+| `Checkbox` / `Switch` | Only when the component has **no own `label`** and the consumer passed neither `aria-label` nor `aria-labelledby` |
+| `RadioGroup` | At the group root, unless the consumer passed `aria-label` / `aria-labelledby` (items keep their own labels) |
+| `Input` / `Textarea` / `Select` | Never — they consume `field.id` and are named natively via `htmlFor` |
+
+Precedence (per component-architecture §5): explicit `aria-label` /
+`aria-labelledby` prop > own `label` prop > `field?.labelId`.
+
+### Known limitations (accepted, documented)
+
+- **No click affordance.** Clicking the Field label does not focus/toggle a
+  self-labelled control — `htmlFor` still points at the unconsumed `field.id`.
+  Only the screen-reader name is wired. Consumers who need click-to-toggle
+  should use the component's own `label` prop.
+- **Multiple bare controls share the name.** Field is a wrapper around a
+  single form input; placing several label-less Checkboxes inside one Field
+  gives them all the same accessible name. Give each its own `label` /
+  `aria-label` instead.
 
 ## Accessibility Patterns
 

--- a/src/components/lv1/Checkbox/Checkbox.stories.tsx
+++ b/src/components/lv1/Checkbox/Checkbox.stories.tsx
@@ -97,9 +97,12 @@ export const States: Story = {
   name: 'States',
   render: () => (
     <div className="flex items-center gap-4">
-      <Checkbox />
-      <Checkbox defaultChecked />
-      <Checkbox checked="indeterminate" />
+      {/* Bare state-matrix checkboxes have no visible label by design —
+       * aria-label keeps the axe `button-name` rule green without changing
+       * a pixel (#345). */}
+      <Checkbox aria-label="Unchecked" />
+      <Checkbox defaultChecked aria-label="Checked" />
+      <Checkbox checked="indeterminate" aria-label="Indeterminate" />
     </div>
   ),
 }

--- a/src/components/lv1/Checkbox/Checkbox.test.tsx
+++ b/src/components/lv1/Checkbox/Checkbox.test.tsx
@@ -176,6 +176,34 @@ describe('Checkbox', () => {
       expect(internalLabel).toHaveAttribute('for', checkbox.id)
     })
 
+    it('takes its accessible name from the Field label when it has no own label', () => {
+      render(
+        <Field label="Terms">
+          <Checkbox />
+        </Field>,
+      )
+      expect(screen.getByRole('checkbox', { name: 'Terms' })).toBeInTheDocument()
+    })
+
+    it('prefers its own label over the Field label for naming', () => {
+      render(
+        <Field label="Terms">
+          <Checkbox label="Accept" />
+        </Field>,
+      )
+      const checkbox = screen.getByRole('checkbox', { name: 'Accept' })
+      expect(checkbox).not.toHaveAttribute('aria-labelledby')
+    })
+
+    it('prefers an explicit aria-label over the Field label', () => {
+      render(
+        <Field label="Terms">
+          <Checkbox aria-label="Custom name" />
+        </Field>,
+      )
+      expect(screen.getByRole('checkbox', { name: 'Custom name' })).toBeInTheDocument()
+    })
+
     it('prop isError overrides false Field context when used standalone', () => {
       render(<Checkbox aria-label="cb" isError />)
       expect(screen.getByRole('checkbox')).toHaveAttribute('aria-invalid', 'true')

--- a/src/components/lv1/Checkbox/Checkbox.tsx
+++ b/src/components/lv1/Checkbox/Checkbox.tsx
@@ -51,6 +51,7 @@ export const Checkbox = forwardRef<ElementRef<typeof CheckboxPrimitive.Root>, Ch
       id: idProp,
       disabled: disabledProp,
       'aria-describedby': ariaDescribedByProp,
+      'aria-labelledby': ariaLabelledByProp,
       ...props
     },
     ref,
@@ -63,6 +64,11 @@ export const Checkbox = forwardRef<ElementRef<typeof CheckboxPrimitive.Root>, Ch
     const isError = field?.isError ?? isErrorProp
     const disabled = field?.disabled ?? disabledProp
     const ariaDescribedBy = field?.describedBy ?? ariaDescribedByProp
+    // With no own `label` (and no explicit naming), the Field-rendered label
+    // names this control via aria-labelledby — htmlFor can't reach it because
+    // Checkbox keeps its own per-instance id. See field-context-guideline.
+    const ariaLabelledBy =
+      ariaLabelledByProp ?? (label || props['aria-label'] ? undefined : field?.labelId)
 
     return (
       <div className={cn('st-checkbox-wrapper', className)}>
@@ -72,6 +78,7 @@ export const Checkbox = forwardRef<ElementRef<typeof CheckboxPrimitive.Root>, Ch
           className={cn(checkboxVariants({ size }))}
           aria-invalid={isError || undefined}
           aria-describedby={ariaDescribedBy}
+          aria-labelledby={ariaLabelledBy}
           disabled={disabled}
           {...props}
         >

--- a/src/components/lv1/Dialog/Dialog.css
+++ b/src/components/lv1/Dialog/Dialog.css
@@ -141,6 +141,16 @@
     color: var(--color-foreground);
   }
 
+  /* The body receives tabIndex=0 from the React layer only while its
+   * content overflows (keyboard-scroll affordance — see Body in
+   * Dialog.tsx). Focus ring matches the Button treatment. */
+  .st-dialog__body:focus-visible {
+    outline: none;
+    box-shadow:
+      0 0 0 2px var(--color-ring-offset),
+      0 0 0 4px var(--color-ring);
+  }
+
   /* ===== footer =====
    * `.st-dialog__footer` is a flex container only. Per-button order is
    * a JSX-side concern (Tailwind utility on each Button — see comment

--- a/src/components/lv1/Dialog/Dialog.test.tsx
+++ b/src/components/lv1/Dialog/Dialog.test.tsx
@@ -40,6 +40,40 @@ describe('Dialog', () => {
     expect(screen.getByText('Body content')).toBeInTheDocument()
   })
 
+  describe('body scroll focusability', () => {
+    it('does not make the body a tab stop when content fits', () => {
+      // jsdom reports scrollHeight = clientHeight = 0 → not scrollable.
+      render(
+        <Controlled>
+          <p>Short content</p>
+        </Controlled>,
+      )
+      expect(document.querySelector('.st-dialog__body')).not.toHaveAttribute('tabindex')
+    })
+
+    it('makes the body focusable when content overflows', () => {
+      // Simulate overflow — jsdom has no layout, so pin the two metrics the
+      // Body effect compares.
+      const scrollHeight = vi
+        .spyOn(HTMLElement.prototype, 'scrollHeight', 'get')
+        .mockReturnValue(400)
+      const clientHeight = vi
+        .spyOn(HTMLElement.prototype, 'clientHeight', 'get')
+        .mockReturnValue(200)
+      try {
+        render(
+          <Controlled>
+            <p>Long content</p>
+          </Controlled>,
+        )
+        expect(document.querySelector('.st-dialog__body')).toHaveAttribute('tabindex', '0')
+      } finally {
+        scrollHeight.mockRestore()
+        clientHeight.mockRestore()
+      }
+    })
+  })
+
   it('does not render when isOpen is false', () => {
     render(<Controlled initialOpen={false} />)
     expect(screen.queryByText('Test dialog')).not.toBeInTheDocument()

--- a/src/components/lv1/Dialog/Dialog.tsx
+++ b/src/components/lv1/Dialog/Dialog.tsx
@@ -1,6 +1,6 @@
 import * as DialogPrimitive from '@radix-ui/react-dialog'
 import { type LucideIcon, X } from 'lucide-react'
-import { type ReactNode, useCallback, useEffect } from 'react'
+import { type ReactNode, useCallback, useEffect, useRef, useState } from 'react'
 import { Button } from '../Button'
 import { Separator } from '../Separator'
 import './Dialog.css'
@@ -128,7 +128,30 @@ function Header({ title, description }: { title: string; description?: string })
 }
 
 function Body({ children }: { children: ReactNode }) {
-  return <div className="st-dialog__body">{children}</div>
+  const ref = useRef<HTMLDivElement>(null)
+  const [isScrollable, setIsScrollable] = useState(false)
+
+  // The body is the dialog's only scroll region (`min-height: 0;
+  // overflow-y: auto` — Dialog.css). When it overflows and contains no
+  // focusable descendant, keyboard users can't scroll it (WCAG 2.1.1 /
+  // axe `scrollable-region-focusable`), so it becomes a tab stop — but
+  // only while actually overflowing, to avoid a dead stop in the common
+  // non-scrolling case.
+  useEffect(() => {
+    const el = ref.current
+    if (!el) return
+    const check = () => setIsScrollable(el.scrollHeight > el.clientHeight)
+    check()
+    const observer = new ResizeObserver(check)
+    observer.observe(el)
+    return () => observer.disconnect()
+  }, [])
+
+  return (
+    <div ref={ref} className="st-dialog__body" tabIndex={isScrollable ? 0 : undefined}>
+      {children}
+    </div>
+  )
 }
 
 function Footer({

--- a/src/components/lv1/Dialog/Dialog.tsx
+++ b/src/components/lv1/Dialog/Dialog.tsx
@@ -137,6 +137,12 @@ function Body({ children }: { children: ReactNode }) {
   // axe `scrollable-region-focusable`), so it becomes a tab stop — but
   // only while actually overflowing, to avoid a dead stop in the common
   // non-scrolling case.
+  //
+  // Known limit: ResizeObserver watches the body's own box, so content
+  // that grows after mount *without* changing that box (async load while
+  // already pinned at max-height) won't re-run the check until the next
+  // resize. Acceptable today — dialog content is static at mount in all
+  // current usages; revisit if a consumer streams content into the body.
   useEffect(() => {
     const el = ref.current
     if (!el) return

--- a/src/components/lv1/Field/Field.test.tsx
+++ b/src/components/lv1/Field/Field.test.tsx
@@ -10,6 +10,7 @@ function ContextConsumer() {
   return (
     <div data-testid="context-consumer">
       <span data-testid="context-id">{context?.id}</span>
+      <span data-testid="context-labelId">{context?.labelId ?? 'undefined'}</span>
       <span data-testid="context-isError">{String(context?.isError)}</span>
       <span data-testid="context-disabled">{String(context?.disabled)}</span>
       <span data-testid="context-describedBy">{context?.describedBy ?? 'undefined'}</span>
@@ -75,6 +76,26 @@ describe('Field', () => {
       const id = screen.getByTestId('context-id').textContent
       expect(id).toBeTruthy()
       expect(id?.length).toBeGreaterThan(0)
+    })
+
+    it('provides labelId pointing at the rendered label element', () => {
+      render(
+        <Field label="Email">
+          <ContextConsumer />
+        </Field>,
+      )
+      const labelId = screen.getByTestId('context-labelId').textContent
+      expect(labelId).toContain('-label')
+      expect(screen.getByText('Email')).toHaveAttribute('id', labelId)
+    })
+
+    it('provides labelId as undefined when no label is set', () => {
+      render(
+        <Field>
+          <ContextConsumer />
+        </Field>,
+      )
+      expect(screen.getByTestId('context-labelId').textContent).toBe('undefined')
     })
 
     it('provides isError=true when error prop is set', () => {

--- a/src/components/lv1/Field/Field.tsx
+++ b/src/components/lv1/Field/Field.tsx
@@ -62,6 +62,7 @@ export function Field({
 }: FieldProps) {
   const fieldSet = useFieldSetContext()
   const id = useId()
+  const labelId = `${id}-label`
   const descriptionId = `${id}-description`
   const errorId = `${id}-error`
 
@@ -75,9 +76,16 @@ export function Field({
     return ids.length > 0 ? ids.join(' ') : undefined
   }, [description, error, descriptionId, errorId])
 
+  const hasLabel = !!label
   const contextValue = useMemo<FieldContextValue>(
-    () => ({ id, isError, disabled: effectiveDisabled, describedBy }),
-    [id, isError, effectiveDisabled, describedBy],
+    () => ({
+      id,
+      labelId: hasLabel ? labelId : undefined,
+      isError,
+      disabled: effectiveDisabled,
+      describedBy,
+    }),
+    [id, labelId, hasLabel, isError, effectiveDisabled, describedBy],
   )
 
   return (
@@ -95,7 +103,10 @@ export function Field({
       >
         {label && (
           <div className="st-field__label-row">
-            <label htmlFor={id} className="st-field__label">
+            {/* `id` makes this label referenceable via aria-labelledby for
+             * self-labelled / group children that htmlFor cannot reach
+             * (Checkbox / Switch / RadioGroup) — see field-context-guideline. */}
+            <label id={labelId} htmlFor={id} className="st-field__label">
               {label}
               {required && <span className="st-field__required-marker">*</span>}
             </label>

--- a/src/components/lv1/Input/Input.stories.tsx
+++ b/src/components/lv1/Input/Input.stories.tsx
@@ -250,8 +250,11 @@ export const Types: Story = {
       <Input type="password" placeholder="Password" />
       <Input type="number" placeholder="Number" />
       <Input type="search" placeholder="Search" />
-      <Input type="date" />
-      <Input type="datetime-local" />
+      {/* date/datetime-local don't support placeholder, and value-only inputs
+       * have no accessible name — these stories carry aria-label so the axe
+       * `label` rule passes without changing a pixel (#345). */}
+      <Input type="date" aria-label="Date" />
+      <Input type="datetime-local" aria-label="Date and time" />
     </div>
   ),
 }
@@ -293,7 +296,7 @@ export const ErrorState: Story = {
   render: () => (
     <div className="flex flex-col gap-4 w-72">
       <Input isError placeholder="Error state" />
-      <Input isError defaultValue="Invalid input" />
+      <Input isError defaultValue="Invalid input" aria-label="Invalid input" />
       <Input isError iconLeft={CircleAlert} placeholder="With icon" />
     </div>
   ),
@@ -304,7 +307,7 @@ export const Disabled: Story = {
   render: () => (
     <div className="flex flex-col gap-4 w-72">
       <Input disabled placeholder="Disabled" />
-      <Input disabled defaultValue="Disabled with value" />
+      <Input disabled defaultValue="Disabled with value" aria-label="Disabled with value" />
     </div>
   ),
 }
@@ -314,7 +317,7 @@ export const DisabledWithError: Story = {
   render: () => (
     <div className="flex flex-col gap-4 w-72">
       <Input disabled isError placeholder="Disabled + error" />
-      <Input disabled isError defaultValue="Disabled + error" />
+      <Input disabled isError defaultValue="Disabled + error" aria-label="Disabled with error" />
     </div>
   ),
 }
@@ -323,9 +326,9 @@ export const ReadOnly: Story = {
   name: 'ReadOnly',
   render: () => (
     <div className="flex flex-col gap-4 w-72">
-      <Input readOnly defaultValue="Read-only value" />
-      <Input readOnly iconLeft={Lock} defaultValue="With icon" />
-      <Input readOnly textLeft="ID" defaultValue="usr_123456" />
+      <Input readOnly defaultValue="Read-only value" aria-label="Read-only value" />
+      <Input readOnly iconLeft={Lock} defaultValue="With icon" aria-label="With icon" />
+      <Input readOnly textLeft="ID" defaultValue="usr_123456" aria-label="User ID" />
     </div>
   ),
 }
@@ -335,11 +338,11 @@ export const DisabledVsReadOnly: Story = {
   render: () => (
     <div className="flex flex-col gap-3 w-72">
       <div className="text-xs text-foreground-muted">Default</div>
-      <Input defaultValue="Editable value" />
+      <Input defaultValue="Editable value" aria-label="Editable value" />
       <div className="text-xs text-foreground-muted mt-2">ReadOnly (informational)</div>
-      <Input readOnly defaultValue="Read-only value" />
+      <Input readOnly defaultValue="Read-only value" aria-label="Read-only value" />
       <div className="text-xs text-foreground-muted mt-2">Disabled (cannot interact)</div>
-      <Input disabled defaultValue="Disabled value" />
+      <Input disabled defaultValue="Disabled value" aria-label="Disabled value" />
     </div>
   ),
 }
@@ -348,7 +351,7 @@ export const ReadOnlyWithError: Story = {
   name: 'ReadOnly with error',
   render: () => (
     <div className="flex flex-col gap-4 w-72">
-      <Input readOnly isError defaultValue="ReadOnly + error" />
+      <Input readOnly isError defaultValue="ReadOnly + error" aria-label="ReadOnly with error" />
     </div>
   ),
 }

--- a/src/components/lv1/Radio/Radio.test.tsx
+++ b/src/components/lv1/Radio/Radio.test.tsx
@@ -228,6 +228,28 @@ describe('Radio', () => {
       const group = container.querySelector('[role="radiogroup"]')
       expect(group?.getAttribute('aria-describedby')).toContain('-description')
     })
+
+    it('RadioGroup takes its accessible name from the Field label', () => {
+      render(
+        <Field label="Pick one">
+          <RadioGroup>
+            <Radio value="a" label="A" />
+          </RadioGroup>
+        </Field>,
+      )
+      expect(screen.getByRole('radiogroup', { name: 'Pick one' })).toBeInTheDocument()
+    })
+
+    it('prefers an explicit aria-label on RadioGroup over the Field label', () => {
+      render(
+        <Field label="Pick one">
+          <RadioGroup aria-label="Custom name">
+            <Radio value="a" label="A" />
+          </RadioGroup>
+        </Field>,
+      )
+      expect(screen.getByRole('radiogroup', { name: 'Custom name' })).toBeInTheDocument()
+    })
   })
 
   it('forwards className on the radio wrapper', () => {

--- a/src/components/lv1/Radio/Radio.tsx
+++ b/src/components/lv1/Radio/Radio.tsx
@@ -51,6 +51,7 @@ export const RadioGroup = forwardRef<ElementRef<typeof RadioGroupPrimitive.Root>
       children,
       disabled: disabledProp,
       'aria-describedby': ariaDescribedByProp,
+      'aria-labelledby': ariaLabelledByProp,
       ...props
     },
     ref,
@@ -60,6 +61,10 @@ export const RadioGroup = forwardRef<ElementRef<typeof RadioGroupPrimitive.Root>
     const isError = field?.isError ?? isErrorProp
     const disabled = field?.disabled ?? disabledProp ?? false
     const ariaDescribedBy = field?.describedBy ?? ariaDescribedByProp
+    // role="radiogroup" cannot be named through htmlFor, so the Field-rendered
+    // label names the group via aria-labelledby (unless the consumer names it
+    // explicitly). Individual Radio items keep their own labels.
+    const ariaLabelledBy = ariaLabelledByProp ?? (props['aria-label'] ? undefined : field?.labelId)
 
     return (
       <RadioGroupContext.Provider value={{ isError, disabled, size }}>
@@ -69,6 +74,7 @@ export const RadioGroup = forwardRef<ElementRef<typeof RadioGroupPrimitive.Root>
           className={cn('st-radio-group', className)}
           aria-invalid={isError || undefined}
           aria-describedby={ariaDescribedBy}
+          aria-labelledby={ariaLabelledBy}
           {...props}
         >
           {children}

--- a/src/components/lv1/Select/Select.stories.tsx
+++ b/src/components/lv1/Select/Select.stories.tsx
@@ -83,8 +83,11 @@ export const Sizes: Story = {
   name: 'Sizes',
   render: () => (
     <div className="flex flex-col gap-4">
+      {/* role="combobox" gets no accessible name from its content, so every
+       * standalone trigger carries aria-label (the real-usage alternative is
+       * a wrapping <Field label> — see SelectTriggerProps TSDoc) (#345). */}
       <Select>
-        <SelectTrigger size="sm">
+        <SelectTrigger size="sm" aria-label="Small select">
           <SelectValue placeholder="Small" />
         </SelectTrigger>
         <SelectContent>
@@ -93,7 +96,7 @@ export const Sizes: Story = {
         </SelectContent>
       </Select>
       <Select>
-        <SelectTrigger size="md">
+        <SelectTrigger size="md" aria-label="Medium select">
           <SelectValue placeholder="Medium" />
         </SelectTrigger>
         <SelectContent>
@@ -102,7 +105,7 @@ export const Sizes: Story = {
         </SelectContent>
       </Select>
       <Select>
-        <SelectTrigger size="lg">
+        <SelectTrigger size="lg" aria-label="Large select">
           <SelectValue placeholder="Large" />
         </SelectTrigger>
         <SelectContent>
@@ -118,7 +121,7 @@ export const WithGroups: Story = {
   name: 'With Groups',
   render: () => (
     <Select>
-      <SelectTrigger>
+      <SelectTrigger aria-label="Food">
         <SelectValue placeholder="Select a food" />
       </SelectTrigger>
       <SelectContent>
@@ -145,7 +148,7 @@ export const ErrorState: Story = {
   render: () => (
     <div className="flex flex-col gap-4">
       <Select>
-        <SelectTrigger isError>
+        <SelectTrigger isError aria-label="Error state">
           <SelectValue placeholder="Error state" />
         </SelectTrigger>
         <SelectContent>
@@ -154,7 +157,7 @@ export const ErrorState: Story = {
         </SelectContent>
       </Select>
       <Select defaultValue="apple">
-        <SelectTrigger isError>
+        <SelectTrigger isError aria-label="Error state with value">
           <SelectValue />
         </SelectTrigger>
         <SelectContent>
@@ -171,7 +174,7 @@ export const Disabled: Story = {
   render: () => (
     <div className="flex flex-col gap-4">
       <Select disabled>
-        <SelectTrigger>
+        <SelectTrigger aria-label="Disabled">
           <SelectValue placeholder="Disabled" />
         </SelectTrigger>
         <SelectContent>
@@ -179,7 +182,7 @@ export const Disabled: Story = {
         </SelectContent>
       </Select>
       <Select disabled defaultValue="apple">
-        <SelectTrigger>
+        <SelectTrigger aria-label="Disabled with value">
           <SelectValue />
         </SelectTrigger>
         <SelectContent>
@@ -195,7 +198,7 @@ export const DisabledWithError: Story = {
   render: () => (
     <div className="flex flex-col gap-4">
       <Select disabled>
-        <SelectTrigger isError>
+        <SelectTrigger isError aria-label="Disabled with error">
           <SelectValue placeholder="Disabled + error" />
         </SelectTrigger>
         <SelectContent>
@@ -203,7 +206,7 @@ export const DisabledWithError: Story = {
         </SelectContent>
       </Select>
       <Select disabled defaultValue="apple">
-        <SelectTrigger isError>
+        <SelectTrigger isError aria-label="Disabled error with value">
           <SelectValue />
         </SelectTrigger>
         <SelectContent>
@@ -220,7 +223,7 @@ export const ManyItems: Story = {
     const items = Array.from({ length: 50 }, (_, i) => `Item ${i + 1}`)
     return (
       <Select>
-        <SelectTrigger>
+        <SelectTrigger aria-label="Items">
           <SelectValue placeholder="50 items" />
         </SelectTrigger>
         <SelectContent>
@@ -239,7 +242,7 @@ export const LongText: Story = {
   name: 'Long Text',
   render: () => (
     <Select>
-      <SelectTrigger>
+      <SelectTrigger aria-label="Option">
         <SelectValue placeholder="Select an option" />
       </SelectTrigger>
       <SelectContent>
@@ -261,7 +264,7 @@ export const DisabledItems: Story = {
   name: 'Disabled Items',
   render: () => (
     <Select>
-      <SelectTrigger>
+      <SelectTrigger aria-label="Availability">
         <SelectValue placeholder="Some items disabled" />
       </SelectTrigger>
       <SelectContent>
@@ -296,10 +299,18 @@ export const DisabledItems: Story = {
  */
 export const OpenContent: Story = {
   name: 'Open Content (VRT)',
-  parameters: { layout: 'padded', docs: { disable: true } },
+  parameters: {
+    layout: 'padded',
+    docs: { disable: true },
+    // Known Radix behavior, not fixable from Schatten: while open, Radix
+    // hides the rest of the page via aria-hidden but leaves the trigger
+    // focusable (focus is trapped in the listbox, so there is no real
+    // keyboard escape). Mirrors the same disable in Select.vrt.spec.ts.
+    a11y: { config: { rules: [{ id: 'aria-hidden-focus', enabled: false }] } },
+  },
   render: () => (
     <Select defaultOpen>
-      <SelectTrigger>
+      <SelectTrigger aria-label="Choose">
         <SelectValue placeholder="Choose" />
       </SelectTrigger>
       <SelectContent>

--- a/src/components/lv1/Select/Select.tsx
+++ b/src/components/lv1/Select/Select.tsx
@@ -32,6 +32,15 @@ SelectValue.displayName = SelectPrimitive.Value.displayName
 
 /* ----- Trigger ----- */
 
+/**
+ * Props for the select trigger button.
+ *
+ * Accessible name: the trigger renders as `role="combobox"`, which does NOT
+ * derive its name from content — the visible placeholder / selected value
+ * never becomes the accessible name. Always render the trigger inside a
+ * `<Field label="…">` (named via the Field label's `htmlFor`) or pass an
+ * explicit `aria-label`.
+ */
 export interface SelectTriggerProps
   extends Omit<ComponentPropsWithoutRef<typeof SelectPrimitive.Trigger>, 'size' | 'asChild'>,
     SelectTriggerVariants {

--- a/src/components/lv1/Select/Select.vrt.spec.ts
+++ b/src/components/lv1/Select/Select.vrt.spec.ts
@@ -99,6 +99,12 @@ for (const story of portalStories) {
 
       const results = await new AxeBuilder({ page })
         .withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa'])
+        // Known Radix behavior, not fixable from Schatten: while open, Radix
+        // (hideOthers) sets aria-hidden on #storybook-root but leaves the
+        // trigger focusable. Focus is trapped in the portaled listbox, so no
+        // real keyboard escape exists — disable just this rule, just here.
+        // Mirrored in the story's `parameters.a11y` for the addon panel.
+        .disableRules(['aria-hidden-focus'])
         .analyze()
 
       expect(results.violations).toEqual([])

--- a/src/components/lv1/Switch/Switch.stories.tsx
+++ b/src/components/lv1/Switch/Switch.stories.tsx
@@ -95,8 +95,11 @@ export const States: Story = {
   name: 'States',
   render: () => (
     <div className="flex items-center gap-4">
-      <Switch />
-      <Switch defaultChecked />
+      {/* Bare state-matrix switches have no visible label by design —
+       * aria-label keeps the axe `button-name` rule green without changing
+       * a pixel (#345). */}
+      <Switch aria-label="Off" />
+      <Switch defaultChecked aria-label="On" />
     </div>
   ),
 }

--- a/src/components/lv1/Switch/Switch.test.tsx
+++ b/src/components/lv1/Switch/Switch.test.tsx
@@ -170,6 +170,34 @@ describe('Switch', () => {
       const internalLabel = screen.getByText('Toggle')
       expect(internalLabel).toHaveAttribute('for', sw.id)
     })
+
+    it('takes its accessible name from the Field label when it has no own label', () => {
+      render(
+        <Field label="Notifications">
+          <Switch />
+        </Field>,
+      )
+      expect(screen.getByRole('switch', { name: 'Notifications' })).toBeInTheDocument()
+    })
+
+    it('prefers its own label over the Field label for naming', () => {
+      render(
+        <Field label="Notifications">
+          <Switch label="Toggle" />
+        </Field>,
+      )
+      const sw = screen.getByRole('switch', { name: 'Toggle' })
+      expect(sw).not.toHaveAttribute('aria-labelledby')
+    })
+
+    it('prefers an explicit aria-label over the Field label', () => {
+      render(
+        <Field label="Notifications">
+          <Switch aria-label="Custom name" />
+        </Field>,
+      )
+      expect(screen.getByRole('switch', { name: 'Custom name' })).toBeInTheDocument()
+    })
   })
 
   it('forwards className to the wrapper', () => {

--- a/src/components/lv1/Switch/Switch.tsx
+++ b/src/components/lv1/Switch/Switch.tsx
@@ -45,6 +45,7 @@ export const Switch = forwardRef<ElementRef<typeof SwitchPrimitive.Root>, Switch
       id: idProp,
       disabled: disabledProp,
       'aria-describedby': ariaDescribedByProp,
+      'aria-labelledby': ariaLabelledByProp,
       ...props
     },
     ref,
@@ -57,6 +58,11 @@ export const Switch = forwardRef<ElementRef<typeof SwitchPrimitive.Root>, Switch
     const isError = field?.isError ?? isErrorProp
     const disabled = field?.disabled ?? disabledProp
     const ariaDescribedBy = field?.describedBy ?? ariaDescribedByProp
+    // With no own `label` (and no explicit naming), the Field-rendered label
+    // names this control via aria-labelledby — htmlFor can't reach it because
+    // Switch keeps its own per-instance id. See field-context-guideline.
+    const ariaLabelledBy =
+      ariaLabelledByProp ?? (label || props['aria-label'] ? undefined : field?.labelId)
 
     return (
       <div className={cn('st-switch-wrapper', className)}>
@@ -66,6 +72,7 @@ export const Switch = forwardRef<ElementRef<typeof SwitchPrimitive.Root>, Switch
           className={cn(switchVariants({ size }))}
           aria-invalid={isError || undefined}
           aria-describedby={ariaDescribedBy}
+          aria-labelledby={ariaLabelledBy}
           disabled={disabled}
           {...props}
         >

--- a/src/components/lv1/Textarea/Textarea.stories.tsx
+++ b/src/components/lv1/Textarea/Textarea.stories.tsx
@@ -88,7 +88,10 @@ export const ErrorState: Story = {
   render: () => (
     <div className="flex flex-col gap-4 w-80">
       <Textarea isError placeholder="Error state" rows={3} />
-      <Textarea isError defaultValue="Invalid input" rows={3} />
+      {/* Value-only textareas have no accessible name — these stories carry
+       * aria-label so the axe `label` rule passes without changing a pixel
+       * (#345). */}
+      <Textarea isError defaultValue="Invalid input" rows={3} aria-label="Invalid input" />
     </div>
   ),
 }
@@ -98,7 +101,12 @@ export const Disabled: Story = {
   render: () => (
     <div className="flex flex-col gap-4 w-80">
       <Textarea disabled placeholder="Disabled" rows={3} />
-      <Textarea disabled defaultValue="Disabled with value" rows={3} />
+      <Textarea
+        disabled
+        defaultValue="Disabled with value"
+        rows={3}
+        aria-label="Disabled with value"
+      />
     </div>
   ),
 }
@@ -108,7 +116,13 @@ export const DisabledWithError: Story = {
   render: () => (
     <div className="flex flex-col gap-4 w-80">
       <Textarea disabled isError placeholder="Disabled + error" rows={3} />
-      <Textarea disabled isError defaultValue="Disabled + error" rows={3} />
+      <Textarea
+        disabled
+        isError
+        defaultValue="Disabled + error"
+        rows={3}
+        aria-label="Disabled with error"
+      />
     </div>
   ),
 }
@@ -117,11 +131,12 @@ export const ReadOnly: Story = {
   name: 'ReadOnly',
   render: () => (
     <div className="flex flex-col gap-4 w-80">
-      <Textarea readOnly defaultValue="Read-only value." rows={3} />
+      <Textarea readOnly defaultValue="Read-only value." rows={3} aria-label="Read-only value" />
       <Textarea
         readOnly
         defaultValue={'Multi-line read-only content.\nSelectable, but not editable.'}
         rows={4}
+        aria-label="Multi-line read-only content"
       />
     </div>
   ),
@@ -132,11 +147,16 @@ export const DisabledVsReadOnly: Story = {
   render: () => (
     <div className="flex flex-col gap-3 w-80">
       <div className="text-xs text-foreground-muted">Default</div>
-      <Textarea defaultValue="Editable content." rows={2} />
+      <Textarea defaultValue="Editable content." rows={2} aria-label="Editable content" />
       <div className="text-xs text-foreground-muted mt-2">ReadOnly (informational)</div>
-      <Textarea readOnly defaultValue="Read-only content." rows={2} />
+      <Textarea
+        readOnly
+        defaultValue="Read-only content."
+        rows={2}
+        aria-label="Read-only content"
+      />
       <div className="text-xs text-foreground-muted mt-2">Disabled (cannot interact)</div>
-      <Textarea disabled defaultValue="Disabled content." rows={2} />
+      <Textarea disabled defaultValue="Disabled content." rows={2} aria-label="Disabled content" />
     </div>
   ),
 }
@@ -145,7 +165,13 @@ export const ReadOnlyWithError: Story = {
   name: 'ReadOnly with error',
   render: () => (
     <div className="flex flex-col gap-4 w-80">
-      <Textarea readOnly isError defaultValue="ReadOnly + error" rows={3} />
+      <Textarea
+        readOnly
+        isError
+        defaultValue="ReadOnly + error"
+        rows={3}
+        aria-label="ReadOnly with error"
+      />
     </div>
   ),
 }

--- a/src/contexts/field.ts
+++ b/src/contexts/field.ts
@@ -3,6 +3,14 @@ import { createContext, useContext } from 'react'
 export interface FieldContextValue {
   /** Input element id */
   id: string
+  /**
+   * Id of the `<label>` element Field renders. Consumed via `aria-labelledby`
+   * by self-labelled components (Checkbox / Switch) when they have no own
+   * `label`, and by group components (RadioGroup) at the group root —
+   * `role="radiogroup"` cannot be named through `htmlFor`.
+   * Undefined when Field has no `label` prop.
+   */
+  labelId?: string
   /** Error state */
   isError: boolean
   /** Disabled state */


### PR DESCRIPTION
## What

- **FieldContext に `labelId` を追加** — `<Field label>` が描画する label 要素に id を付け、自前 label を持たない Checkbox / Switch と RadioGroup root が `aria-labelledby` で Field label を accessible name として参照するように。`<Field label="Notifications"><Switch /></Field>` の「宙に浮く htmlFor」ギャップを解消 (優先順位: 明示の `aria-label` / `aria-labelledby` > 自前 `label` > `labelId`)。
- **Dialog 本文の keyboard スクロール** — `.st-dialog__body` がオーバーフローした時のみ `tabIndex={0}` (ResizeObserver 検知) + focus ring。focusable 子要素の無い長文ダイアログを keyboard でスクロール可能に (WCAG 2.1.1 / axe `scrollable-region-focusable`)。
- **状態マトリクス story の bare control に `aria-label`** — Input / Textarea / Checkbox / Switch / Select の value-only / label-less control。ピクセル不変なので VRT baseline 再生成ゼロ。
- **Select open-content の `aria-hidden-focus` を rule 単位 disable** — Radix が開時に page を aria-hidden しつつ trigger を focusable に残す既知動作 (focus は listbox にトラップ済みで実害なし)。spec と story `parameters.a11y` の両方に理由コメント。
- `SelectTrigger` TSDoc に「`role="combobox"` は content から accessible name を得ない (Field 内で使うか aria-label)」を明記。rule docs (field-context-guideline / component-architecture §5・§8) を同期。

## Why

PR #343 (#147 Phase 1) の triage で検出された `label` / `button-name` / `aria-hidden-focus` / `scrollable-region-focusable` 違反の解消 (#345)。大半は story artifact だが、refinement で 2 件の真の欠陥 (Dialog の scroll 領域 / Field × self-labelled の名前配線ギャップ) が確定し、後者は `labelId` 配線というコンポーネント修正により「実利用形の story (`Field/disabled`) がそのまま通る」形にした。#346 (a11y job の blocking 昇格) の前提の片翼 (もう片翼は #344 color-contrast)。

## Related rules

- [.claude/rules/field-context-guideline.md](.claude/rules/field-context-guideline.md) — `labelId` 配線ルール (消費表 / 優先順位 / 既知の限界) を新設
- [.claude/rules/component-architecture.md](.claude/rules/component-architecture.md) — §5 context 消費の統一ルール / §8 accessible name ソース一覧に追記
- [.claude/rules/vrt-spec-guideline.md](.claude/rules/vrt-spec-guideline.md) — a11y assertion / re-baseline 規律に準拠 (baseline 変更ゼロ)

## Test plan

- [x] `pnpm lint` 緑
- [x] `pnpm test --run` 緑 (789 passed — labelId 配線 ×9 / Dialog tabIndex ×2 を新規追加)
- [x] `pnpm typecheck` 緑
- [x] `pnpm check:manifest` 緑 (CSS surface 不変 — focus-visible ルールは既存クラスへの追加宣言のみ)
- [x] a11y: 影響 8 コンポーネントの a11y spec をローカル実行 — `label` / `button-name` / `aria-hidden-focus` / `scrollable-region-focusable` の violation **0 件** (残 34 failures はすべて color-contrast = #344 スコープ)
- [x] VRT: 影響 8 コンポーネント 131 screenshots を committed baseline と比較し**ゼロ diff で pass** (再生成なし)

closes #345

🤖 Generated with [Claude Code](https://claude.com/claude-code)
