### PR TITLE
test(storybook): Welcome deep-link の drift test を追加 (closes #375)

### DIFF
--- a/.claude/rules/storybook-guideline.md
+++ b/.claude/rules/storybook-guideline.md
@@ -243,15 +243,32 @@ README and CLAUDE.md only point here, they do not restate it.
   persona #2). A page that fits none of the seven is a signal to discuss,
   not to add a category.
 
-### Renaming a story title is a story-ID change
+### Renaming a story title (or export) is a story-ID change
 
-A story's `title` determines its story ID (URL slug — Storybook kebab-cases
-it: `Tokens/Color` → `tokens-color`). Renaming a title therefore breaks every
-place that hard-codes the old slug. When you change a `title`, fix all of
-these **in the same PR**:
+A story ID has two halves and **both** are derived from source, so a rename of
+either silently breaks any hard-coded link:
+
+- the **slug** (left of `--`) comes from `meta.title` — Storybook kebab-cases
+  it: `Tokens/Color` → `tokens-color`.
+- the **suffix** (right of `--`) comes from the **story export name**, not the
+  story's `name:` field. `export const ButtonAsLink` → `…--button-as-link`
+  regardless of any `name: '…'`. Renaming the export changes the URL; changing
+  only `name:` does **not** (e.g. CSSApi's `export const Reference` keeps
+  `…--reference` despite `name: 'Reference (all 18 lv1 components)'`).
+
+When you change a `title` **or rename a story export that something links to**,
+fix all of these **in the same PR**:
 
 - the VRT spec's `STORY_ID_PREFIX` (e.g. `src/docs/CSSApi.vrt.spec.ts`)
