### PR TITLE
perf(lv1): Button のローディングスピナーをアイドル時に停止

### DIFF
--- a/.changeset/button-spinner-pause-when-idle.md
+++ b/.changeset/button-spinner-pause-when-idle.md
@@ -1,0 +1,11 @@
+---
+'@yasmro/schatten': patch
+---
+
+perf(lv1): Button のローディングスピナーをアイドル時に停止
+
+非 link / 非 asChild の Button は、ローディング transition をレイアウトシフトなしでクロスフェードさせるため、`.st-btn__spinner-overlay`（中の `Spinner`）を常に DOM に保持し、アイドル時は `opacity: 0` で隠している。だが `opacity: 0` の要素もコンポジット対象なので、Spinner の `animation: schatten-spin … infinite` が**全アイドルボタン上で回り続け**、ローディング中のボタン数ではなく描画ボタン数に比例した無駄なコンポジタ処理が発生していた（タブが idle に落ちず、低スペック / モバイルでの電力影響、`O(全ボタン数)` のスケール特性）。
+
+`.st-btn__spinner-overlay .st-spinner__rotor` を既定で `animation-play-state: paused` にし、`.st-btn[aria-busy="true"]` 配下でのみ `running` に切り替える。クロスフェードの UX（overlay の `opacity` 0↔1 transition）と DOM 常駐はそのまま、見えていないスピナーのアニメーション tick だけを止める。
+
+CSS API: クラス・状態属性・CSS 変数の追加 / 改名 / 削除はなし（既存 `.st-btn__spinner-overlay` / `.st-spinner__rotor` / `[aria-busy="true"]` を使った `animation-play-state` の付与のみ — component-architecture.md §7 が lv1-local CSS で許可する「`animation-play-state` を状態属性に紐づける」パターン）。静止画の見た目は不変（アイドル時は `opacity: 0`、ローディング時は停止フレームと実行中フレームが静止画では区別不能）なため、VRT baseline の再生成は不要。

--- a/src/components/lv1/Button/Button.css
+++ b/src/components/lv1/Button/Button.css
@@ -349,6 +349,20 @@
     width: 1em;
     height: 1em;
   }
+  /* The spinner overlay stays in the DOM at `opacity: 0` while idle (so the
+   * loading transition can cross-fade without layout shift). But an
+   * `opacity: 0` element is still composited, so the Spinner's
+   * `animation: schatten-spin … infinite` keeps ticking on EVERY idle button
+   * — wasted compositor work that scales with button count, not with the
+   * number actually loading. Pause it while idle and only run it under
+   * `[aria-busy="true"]`. `animation-play-state` gated on a state attribute is
+   * the lv1-local-CSS pattern allowed by component-architecture.md §7. */
+  .st-btn__spinner-overlay .st-spinner__rotor {
+    animation-play-state: paused;
+  }
+  .st-btn[aria-busy="true"] .st-btn__spinner-overlay .st-spinner__rotor {
+    animation-play-state: running;
+  }
 
   /* Content row — fades out when loading so the spinner overlay reads as
    * "the only thing in the button". */


### PR DESCRIPTION
## 概要

非 `link` / 非 `asChild` の `Button` は、ローディング切替をレイアウトシフトなしでクロスフェードさせるため、overlay スピナー(`.st-btn__spinner-overlay` 内の `Spinner`)を**常に DOM に保持**し、アイドル時は `opacity: 0` で隠している。

しかし `opacity: 0` の要素も(`display: none` と違って)コンポジット対象なので、Spinner の `animation: schatten-spin … infinite` が**全アイドルボタン上で回り続けて**いた。コスト構造が「ローディング中のボタン数」ではなく「描画ボタン数」に比例し、

- タブが idle に落ちない(低スペック / モバイルでの電力影響)
- `O(全ボタン数)` のスケール特性
- デザインシステム primitive ＝ 全 consumer に掛け算で波及

という無駄が出ていた。検証ツールで「ローディング中でもないのにスピナーが居る」と気づいたのが発端。

## 修正

