### PR TITLE
docs(storybook): Providers/* ストーリーを 7 グループ IA 内の Theming/* へ移設

### DIFF
--- a/.changeset/providers-stories-theming-ia-3b7e.md
+++ b/.changeset/providers-stories-theming-ia-3b7e.md
@@ -1,0 +1,13 @@
+---
+'@yasmro/schatten': patch
+---
+
+docs(storybook): `Providers/*` ストーリーを docs IA 7 グループ内の `Theming/*` へ移設
+
+`Providers/ThemeProvider` / `Providers/ThemeInitScript` は #320 で確定した
+7 グループ IA (storybook-guideline §Story title taxonomy) の外側に 8 番目の
+トップレベルを作っていた。両者は Mode × Special のランタイム機構なので
+決定表「Anything about Mode × Special → Theming」に従い
+`Theming/ThemeProvider` / `Theming/ThemeInitScript` へ retitle。
+旧 story ID (`providers-*`) への参照は VRT spec / Welcome deep link /
+storySort のいずれにも存在しないことを確認済み。公開 API の変更なし。

--- a/src/providers/ThemeProvider/ThemeInitScript.stories.tsx
+++ b/src/providers/ThemeProvider/ThemeInitScript.stories.tsx
@@ -4,7 +4,7 @@ import { buildThemeInitScript } from '../../theme-init'
 import { ThemeInitScript } from './ThemeInitScript'
 
 const meta: Meta<typeof ThemeInitScript> = {
-  title: 'Providers/ThemeInitScript',
+  title: 'Theming/ThemeInitScript',
   component: ThemeInitScript,
   parameters: {
     layout: 'centered',

--- a/src/providers/ThemeProvider/ThemeProvider.stories.tsx
+++ b/src/providers/ThemeProvider/ThemeProvider.stories.tsx
@@ -8,7 +8,7 @@ import type { SpecialThemeId, ThemeModeSetting } from './theme-context'
 import { useTheme } from './useTheme'
 
 const meta: Meta<typeof ThemeProvider> = {
-  title: 'Providers/ThemeProvider',
+  title: 'Theming/ThemeProvider',
   component: ThemeProvider,
   parameters: {
     layout: 'centered',


### PR DESCRIPTION
## 概要

`Providers/ThemeProvider` / `Providers/ThemeInitScript` の 2 ストーリーが、#320 で確定した docs IA の 7 グループ cap (storybook-guideline §Story title taxonomy — "do not invent an 8th top-level group") の外側に 8 番目のトップレベル `Providers` を作っていたため、`Theming/*` へ移設する。

## 配置の判断

storybook-guideline の決定表「**Anything about Mode × Special → `Theming`**」に従う:

- `ThemeProvider` — Mode × Special のランタイム機構 (React provider + localStorage 永続化) そのもの
- `ThemeInitScript` — その FOUC 回避スニペット (persisted Mode / Special を first paint 前に適用)

いずれも Theming グループの責務 ("The Mode × Special theme machinery") に合致し、`Getting Started` (統合オンランプ) より機構ドキュメントとしての性格が強い。

## 変更内容

- `title: 'Providers/ThemeProvider'` → `'Theming/ThemeProvider'`
- `title: 'Providers/ThemeInitScript'` → `'Theming/ThemeInitScript'`
- changeset (`patch`, `docs(storybook):`)

## story-ID rename チェック (storybook-guideline §Renaming a story title)

旧 slug `providers-*` への参照を repo 全体で grep し、**ゼロ件**を確認:

- VRT spec の `STORY_ID_PREFIX` — providers 配下に `*.vrt.spec.ts` は存在しない (snapshot 影響なし)
- `Welcome.stories.tsx` の `navigateToStory(...)` deep link — 参照なし
- `.storybook/preview.tsx` の `options.storySort.order` — 7 グループのみ列挙のため変更不要 (移設後は既存の `Theming` 順序に乗る)

Story ID は internal (api-stability.md — Storybook は published package 外) のため breaking ではない。

## 検証

- `biome check` / `typecheck` ✅ (pre-commit hook でも再実行済み)
- Storybook dev server で `index.json` を確認 — `providers-*` エントリ消滅、`theming-themeprovider--*` (5 stories + docs) / `theming-themeinitscript--*` が `theming-theme-audit--*` と同居 ✅
- 新 ID で両 Playground を実描画 — ThemePanel / snippet パネルとも正常レンダ、console エラーなし ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)
