### PR TITLE
fix(storybook): Paint Without Re-Render story の Badge stretch を解消

### DIFF
--- a/src/providers/ThemeProvider/ThemeProvider.stories.tsx
+++ b/src/providers/ThemeProvider/ThemeProvider.stories.tsx
@@ -221,7 +221,7 @@ export const PaintWithoutReactReRender: Story = {
             Inner component mounted with random id <strong>{counter}</strong>. Switch theme above —
             this number does NOT change, proving the JSX subtree did not re-render.
           </Text>
-          <div className="flex gap-2">
+          <div className="flex items-center gap-2">
             <Button variant="primary">Primary</Button>
             <Button variant="secondary">Secondary</Button>
             <Badge variant="success">Success</Badge>


### PR DESCRIPTION
## 概要

`Theming/ThemeProvider` の **Paint Without Re-Render** story で、Badge の上下余白が不自然に広く見える問題を修正します。

## 原因

Badge 自体の padding は正常。story 側の Button + Badge 混在行 `<div class="flex gap-2">` が `align-items` 未指定（デフォルト `stretch`）のため、固有 height を持たない Badge（自然高 26px）が同じ行の Button の高さ（40px）まで縦に引き伸ばされていた。

## 修正

親の flex 行に `items-center` を 1 語追加（story-only、1 行変更）。

## 判断メモ

- **Badge 本体は無変更。** `align-self: center` の焼き込みは `items-baseline` レイアウトを壊し、固定 height は padding + line-height ベースの現サイズ契約（PR #283 で pixel-faithful に固定）の作り直し + 全 Badge baseline の re-baseline になるため、レイアウト側（親）での修正が正。shadcn/ui Badge も同挙動。
- この story に VRT spec はなし → baseline 更新不要。
- story は published package 外（api-stability 上 internal）→ changeset 不要。

## 検証

worktree の Storybook で修正後を確認: Badge 26px / Button 40px、行内で垂直中央揃え。

🤖 Generated with [Claude Code](https://claude.com/claude-code)