[`Button.css`](https://github.com/yasmro/schatten/blob/claude/bold-moore-dd3765/src/components/lv1/Button/Button.css) に2ルール追加。**既定で回転を止め、`[aria-busy="true"]` 配下でのみ回す**。

```css
.st-btn__spinner-overlay .st-spinner__rotor                              { animation-play-state: paused; }
.st-btn[aria-busy="true"] .st-btn__spinner-overlay .st-spinner__rotor    { animation-play-state: running; }
```

- クロスフェードの UX(overlay の `opacity` 0↔1 transition)と DOM 常駐はそのまま、**見えていないスピナーのアニメ tick だけ**を停止。
- クラス / 状態属性 / CSS 変数の**追加・改名・削除なし**(既存 `.st-btn__spinner-overlay` / `.st-spinner__rotor` / `[aria-busy="true"]` を使った `animation-play-state` 付与のみ)。これは `component-architecture.md §7` が lv1-local CSS で明示的に許可している「`animation-play-state` を状態属性に紐づける」パターン。

## 検証(実ブラウザで computed style 実測)

VRT は静止画で paused/running を区別できない(アイドルは `opacity:0`、停止フレームと実行中フレームは静止画で同一)ため、隔離 Storybook 上で `getComputedStyle(...).animationPlayState` を直読みした。

| 状態 | `aria-busy` | overlay opacity | rotor `animation-play-state` |
|---|---|---|---|
| アイドル(AllVariants, 6個全部) | なし | `0` | **`paused`** ✅ |
| ローディング(Loading, 4個全部) | `true` | `1` | **`running`** ✅ |

クロスフェード(overlay opacity の 0↔1)は維持されたまま、アイドルボタンの回転だけが停止していることを確認。

## 別案として検討した「DOM ごと消す」方向(条件レンダリング)とのトレードオフ

「アイドル時はスピナーを DOM から外す(`{isLoading && <Spinner/>}`)」案も俎上に載せたが、**今回の pause 修正後では、得られる残りの利益が "アイドル時に数ノード減る" だけ**になり、対価の方が大きいと判断して見送った。記録として残す。

### DOM を消すと失うもの

1. **クロスフェード、特に fade-out(最大の損失)**
   - **fade-in**: 条件レンダリングだと開始時にスピナーが*マウント*される。CSS `transition` は「既存要素の値変化」でしか効かないので、マウント直後は最終 opacity から始まり**フェードせずポップイン**する。再現には `@keyframes` enter / double-rAF トリックの追加が必要。
   - **fade-out**: `isLoading` が false になると要素が*即アンマウント*され、フェード相手が消えるため**プレーンな条件レンダリングでは fade-out が原理的に不可能**。`AnimatePresence` 相当の exit オーケストレーション(終了まで保持 → `onTransitionEnd` で unmount)を自前で組む必要がある。現状の「常駐 + opacity」はこの exit 制御をタダで得ている。

2. **トグルごとの再描画コスト(逆効果)**
   - 常駐方式は切替が `aria-busy` 属性 + class の flip のみで **DOM 構造不変**。条件レンダリングは切替のたびに `div+svg+2図形+sr-only` サブツリーを mount/unmount する reconciliation + DOM 変異が走る。「パフォーマンスのために DOM を消す」のに steady-state のトグルが重くなる逆転。

3. **React-DOM と「文書化された CSS API 構造」の乖離**
   - `css-api.md` はローディングを `[aria-busy="true"]` という状態属性が安定構造の上で visual を駆動するモデルにしている。vanilla HTML consumer は overlay を一度書いて `aria-busy` を flip するだけ。React 側だけ条件レンダリングにすると、React の DOM と文書化された vanilla 構造がズレる。

4. **a11y アナウンスのセマンティクス変化(良し悪し両方)**
   - Spinner は `role="status"`(polite live region)+ sr-only "Loading"。常駐 + `aria-hidden` トグルと条件マウントでは「いつ読み上げられるか」が変わる。条件マウントの方が live region への挿入で発火しやすい側面もあり一概に悪くはないぶん、変えるなら AT 実機テストが要る。

### 逆に「失わないもの」(誤解しやすい点)

- **レイアウト/幅の安定**: overlay は `position: absolute; inset: 0` でサイズに寄与しない。幅は常駐する `.st-btn__content` が確保するので、overlay だけ条件レンダリングしても reflow はしない。
- **アイドル時の無駄アニメ tick**: ← これが唯一「DOM 消し」固有のメリットだったが、**本 PR の pause 修正で既に回収済み**。

### 結論

| 観点 | 常駐 + pause(本 PR) | DOM 消し(条件レンダリング) |
|---|---|---|
| アイドルの無駄アニメ | ✅ 解消 | ✅ 解消(ただし本 PR で既に解消済) |
| fade-in / **fade-out** | ✅ タダで両方 | ❌ 自前 exit 制御が必要 |
| トグルのコスト | ✅ 属性 flip のみ | ⚠️ 毎回 mount/unmount |
| vanilla CSS との構造一致 | ✅ 一致 | ⚠️ 乖離 |
| 残コスト | アイドル数ノード/ボタン | 上記すべて |

DOM 消しが正当化されるのは「行ごとにアクションボタンが数百〜千並ぶグリッドで、かつトランジション不要」級の限定状況のみ。そのときも全体を変えるのではなく、その画面側で対処する方が筋が良い。本 PR は**安い方のレバー**を引いた選択。

## テスト / 契約への影響

- `pnpm lint` ✅(269 files, clean) / `pnpm test --run` ✅(**875 / 875 passed**)
- pre-commit(biome check + typecheck)✅
- **manifest ドリフトなし**(新規 surface ゼロ)→ `update:manifest` 不要
- **VRT baseline 再生成不要**(静止画の見た目不変)
- changeset: `patch`(`perf(lv1)`)を同梱

## changeset

`.changeset/button-spinner-pause-when-idle.md`(`@yasmro/schatten`: `patch`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
