### PR TITLE
docs(a11y): docs prose の table を DocsTable に集約し scope を構造強制 (closes #384)

### DIFF
--- a/.changeset/docs-table-a11y-384.md
+++ b/.changeset/docs-table-a11y-384.md
@@ -1,0 +1,7 @@
+---
+'@yasmro/schatten': patch
+---
+
+docs(a11y): ハンドビルド docs ページの table を共有 `DocsTable` に集約し、`<th scope="col">` を構造的に強制 (closes #384)
+
+`Accessibility` / `Testing` が二重定義していた `RefTable` を `docs-ui.tsx` の `DocsTable` に統合し、`scope` 欠落・`<th>`/`<td>` 不整合を構造で防ぐ。`CompositionWithAsChild` の比較表も `DocsTable` 化、`CSSApi` の bespoke table には `scope="col"` を直書き。`scope` 欠落は axe の WCAG 2.1 A/AA タグでは検出されないため、per-page axe spec ではなくコンポーネント + `docs-ui.test.tsx` で担保する方針を `vrt-spec-guideline.md` に明文化。docs / internal のみで公開 API は不変。

--- a/.claude/rules/vrt-spec-guideline.md
+++ b/.claude/rules/vrt-spec-guideline.md
@@ -294,6 +294,44 @@ docs page, **default to skip**.
 > ["Brand-new snapshots"](#brand-new-snapshots) and verify local↔CI rendering
 > parity first by passing an existing spec against its committed baseline.
 
+### docs page tables and a11y — structural, not a per-page axe spec
+
+Hand-built docs pages (`Patterns/*`, `Tokens/*`, `CSS API/*`) increasingly
+carry `<table>` prose. The a11y of those tables is enforced **structurally
+through a shared component**, NOT through a per-page `@axe-core/playwright`
+spec. The policy (decided in
+[#384](https://github.com/yasmro/schatten/issues/384)):
+
+- **Render docs-prose tables with `DocsTable`**
+  ([`src/docs/docs-ui.tsx`](../../src/docs/docs-ui.tsx)), never a raw
+  `<table>` hand-written per page. `DocsTable` bakes in `<th scope="col">`
+  + `<thead>` / `<tbody>`, so the column-header association cannot drift.
+  Its `scope="col"` invariant is pinned by
+  [`docs-ui.test.tsx`](../../src/docs/docs-ui.test.tsx).
+- **Do not add a per-page axe spec to assert table semantics.** This is the
+  load-bearing reason for the structural approach: a missing `scope` is
+  **not** an axe violation under the WCAG 2.1 A/AA tag set
+  (`wcag2a` / `wcag2aa` / `wcag21a` / `wcag21aa`) the a11y suite pins —
+  `scope-attr-valid` only fires on an *invalid* value, never on an absent
+  one. So an axe sweep would give a false sense of coverage for exactly the
+  drift (missing `scope`, `<th>`/`<td>` mismatch) the concern was about. The
+  component, plus its unit test, is what actually guards it.
+- **A docs page that already styles its table bespoke** (e.g.
+  `CSSApi.stories.tsx`'s `cssapi-doc__attr-table`, scoped to a page-chrome
+  stylesheet) keeps its own `<table>` but **must still set
+  `scope="col"`** on every header cell by hand. Migrating it onto
+  `DocsTable` is optional and non-breaking.
+- **Non-table docs-prose a11y** (color-contrast, heading order, link names)
+  is checked at **dev time** via the Storybook `addon-a11y` panel
+  (`.storybook/preview.tsx`, same WCAG tag set), not in CI. If a future need
+  arises to gate *all* docs prose with axe in CI, that is a separate
+  "docs-only a11y sweep" decision — open an issue and update this section;
+  do not bolt a one-off axe spec onto a single docs page.
+
+The three-axis rule for docs pages, then: **visual contract → VRT (above);
+table semantics → `DocsTable` (structural); broader prose a11y → dev-time
+`addon-a11y` panel.**
+
 ### Adding a new story → add it to the VRT roster (or document the skip)
 
 When you add a new story to `{Component}.stories.tsx`, the **same PR** must do

--- a/src/docs/Accessibility.stories.tsx
+++ b/src/docs/Accessibility.stories.tsx
@@ -17,7 +17,15 @@ import {
 } from '../components/lv1/Select/Select'
 import { Switch } from '../components/lv1/Switch/Switch'
 import { Text } from '../components/lv1/Text/Text'
-import { CodeBlock, Lead, Note, PageTitle, SectionTitle, SubsectionTitle } from './docs-ui'
+import {
+  CodeBlock,
+  DocsTable,
+  Lead,
+  Note,
+  PageTitle,
+  SectionTitle,
+  SubsectionTitle,
+} from './docs-ui'
 
 /*
  * Patterns/Accessibility — narrative + conventions doc for Schatten's a11y
@@ -70,35 +78,6 @@ const Demo = ({ label, children }: { label: string; children: ReactNode }) => (
       {label}
     </h3>
     <div className="flex flex-wrap items-center gap-4">{children}</div>
-  </div>
-)
-
-type TableRow = { key: string; cells: ReactNode[] }
-
-const RefTable = ({ headers, rows }: { headers: string[]; rows: TableRow[] }) => (
-  <div className="overflow-x-auto mb-4">
-    <table className="w-full text-sm border-collapse">
-      <thead>
-        <tr className="border-b border-border">
-          {headers.map((h) => (
-            <th key={h} className="text-left font-semibold text-foreground py-2 pr-4 align-top">
-              {h}
-            </th>
-          ))}
-        </tr>
-      </thead>
-      <tbody>
-        {rows.map((row) => (
-          <tr key={row.key} className="border-b border-border last:border-b-0 align-top">
-            {row.cells.map((cell, idx) => (
-              <td key={headers[idx]} className="py-2 pr-4 text-foreground-muted">
-                {cell}
-              </td>
-            ))}
-          </tr>
-        ))}
-      </tbody>
-    </table>
   </div>
 )
 
@@ -255,7 +234,7 @@ export const AriaConventions: Story = {
        * source of truth — re-verify this table whenever a component's aria-*
        * wiring changes (this page's own issue body went stale exactly this way).
        */}
-      <RefTable
+      <DocsTable
         headers={['Component', 'Attribute', 'Source']}
         rows={[
           {
@@ -361,7 +340,7 @@ export const Contrast: Story = {
       </Lead>
 
       <SectionTitle>The lines</SectionTitle>
-      <RefTable
+      <DocsTable
         headers={['Surface', 'Minimum ratio', 'Applies to']}
         rows={[
           {
@@ -450,7 +429,7 @@ export const Keyboard: Story = {
       </Lead>
 
       <SectionTitle>Key map</SectionTitle>
-      <RefTable
+      <DocsTable
         headers={['Widget', 'Keys']}
         rows={[
           {

--- a/src/docs/CSSApi.stories.tsx
+++ b/src/docs/CSSApi.stories.tsx
@@ -175,9 +175,9 @@ const Section = ({
         <table className="cssapi-doc__attr-table">
           <thead>
             <tr>
-              <th>Attribute</th>
-              <th>Meaning</th>
-              <th>When</th>
+              <th scope="col">Attribute</th>
+              <th scope="col">Meaning</th>
+              <th scope="col">When</th>
             </tr>
           </thead>
           <tbody>

--- a/src/docs/CompositionWithAsChild.stories.tsx
+++ b/src/docs/CompositionWithAsChild.stories.tsx
@@ -1,10 +1,11 @@
 import type { Meta, StoryObj } from '@storybook/react-vite'
 import { ArrowRight } from 'lucide-react'
+import { Fragment } from 'react'
 import { Button } from '../components/lv1/Button/Button'
 import { Text } from '../components/lv1/Text/Text'
 import { buttonVariants } from '../variants/button'
 import { textVariants } from '../variants/text'
-import { CodeBlock, Lead, Note, PageTitle, SectionTitle } from './docs-ui'
+import { CodeBlock, DocsTable, Lead, Note, PageTitle, SectionTitle } from './docs-ui'
 
 /*
  * Patterns: asChild / *Variants() / as の使い分け。narrative（escape-hatch
@@ -50,75 +51,67 @@ export const Overview: Story = {
         <code className="text-xs">component-architecture.md</code>.)
       </Lead>
 
-      <table className="w-full text-sm border-collapse">
-        <thead>
-          <tr className="border-b border-border">
-            <th scope="col" className="text-left font-semibold text-foreground py-2 pr-4 align-top">
-              Escape hatch
-            </th>
-            <th scope="col" className="text-left font-semibold text-foreground py-2 pr-4 align-top">
-              What you get
-            </th>
-            <th scope="col" className="text-left font-semibold text-foreground py-2 pr-4 align-top">
-              Where it works
-            </th>
-            <th scope="col" className="text-left font-semibold text-foreground py-2 align-top">
-              Available on
-            </th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr className="border-b border-border align-top">
-            <td className="py-2 pr-4 text-foreground-muted">
-              <code className="text-xs">asChild</code> (Radix <code className="text-xs">Slot</code>)
-            </td>
-            <td className="py-2 pr-4 text-foreground-muted">
-              The component's resolved <code className="text-xs">className</code>{' '}
-              <strong>plus its forwarded props / ref</strong> merged onto a single child — the child{' '}
-              <em>becomes</em> the component
-            </td>
-            <td className="py-2 pr-4 text-foreground-muted">React only</td>
-            <td className="py-2 text-foreground-muted">
-              <strong>
+      <DocsTable
+        caption="Escape-hatch comparison: asChild / *Variants() / as"
+        headers={['Escape hatch', 'What you get', 'Where it works', 'Available on']}
+        rows={[
+          {
+            key: 'aschild',
+            cells: [
+              <Fragment key="hatch">
+                <code className="text-xs">asChild</code> (Radix{' '}
+                <code className="text-xs">Slot</code>)
+              </Fragment>,
+              <Fragment key="get">
+                The component's resolved <code className="text-xs">className</code>{' '}
+                <strong>plus its forwarded props / ref</strong> merged onto a single child — the
+                child <em>becomes</em> the component
+              </Fragment>,
+              'React only',
+              <strong key="on">
                 <code className="text-xs">Button</code> only
-              </strong>
-            </td>
-          </tr>
-          <tr className="border-b border-border align-top">
-            <td className="py-2 pr-4 text-foreground-muted">
-              <code className="text-xs">*Variants()</code> (
-              <code className="text-xs">buttonVariants()</code> /{' '}
-              <code className="text-xs">textVariants()</code>)
-            </td>
-            <td className="py-2 pr-4 text-foreground-muted">
-              <strong>Only the class string</strong> — your element keeps its full native typing
-            </td>
-            <td className="py-2 pr-4 text-foreground-muted">
-              Any context: React, SSR HTML, email, framework{' '}
-              <code className="text-xs">&lt;Link&gt;</code>
-            </td>
-            <td className="py-2 text-foreground-muted">
-              <code className="text-xs">Button</code>, <code className="text-xs">Text</code>
-            </td>
-          </tr>
-          <tr className="border-b border-border last:border-b-0 align-top">
-            <td className="py-2 pr-4 text-foreground-muted">
-              <code className="text-xs">as</code> (closed tag enum)
-            </td>
-            <td className="py-2 pr-4 text-foreground-muted">
-              Swaps the rendered semantic tag (<code className="text-xs">p</code> /{' '}
-              <code className="text-xs">span</code> / <code className="text-xs">h1</code>–
-              <code className="text-xs">h6</code>)
-            </td>
-            <td className="py-2 pr-4 text-foreground-muted">React only</td>
-            <td className="py-2 text-foreground-muted">
-              <strong>
+              </strong>,
+            ],
+          },
+          {
+            key: 'variants',
+            cells: [
+              <Fragment key="hatch">
+                <code className="text-xs">*Variants()</code> (
+                <code className="text-xs">buttonVariants()</code> /{' '}
+                <code className="text-xs">textVariants()</code>)
+              </Fragment>,
+              <Fragment key="get">
+                <strong>Only the class string</strong> — your element keeps its full native typing
+              </Fragment>,
+              <Fragment key="where">
+                Any context: React, SSR HTML, email, framework{' '}
+                <code className="text-xs">&lt;Link&gt;</code>
+              </Fragment>,
+              <Fragment key="on">
+                <code className="text-xs">Button</code>, <code className="text-xs">Text</code>
+              </Fragment>,
+            ],
+          },
+          {
+            key: 'as',
+            cells: [
+              <Fragment key="hatch">
+                <code className="text-xs">as</code> (closed tag enum)
+              </Fragment>,
+              <Fragment key="get">
+                Swaps the rendered semantic tag (<code className="text-xs">p</code> /{' '}
+                <code className="text-xs">span</code> / <code className="text-xs">h1</code>–
+                <code className="text-xs">h6</code>)
+              </Fragment>,
+              'React only',
+              <strong key="on">
                 <code className="text-xs">Text</code> only
-              </strong>
-            </td>
-          </tr>
-        </tbody>
-      </table>
+              </strong>,
+            ],
+          },
+        ]}
+      />
 
       <Note>
         This table is the consumer-facing companion to the contributor contract in{' '}

--- a/src/docs/Testing.stories.tsx
+++ b/src/docs/Testing.stories.tsx
@@ -20,7 +20,15 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from '../components/lv1/Tooltip/Tooltip'
-import { CodeBlock, Lead, Note, PageTitle, SectionTitle, SubsectionTitle } from './docs-ui'
+import {
+  CodeBlock,
+  DocsTable,
+  Lead,
+  Note,
+  PageTitle,
+  SectionTitle,
+  SubsectionTitle,
+} from './docs-ui'
 
 /*
  * Patterns/Testing — canonical reference for wiring `data-testid` into Schatten
@@ -69,35 +77,6 @@ const Demo = ({ label, children }: { label: string; children: ReactNode }) => (
       {label}
     </h3>
     <div className="flex flex-wrap items-center gap-4">{children}</div>
-  </div>
-)
-
-type TableRow = { key: string; cells: ReactNode[] }
-
-const RefTable = ({ headers, rows }: { headers: string[]; rows: TableRow[] }) => (
-  <div className="overflow-x-auto mb-4">
-    <table className="w-full text-sm border-collapse">
-      <thead>
-        <tr className="border-b border-border">
-          {headers.map((h) => (
-            <th key={h} className="text-left font-semibold text-foreground py-2 pr-4 align-top">
-              {h}
-            </th>
-          ))}
-        </tr>
-      </thead>
-      <tbody>
-        {rows.map((row) => (
-          <tr key={row.key} className="border-b border-border last:border-b-0 align-top">
-            {row.cells.map((cell, idx) => (
-              <td key={headers[idx]} className="py-2 pr-4 text-foreground-muted">
-                {cell}
-              </td>
-            ))}
-          </tr>
-        ))}
-      </tbody>
-    </table>
   </div>
 )
 
@@ -530,7 +509,7 @@ export const FrameworkSelectors: Story = {
         first; fall back to the testid row when role + name cannot disambiguate.
       </Lead>
 
-      <RefTable
+      <DocsTable
         headers={['Intent', 'Playwright', 'Cypress', 'React Testing Library']}
         rows={[
           {

--- a/src/docs/docs-ui.test.tsx
+++ b/src/docs/docs-ui.test.tsx
@@ -1,0 +1,52 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import { DocsTable } from './docs-ui'
+
+/*
+ * DocsTable is a docs-only prose helper (no public API surface). The single
+ * contract worth pinning is its a11y STRUCTURE: every column header carries
+ * `scope="col"`. This is the enforcement chosen in #384 over a per-page axe
+ * spec, precisely because axe's WCAG 2.1 A/AA tags do NOT flag a missing
+ * `scope` — so a screenshot/axe pass would not catch the drift this test does.
+ */
+describe('DocsTable', () => {
+  it('renders every column header with scope="col"', () => {
+    render(
+      <DocsTable
+        headers={['Token', 'Meaning']}
+        rows={[{ key: 'r', cells: ['--color-error', 'error state'] }]}
+      />,
+    )
+    const headers = screen.getAllByRole('columnheader')
+    expect(headers).toHaveLength(2)
+    for (const th of headers) {
+      expect(th).toHaveAttribute('scope', 'col')
+    }
+  })
+
+  it('maps each row cell to a data cell under the matching header', () => {
+    render(
+      <DocsTable
+        headers={['A', 'B']}
+        rows={[
+          { key: 'r1', cells: ['a1', 'b1'] },
+          { key: 'r2', cells: ['a2', 'b2'] },
+        ]}
+      />,
+    )
+    expect(screen.getAllByRole('row')).toHaveLength(3) // 1 header row + 2 body rows
+    expect(screen.getAllByRole('cell')).toHaveLength(4)
+    expect(screen.getByText('b2')).toBeInTheDocument()
+  })
+
+  it('exposes an accessible table name when caption is provided', () => {
+    render(
+      <DocsTable
+        caption="State tokens"
+        headers={['Token']}
+        rows={[{ key: 'r', cells: ['--color-error'] }]}
+      />,
+    )
+    expect(screen.getByRole('table', { name: 'State tokens' })).toBeInTheDocument()
+  })
+})

--- a/src/docs/docs-ui.tsx
+++ b/src/docs/docs-ui.tsx
@@ -37,3 +37,54 @@ export const CodeBlock = ({ children }: { children: ReactNode }) => (
     {children}
   </pre>
 )
+
+export type DocsTableRow = { key: string; cells: ReactNode[] }
+
+/*
+ * Shared docs-prose table. Bakes in `<th scope="col">` + thead/tbody so the
+ * column-header association can't drift: axe's WCAG 2.1 A/AA tags do NOT flag a
+ * missing `scope`, so this STRUCTURE — not a per-page a11y spec — is the
+ * enforcement (the policy decision in #384). A contributor cannot add a docs
+ * table without `scope` because they go through this component, not raw
+ * `<table>`. See `.claude/rules/vrt-spec-guideline.md` "docs page tables and a11y".
+ */
+export const DocsTable = ({
+  headers,
+  rows,
+  caption,
+}: {
+  headers: string[]
+  rows: DocsTableRow[]
+  /** Optional accessible table name, rendered as a visually-hidden <caption>. */
+  caption?: string
+}) => (
+  <div className="overflow-x-auto mb-4">
+    <table className="w-full text-sm border-collapse">
+      {caption ? <caption className="sr-only">{caption}</caption> : null}
+      <thead>
+        <tr className="border-b border-border">
+          {headers.map((h) => (
+            <th
+              key={h}
+              scope="col"
+              className="text-left font-semibold text-foreground py-2 pr-4 align-top"
+            >
+              {h}
+            </th>
+          ))}
+        </tr>
+      </thead>
+      <tbody>
+        {rows.map((row) => (
+          <tr key={row.key} className="border-b border-border last:border-b-0 align-top">
+            {row.cells.map((cell, idx) => (
+              <td key={headers[idx]} className="py-2 pr-4 text-foreground-muted">
+                {cell}
+              </td>
+            ))}
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  </div>
+)

--- a/src/docs/foundations/ThemeAudit.stories.tsx
+++ b/src/docs/foundations/ThemeAudit.stories.tsx
@@ -236,10 +236,14 @@ function CascadeTable() {
         <table aria-labelledby={labelId} className="w-full border-collapse text-sm">
           <thead>
             <tr className="bg-surface-hover text-left">
-              <th className="px-3 py-2 font-mono font-semibold text-foreground">token</th>
-              <th className="px-3 py-2 font-semibold text-foreground">owner</th>
+              <th scope="col" className="px-3 py-2 font-mono font-semibold text-foreground">
+                token
+              </th>
+              <th scope="col" className="px-3 py-2 font-semibold text-foreground">
+                owner
+              </th>
               {CASCADE_SCENARIOS.map((s) => (
-                <th key={s.id} className="px-3 py-2 font-mono text-foreground text-xs">
+                <th key={s.id} scope="col" className="px-3 py-2 font-mono text-foreground text-xs">
                   {s.label}
                 </th>
               ))}


### PR DESCRIPTION
## 概要

#384 で確定した方針（**案C: 共有 `DocsTable` で table セマンティクスを構造的に強制**）の最小実装。ハンドビルド docs ページの table a11y を、per-page axe spec ではなく共有コンポーネント + unit test で担保する。

判断の決め手: issue が懸念する drift（`scope` 欠落・`<th>`/`<td>` 不整合）は **axe の WCAG 2.1 A/AA タグでは検出されない**（`scope-attr-valid` は無効値のときのみ発火）。よって axe sweep（案A/B）では穴を塞げず、コンポーネント側で構造強制するのが正しい。

## 変更

| ファイル | 変更 |
|---|---|
| `src/docs/docs-ui.tsx` | **追加** — `DocsTable`（`<th scope="col">` + thead/tbody + 任意 `caption`）。`Accessibility` / `Testing` が二重定義していた `RefTable` を統合 |
| `src/docs/Accessibility.stories.tsx` | ローカル `RefTable` 削除 → `DocsTable` |
| `src/docs/Testing.stories.tsx` | 同上 |
| `src/docs/CompositionWithAsChild.stories.tsx` | escape-hatch 比較表を `DocsTable` 化（`caption` 付与） |
| `src/docs/CSSApi.stories.tsx` | bespoke `cssapi-doc__attr-table` の `<th>` に `scope="col"` を直書き |
| `src/docs/docs-ui.test.tsx` | **追加** — 全ヘッダセルの `scope="col"`・cell マッピング・`caption` のアクセシブルネームを pin |
| `.claude/rules/vrt-spec-guideline.md` | 「docs page tables and a11y」節を追記（構造担保方針の明文化） |
| `.changeset/docs-table-a11y-384.md` | `patch`（docs/internal のみ） |

## 確定した個別判断（#384「未解決の論点」）

- 案A（docs 全体 axe sweep）は**入れない** → vrt-spec-guideline に将来オプションとして明記
- `CSSApi` table は `DocsTable` に寄せず **`scope="col"` 直書き**（page-chrome CSS と Tailwind class が噛み合わないため）
- `docs-ui.test.tsx` を**新設**（案Cの担保が axe ではなくこの test であることを明示）

## 検証

- ✅ `pnpm typecheck`
- ✅ `pnpm lint`
- ✅ `pnpm test --run` — 862 passed（うち `docs-ui.test.tsx` 3 件新規）
- ✅ `pnpm test:vrt`（`CSSApi` / `CompositionWithAsChild`）— **baseline 差分ゼロ**（`scope` は非視覚属性・class 維持のため）

`Accessibility` / `Testing` は元々 VRT spec なし（視覚契約なし方針）のため追加なし。方針どおり per-page axe spec も追加していない。

Closes #384

🤖 Generated with [Claude Code](https://claude.com/claude-code)