-- any deep link in `Welcome.stories.tsx` (`navigateToStory(...)` + `href`)
+- any deep link in `Welcome.stories.tsx` — these live in the exported
+  `WELCOME_DEEP_LINKS` manifest, mechanically guarded by
+  [`Welcome.drift.test.ts`](../../src/docs/Welcome.drift.test.ts) (#375): it
+  reconstructs each target's real id with Storybook's own `sanitize` /
+  `storyNameFromExport` and fails on a slug **or** suffix mismatch, plus on a
+  `viewMode` ↔ entry-type drift (`'docs'` needs autodocs, `'story'` needs a
+  Canvas export) and on a `Patterns/*` page that isn't linked. A title/export
+  rename that misses the manifest turns this test red rather than shipping a
+  dead link.
 - `options.storySort.order` in `.storybook/preview.tsx` if a top-level group
   name changed
 

--- a/src/docs/Welcome.drift.test.ts
+++ b/src/docs/Welcome.drift.test.ts
@@ -1,0 +1,137 @@
+/// <reference types="vite/client" />
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { sanitize, storyNameFromExport } from 'storybook/internal/csf'
+import { describe, expect, it } from 'vitest'
+import { WELCOME_COMPONENT_SLUGS, WELCOME_DEEP_LINKS } from './Welcome.stories'
+
+/*
+ * Welcome deep-link drift guard (#375).
+ *
+ * `Welcome.stories.tsx` links to other stories by a hard-coded `slug--suffix`
+ * id. Those ids derive from the target module's `meta.title` (slug) and a story
+ * export name (suffix) — a rename of either silently breaks the link (Storybook
+ * renders "story not found" / "No Preview"; nothing fails to build).
+ *
+ * This test reconstructs the real Storybook id from each target module and
+ * reconciles it against the `WELCOME_DEEP_LINKS` manifest. It runs as a plain
+ * unit test (no Storybook build):
+ *
+ *   - The story files are read as TEXT (readFileSync), never imported — eagerly
+ *     importing every story executes import-time side effects, and some docs
+ *     stories (SeasonalShowcase) read `*.css?raw`, which Vitest resolves to an
+ *     empty string and throws. Source-parsing is also the established
+ *     *.drift.test.ts approach (Elevation / Motion / Radius).
+ *   - Id derivation stays faithful by reusing Storybook's own `sanitize` /
+ *     `storyNameFromExport` (pure functions, no side effects) on the parsed
+ *     `title` strings and export names.
+ *
+ * NOTE: the suffix comes from the export *name*, not the story's `name:` field
+ * (e.g. CSSApi's `export const Reference` keeps id suffix `reference` despite
+ * `name: 'Reference (all 18 lv1 components)'`). So an export rename is caught;
+ * a `name:` change is intentionally not — it does not change the URL.
+ */
+
+// Glob KEYS only (paths) — the loaders are never called, so no story module's
+// import-time side effect runs. `../**/*.stories.tsx` from src/docs resolves to
+// src/**/*.stories.tsx (lv1 catalog + docs pages + providers).
+const storyPaths = Object.keys(import.meta.glob('../**/*.stories.tsx'))
+
+interface ParsedStory {
+  slug: string
+  exports: string[]
+  autodocs: boolean
+}
+
+function parseStory(raw: string): ParsedStory | null {
+  // Strip block comments first — a TSDoc example can contain a `title: '…'`
+  // line (e.g. Toast's usage snippet) that would otherwise shadow meta.title.
+  const src = raw.replace(/\/\*[\s\S]*?\*\//g, '')
+  const title = src.match(/title:\s*'([^']+)'/)?.[1]
+  if (!title) return null
+  const autodocs = /tags:\s*\[[^\]]*['"]autodocs['"]/.test(src)
+  // PascalCase `export const Foo` = a CSF story export. Over-capturing a
+  // non-story const (e.g. WELCOME_DEEP_LINKS) is harmless — it only adds an
+  // extra candidate suffix to a `.toContain` check.
+  const exports = [...src.matchAll(/export const ([A-Z][A-Za-z0-9_]*)/g)].map((m) => m[1])
+  return { slug: sanitize(title), exports, autodocs }
+}
+
+// Index by sanitize(meta.title). Titles can collide (CSSApi + CSSApiParity both
+// declare 'CSS API/Overview'), so each slug maps to an array of parsed modules.
+const bySlug = new Map<string, ParsedStory[]>()
+for (const rel of storyPaths) {
+  const parsed = parseStory(readFileSync(resolve(__dirname, rel), 'utf8'))
+  if (!parsed) continue
+  bySlug.set(parsed.slug, [...(bySlug.get(parsed.slug) ?? []), parsed])
+}
+
+/** Id suffixes a slug's module group exposes (export → storyNameFromExport → sanitize). */
+function suffixesForSlug(slug: string): Set<string> {
+  const out = new Set<string>()
+  for (const mod of bySlug.get(slug) ?? []) {
+    for (const exp of mod.exports) out.add(sanitize(storyNameFromExport(exp)))
+  }
+  return out
+}
+
+const hasAutodocs = (slug: string): boolean => (bySlug.get(slug) ?? []).some((m) => m.autodocs)
+
+// Dedupe by slug--suffix: patterns-accessibility/overview is linked from both
+// the Engineering and Patterns sections with different card copy.
+const uniqueLinks = [
+  ...new Map(WELCOME_DEEP_LINKS.map((l) => [`${l.slug}--${l.suffix}`, l])).values(),
+]
+
+describe('Welcome deep links ↔ story definitions', () => {
+  it.each(uniqueLinks)('$slug resolves to a real story title', (link) => {
+    expect(bySlug.has(link.slug)).toBe(true)
+  })
+
+  it.each(uniqueLinks)('$slug--$suffix matches an export-derived story id', (link) => {
+    expect([...suffixesForSlug(link.slug)]).toContain(link.suffix)
+  })
+
+  it.each(uniqueLinks)('$slug viewMode matches the index entry type', (link) => {
+    if (link.viewMode === 'docs') {
+      // `/docs/<slug>--docs` only exists when the component is autodocs-tagged.
+      expect(hasAutodocs(link.slug)).toBe(true)
+    } else {
+      // A story-mode link must point at a real Canvas story export.
+      expect([...suffixesForSlug(link.slug)]).toContain(link.suffix)
+    }
+  })
+})
+
+describe('Welcome component cards ↔ lv1 autodocs', () => {
+  // Pin the const against the storyPaths actually wired into the ComponentCards,
+  // so a new card (or a removed one) that desyncs from the const fails here.
+  const SRC = readFileSync(resolve(__dirname, 'Welcome.stories.tsx'), 'utf8')
+  const wiredSlugs = [...SRC.matchAll(/storyPath="(components-lv1-[a-z]+)"/g)].map((m) => m[1])
+
+  it('WELCOME_COMPONENT_SLUGS lists exactly the storyPaths used by ComponentCards', () => {
+    expect(new Set(wiredSlugs)).toEqual(new Set(WELCOME_COMPONENT_SLUGS))
+  })
+
+  it.each(WELCOME_COMPONENT_SLUGS)('%s resolves to an lv1 module with autodocs', (slug) => {
+    expect(bySlug.has(slug)).toBe(true)
+    expect(hasAutodocs(slug)).toBe(true)
+  })
+})
+
+describe('Welcome Patterns coverage', () => {
+  // Patterns pages intentionally NOT linked from Welcome (none today). An entry
+  // here is the documented escape hatch for e.g. an internal-only recipe page.
+  const WELCOME_LINK_EXEMPT = new Set<string>([])
+
+  const patternsSlugs = [...bySlug.keys()].filter((s) => s.startsWith('patterns-'))
+  const linkedSlugs = new Set(WELCOME_DEEP_LINKS.map((l) => l.slug))
+
+  it('there is at least one Patterns page to check', () => {
+    expect(patternsSlugs.length).toBeGreaterThan(0)
+  })
+
+  it.each(patternsSlugs)('Patterns page %s is linked from Welcome (or exempt)', (slug) => {
+    expect(linkedSlugs.has(slug) || WELCOME_LINK_EXEMPT.has(slug)).toBe(true)
+  })
+})

--- a/src/docs/Welcome.stories.tsx
+++ b/src/docs/Welcome.stories.tsx
@@ -51,6 +51,164 @@ const navigateToStory = (
   top.location.href = url.toString()
 }
 
+/**
+ * One internal deep link rendered on the Welcome page. This is the SSOT the
+ * card render and `Welcome.drift.test.ts` both consume — the test reconciles
+ * each entry's `slug` / `suffix` / `viewMode` against the target story module
+ * so a title or export rename can no longer silently break the link.
+ *
+ * - `slug`     target module's `sanitize(meta.title)`
+ * - `suffix`   target export-derived id suffix (`sanitize(storyNameFromExport(export))`)
+ * - `viewMode` Storybook entry kind: `'docs'` for autodocs, `'story'` for Canvas
+ *   (a mismatch renders "No Preview" — #377)
+ * - `section`  which Welcome section renders this card (drift test ignores it)
+ */
+export interface WelcomeDeepLink {
+  slug: string
+  suffix: string
+  viewMode: 'docs' | 'story'
+  section: 'engineering' | 'tokens' | 'patterns'
+  title: string
+  description: string
+}
+
+export const WELCOME_DEEP_LINKS: readonly WelcomeDeepLink[] = [
+  {
+    slug: 'css-api-overview',
+    suffix: 'reference',
+    viewMode: 'story',
+    section: 'engineering',
+    title: 'Framework-agnostic CSS API',
+    description:
+      'Components ship a .st-* BEM class API and a prebuilt stylesheet, so they render with plain HTML — no React, no Tailwind, no build step required on the consumer side.',
+  },
+  {
+    slug: 'theming-theme-audit',
+    suffix: 'overview',
+    viewMode: 'story',
+    section: 'engineering',
+    title: 'Mode × Special theming',
+    description:
+      'Two independent theme axes — light/dark Mode × an exclusive seasonal Special — compose at runtime through CSS variables. See all 16 combinations verified side by side.',
+  },
+  {
+    slug: 'theming-seasonal-showcase',
+    suffix: 'eight-seasons',
+    viewMode: 'story',
+    section: 'engineering',
+    title: 'Seasonal showcase',
+    description:
+      'Eight palettes based on the 24 solar terms re-tint every solid surface at runtime — see all eight seasons worn by buttons, badges, and a full dashboard mockup.',
+  },
+  {
+    slug: 'patterns-accessibility',
+    suffix: 'overview',
+    viewMode: 'story',
+    section: 'engineering',
+    title: 'Accessibility contract',
+    description:
+      'Every primitive guarantees a role, an accessible name, keyboard support, and aria-* wiring — asserted with axe-core in CI alongside the visual regression suite.',
+  },
+  {
+    slug: 'tokens-color',
+    suffix: 'colors',
+    viewMode: 'story',
+    section: 'tokens',
+    title: 'Color',
+    description: 'Color tokens and scales.',
+  },
+  {
+    slug: 'tokens-typography',
+    suffix: 'typography',
+    viewMode: 'story',
+    section: 'tokens',
+    title: 'Typography',
+    description: 'Font scales and text styles.',
+  },
+  {
+    slug: 'patterns-accessibility',
+    suffix: 'overview',
+    viewMode: 'story',
+    section: 'patterns',
+    title: 'Accessibility',
+    description:
+      'Focus visibility, ARIA conventions, contrast, and keyboard support — the contract every primitive satisfies.',
+  },
+  {
+    slug: 'patterns-composition-with-aschild',
+    suffix: 'button-as-link',
+    viewMode: 'story',
+    section: 'patterns',
+    title: 'Composition with asChild',
+    description:
+      'Rendering Button as a link, buttonVariants() on your own element, and Text polymorphism.',
+  },
+  {
+    slug: 'patterns-form-composition',
+    suffix: 'basic-field',
+    viewMode: 'story',
+    section: 'patterns',
+    title: 'Form Composition',
+    description: 'Wiring Field and FieldSet: labels, descriptions, and error messages.',
+  },
+  {
+    slug: 'patterns-form-states',
+    suffix: 'audit',
+    viewMode: 'story',
+    section: 'patterns',
+    title: 'Form States',
+    description: 'disabled / readOnly / error across every form control, audited side by side.',
+  },
+  {
+    slug: 'patterns-layout',
+    suffix: 'flex-recipes',
+    viewMode: 'story',
+    section: 'patterns',
+    title: 'Layout',
+    description: 'Flex and grid recipes for arranging primitives on the page.',
+  },
+  {
+    slug: 'patterns-testing',
+    suffix: 'overview',
+    viewMode: 'story',
+    section: 'patterns',
+    title: 'Testing',
+    description: 'data-testid pass-through and role-first queries for consumer test suites.',
+  },
+]
+
+/**
+ * The `storyPath` slugs the `ComponentCard`s link to (viewMode `'docs'`,
+ * suffix `'docs'`). Kept here as the SSOT so `Welcome.drift.test.ts` can
+ * assert each resolves to an lv1 module that actually carries autodocs — the
+ * `--docs` entry only exists when the component is autodocs-tagged. The card
+ * JSX (live previews) stays inline; the test pins the const against the
+ * storyPaths actually wired into the cards.
+ */
+export const WELCOME_COMPONENT_SLUGS = [
+  'components-lv1-button',
+  'components-lv1-badge',
+  'components-lv1-spinner',
+  'components-lv1-text',
+  'components-lv1-tooltip',
+  'components-lv1-toast',
+  'components-lv1-callout',
+  'components-lv1-field',
+  'components-lv1-fieldset',
+  'components-lv1-input',
+  'components-lv1-textarea',
+  'components-lv1-select',
+  'components-lv1-checkbox',
+  'components-lv1-radio',
+  'components-lv1-switch',
+] as const
+
+/** Build the `href` + `onClick` pair for a deep-link card from a manifest entry. */
+const deepLinkProps = (link: WelcomeDeepLink) => ({
+  href: `/${link.viewMode}/${link.slug}--${link.suffix}`,
+  onClick: (e: React.MouseEvent) => navigateToStory(e, link.slug, link.suffix, link.viewMode),
+})
+
 const ComponentCard = ({
   name,
   description,
@@ -124,6 +282,47 @@ const TextLinkCard = ({
     <p className="text-xs text-foreground-muted mt-1.5 leading-relaxed">{description}</p>
   </a>
 )
+
+/** Preview glyphs for the Tokens cards, keyed by deep-link slug. */
+const TOKEN_PREVIEWS: Record<string, React.ReactNode> = {
+  'tokens-color': (
+    <div className="flex gap-1">
+      {['bg-solid', 'bg-foreground-muted', 'bg-vermillion', 'bg-destructive'].map((c) => (
+        <div key={c} className={`w-8 h-8 rounded-lg ${c}`} />
+      ))}
+    </div>
+  ),
+  'tokens-typography': (
+    <div className="flex flex-col items-center gap-1">
+      <span className="text-2xl font-bold text-foreground">Aa</span>
+      <span className="text-xs text-foreground-muted">Hanken Grotesk</span>
+    </div>
+  ),
+}
+
+/**
+ * Tokens-section card — same chrome as `ComponentCard` but its preview is a
+ * static glyph (no interactive click-trap) and its link routes through the
+ * `WELCOME_DEEP_LINKS` manifest.
+ */
+const TokenCard = ({ link }: { link: WelcomeDeepLink }) => (
+  <a
+    {...deepLinkProps(link)}
+    className="group block border border-border rounded-xl overflow-hidden no-underline transition-shadow duration-200 hover:shadow-md"
+  >
+    <div className="flex items-center justify-center h-40 bg-surface">
+      {TOKEN_PREVIEWS[link.slug]}
+    </div>
+    <div className="px-4 py-3 border-t border-border">
+      <p className="text-sm font-semibold text-vermillion group-hover:underline">{link.title}</p>
+      <p className="text-xs text-foreground-muted mt-0.5">{link.description}</p>
+    </div>
+  </a>
+)
+
+const engineeringLinks = WELCOME_DEEP_LINKS.filter((l) => l.section === 'engineering')
+const tokenLinks = WELCOME_DEEP_LINKS.filter((l) => l.section === 'tokens')
+const patternsLinks = WELCOME_DEEP_LINKS.filter((l) => l.section === 'patterns')
 
 export const Overview: Story = {
   name: 'Overview',
@@ -216,32 +415,14 @@ export const Overview: Story = {
             href="https://github.com/yasmro/schatten/tree/main/.claude/rules"
             external
           />
-          <TextLinkCard
-            title="Framework-agnostic CSS API"
-            description="Components ship a .st-* BEM class API and a prebuilt stylesheet, so they render with plain HTML — no React, no Tailwind, no build step required on the consumer side."
-            href="/story/css-api-overview--reference"
-            onClick={(e) => navigateToStory(e, 'css-api-overview', 'reference', 'story')}
-          />
-          <TextLinkCard
-            title="Mode × Special theming"
-            description="Two independent theme axes — light/dark Mode × an exclusive seasonal Special — compose at runtime through CSS variables. See all 16 combinations verified side by side."
-            href="/story/theming-theme-audit--overview"
-            onClick={(e) => navigateToStory(e, 'theming-theme-audit', 'overview', 'story')}
-          />
-          <TextLinkCard
-            title="Seasonal showcase"
-            description="Eight palettes based on the 24 solar terms re-tint every solid surface at runtime — see all eight seasons worn by buttons, badges, and a full dashboard mockup."
-            href="/story/theming-seasonal-showcase--eight-seasons"
-            onClick={(e) =>
-              navigateToStory(e, 'theming-seasonal-showcase', 'eight-seasons', 'story')
-            }
-          />
-          <TextLinkCard
-            title="Accessibility contract"
-            description="Every primitive guarantees a role, an accessible name, keyboard support, and aria-* wiring — asserted with axe-core in CI alongside the visual regression suite."
-            href="/story/patterns-accessibility--overview"
-            onClick={(e) => navigateToStory(e, 'patterns-accessibility', 'overview', 'story')}
-          />
+          {engineeringLinks.map((link) => (
+            <TextLinkCard
+              key={link.title}
+              title={link.title}
+              description={link.description}
+              {...deepLinkProps(link)}
+            />
+          ))}
         </div>
       </div>
 
@@ -431,42 +612,9 @@ export const Overview: Story = {
       <div className="mb-12">
         <h2 className="text-xl font-bold text-foreground mb-4">Tokens</h2>
         <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-4">
-          <a
-            href="/story/tokens-color--colors"
-            onClick={(e) => navigateToStory(e, 'tokens-color', 'colors', 'story')}
-            className="group block border border-border rounded-xl overflow-hidden no-underline transition-shadow duration-200 hover:shadow-md"
-          >
-            <div className="flex items-center justify-center h-40 bg-surface">
-              <div className="flex gap-1">
-                {['bg-solid', 'bg-foreground-muted', 'bg-vermillion', 'bg-destructive'].map((c) => (
-                  <div key={c} className={`w-8 h-8 rounded-lg ${c}`} />
-                ))}
-              </div>
-            </div>
-            <div className="px-4 py-3 border-t border-border">
-              <p className="text-sm font-semibold text-vermillion group-hover:underline">Color</p>
-              <p className="text-xs text-foreground-muted mt-0.5">Color tokens and scales.</p>
-            </div>
-          </a>
-
-          <a
-            href="/story/tokens-typography--typography"
-            onClick={(e) => navigateToStory(e, 'tokens-typography', 'typography', 'story')}
-            className="group block border border-border rounded-xl overflow-hidden no-underline transition-shadow duration-200 hover:shadow-md"
-          >
-            <div className="flex items-center justify-center h-40 bg-surface">
-              <div className="flex flex-col items-center gap-1">
-                <span className="text-2xl font-bold text-foreground">Aa</span>
-                <span className="text-xs text-foreground-muted">Hanken Grotesk</span>
-              </div>
-            </div>
-            <div className="px-4 py-3 border-t border-border">
-              <p className="text-sm font-semibold text-vermillion group-hover:underline">
-                Typography
-              </p>
-              <p className="text-xs text-foreground-muted mt-0.5">Font scales and text styles.</p>
-            </div>
-          </a>
+          {tokenLinks.map((link) => (
+            <TokenCard key={link.slug} link={link} />
+          ))}
         </div>
       </div>
 
@@ -477,44 +625,14 @@ export const Overview: Story = {
           Cross-component recipes and principles — how the primitives compose in practice.
         </p>
         <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
-          <TextLinkCard
-            title="Accessibility"
-            description="Focus visibility, ARIA conventions, contrast, and keyboard support — the contract every primitive satisfies."
-            href="/story/patterns-accessibility--overview"
-            onClick={(e) => navigateToStory(e, 'patterns-accessibility', 'overview', 'story')}
-          />
-          <TextLinkCard
-            title="Composition with asChild"
-            description="Rendering Button as a link, buttonVariants() on your own element, and Text polymorphism."
-            href="/story/patterns-composition-with-aschild--button-as-link"
-            onClick={(e) =>
-              navigateToStory(e, 'patterns-composition-with-aschild', 'button-as-link', 'story')
-            }
-          />
-          <TextLinkCard
-            title="Form Composition"
-            description="Wiring Field and FieldSet: labels, descriptions, and error messages."
-            href="/story/patterns-form-composition--basic-field"
-            onClick={(e) => navigateToStory(e, 'patterns-form-composition', 'basic-field', 'story')}
-          />
-          <TextLinkCard
-            title="Form States"
-            description="disabled / readOnly / error across every form control, audited side by side."
-            href="/story/patterns-form-states--audit"
-            onClick={(e) => navigateToStory(e, 'patterns-form-states', 'audit', 'story')}
-          />
-          <TextLinkCard
-            title="Layout"
-            description="Flex and grid recipes for arranging primitives on the page."
-            href="/story/patterns-layout--flex-recipes"
-            onClick={(e) => navigateToStory(e, 'patterns-layout', 'flex-recipes', 'story')}
-          />
-          <TextLinkCard
-            title="Testing"
-            description="data-testid pass-through and role-first queries for consumer test suites."
-            href="/story/patterns-testing--overview"
-            onClick={(e) => navigateToStory(e, 'patterns-testing', 'overview', 'story')}
-          />
+          {patternsLinks.map((link) => (
+            <TextLinkCard
+              key={link.title}
+              title={link.title}
+              description={link.description}
+              {...deepLinkProps(link)}
+            />
+          ))}
         </div>
       </div>
     </div>


### PR DESCRIPTION
## What

Welcome ページの内部 deep link を `WELCOME_DEEP_LINKS` manifest に集約し、
`Welcome.drift.test.ts` でリンク先 story の実 ID と突合する drift test を追加。

- `Welcome.stories.tsx`: Engineering / Tokens / Patterns の各カードを manifest
  経由 render に変更(`navigateToStory` の slug/suffix/viewMode ハードコードの
  二重化を解消)。ComponentCard の docs リンク slug は `WELCOME_COMPONENT_SLUGS`
  に抽出(children はインライン据え置き)。
- `Welcome.drift.test.ts`: 5 観点を検証 —
  ① slug 実在 ② suffix 突合(export rename 検知)③ viewMode × entry type
  整合(#377)④ Patterns 網羅性(allowlist 付き)⑤ ComponentCard slug が
  autodocs 付き lv1 に解決。ID 導出は Storybook の `sanitize` /
  `storyNameFromExport` を流用。story モジュールは **import せず source を
  parse**(eager import は SeasonalShowcase の import-time CSS 副作用で
  Vitest 上 throw する — `?raw` が空文字に解決されるため)。
- `storybook-guideline.md`: 「title rename = ID 変更」節に **suffix(export 名)
  も同期対象**、`name:` は ID 不変、drift test が機械ガードである旨を追記。

## Why

deep link の slug/suffix はハードコードで、リンク先の title / export rename で
無言で壊れる(ビルドもテストも落ちず "No Preview" になる — #377 で既存 5 本が
これで壊れていた)。#364 着地で Welcome のリンクが 11 本に増えたため、人間運用
頼みだった同期を機械検知に乗せる。

## Related rules

- [storybook-guideline.md](.claude/rules/storybook-guideline.md)(本 PR で更新)
- [vrt-spec-guideline.md](.claude/rules/vrt-spec-guideline.md)(docs story の VRT 要否)

## Test plan

- [x] `pnpm lint` 緑
- [x] `pnpm test --run` 緑(859 passed、新規 56 ケース含む)
- [x] `pnpm typecheck` 緑
- [x] DoD: target の title rename / export rename で drift test が red になることを確認

closes #375

🤖 Generated with [Claude Code](https://claude.com/claude-code)
