### PR TITLE
chore(storybook): Theming を一旦非表示にし parity story を末尾へ

### DIFF
--- a/.claude/rules/storybook-guideline.md
+++ b/.claude/rules/storybook-guideline.md
@@ -269,8 +269,10 @@ fix all of these **in the same PR**:
   Canvas export) and on a `Patterns/*` page that isn't linked. A title/export
   rename that misses the manifest turns this test red rather than shipping a
   dead link.
-- `options.storySort.order` in `.storybook/preview.tsx` if a top-level group
-  name changed
+- the top-level group order in `options.storySort` in `.storybook/preview.tsx`
+  if a top-level group name changed (it's a comparator function — update the
+  `order` array inside it; the comparator also forces each component's parity
+  story, story id `…--parity`, to sort last)
 
 Story IDs are **internal** per [api-stability.md](api-stability.md) (Storybook
 is not part of the published package), so an IA rename needs **no changeset and

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -91,8 +91,23 @@ const preview: Preview = {
       test: 'todo',
     },
     options: {
-      storySort: {
-        order: [
+      // Comparator form (was a `storySort.order` array). The top-level group
+      // order is unchanged; the function exists so the per-component parity
+      // story ("React vs Vanilla HTML", export `Parity`, story id ending
+      // `--parity`) can be forced LAST within its component. That story lives
+      // in `<Name>.parity.stories.tsx`, which loads before `<Name>.stories.tsx`
+      // by filename, so without this it sorts first. Every other pair returns
+      // 0 → the stable sort preserves the previous load order (the default
+      // `configure` method), so only the parity story moves.
+      // NOTE: Storybook statically generates + `eval`s this arrow at index
+      // build (getStorySortParameter). It MUST be an inline arrow of plain JS:
+      // an external reference is `unsupported`, and any TS type annotation on a
+      // param survives babel codegen into the eval'd string → "Unexpected token
+      // ':'". So `a` / `b` cannot be annotated, and `options.storySort` is too
+      // loosely typed to type them contextually — hence the targeted suppress.
+      // @ts-expect-error -- a/b are Storybook IndexEntry (id, title); see note
+      storySort: (a, b) => {
+        const order = [
           'Welcome',
           'Getting Started',
           'Tokens',
@@ -100,7 +115,18 @@ const preview: Preview = {
           'CSS API',
           'Patterns',
           'Components',
-        ],
+        ]
+        const ga = order.indexOf(a.title.split('/')[0])
+        const gb = order.indexOf(b.title.split('/')[0])
+        const ta = ga === -1 ? order.length : ga
+        const tb = gb === -1 ? order.length : gb
+        if (ta !== tb) return ta - tb
+        if (a.title === b.title) {
+          const ap = a.id.endsWith('--parity')
+          const bp = b.id.endsWith('--parity')
+          if (ap !== bp) return ap ? 1 : -1
+        }
+        return 0
       },
     },
   },

--- a/src/docs/foundations/SeasonalShowcase.stories.tsx
+++ b/src/docs/foundations/SeasonalShowcase.stories.tsx
@@ -114,6 +114,10 @@ function SolidSample() {
 
 const meta: Meta = {
   title: 'Theming/Seasonal Showcase',
+  // Hidden from the sidebar while the Theming docs IA is being reworked.
+  // File / story index / VRT (id-driven iframe URLs) stay live — `!dev`
+  // only drops it from the dev sidebar. Remove the tag to restore.
+  tags: ['!dev'],
   parameters: {
     layout: 'fullscreen',
   },

--- a/src/docs/foundations/ThemeAudit.stories.tsx
+++ b/src/docs/foundations/ThemeAudit.stories.tsx
@@ -83,6 +83,10 @@ function ThemeCell({ mode, special }: { mode: Mode; special: SeasonalThemeId | n
 
 const meta: Meta = {
   title: 'Theming/Theme Audit',
+  // Hidden from the sidebar while the Theming docs IA is being reworked.
+  // File / story index / VRT (id-driven iframe URLs) stay live — `!dev`
+  // only drops it from the dev sidebar. Remove the tag to restore.
+  tags: ['!dev'],
   parameters: {
     layout: 'fullscreen',
   },

--- a/src/providers/ThemeProvider/ThemeInitScript.stories.tsx
+++ b/src/providers/ThemeProvider/ThemeInitScript.stories.tsx
@@ -15,7 +15,11 @@ const meta: Meta<typeof ThemeInitScript> = {
       },
     },
   },
-  tags: ['autodocs'],
+  // Hidden from the sidebar while the Theming docs IA is being reworked.
+  // `!dev` drops the stories; `!autodocs` drops the generated Docs page
+  // (autodocs survives `!dev` alone). File / story index / VRT stay live.
+  // To restore: tags: ['autodocs'].
+  tags: ['!dev', '!autodocs'],
   argTypes: {
     nonce: {
       description: 'CSP nonce forwarded to the rendered `<script>` element.',

--- a/src/providers/ThemeProvider/ThemeProvider.stories.tsx
+++ b/src/providers/ThemeProvider/ThemeProvider.stories.tsx
@@ -19,7 +19,11 @@ const meta: Meta<typeof ThemeProvider> = {
     // its <html> mutation when true.
     disableGlobalThemeDecorator: true,
   },
-  tags: ['autodocs'],
+  // Hidden from the sidebar while the Theming docs IA is being reworked.
+  // `!dev` drops the stories; `!autodocs` drops the generated Docs page
+  // (autodocs survives `!dev` alone). File / story index / VRT stay live.
+  // To restore: tags: ['autodocs'].
+  tags: ['!dev', '!autodocs'],
   argTypes: {
     defaultMode: {
       description: 'Initial color-mode setting.',


### PR DESCRIPTION
## 概要

Storybook サイドバーの情報設計まわりを2点調整。どちらも **Storybook 限定**で、公開される `.st-*` / React props / token などの surface には影響しません(stories は [api-stability.md](.claude/rules/api-stability.md) 上 internal 扱い → **changeset なし**)。

### 1. Theming セクションを一旦サイドバーから非表示
Theming 配下の story が 4 グループ・15 リーフと多く、評価者向けの導線として過剰だったため、IA を再検討する間だけ**導線を隠す**(ファイルは残す)。

- 4 ファイルの `meta` に `tags: ['!dev']` を付与(`ThemeProvider` / `ThemeInitScript` は autodocs の Docs ページも消すため `['!dev', '!autodocs']`)。
- `!dev` はサイドバーのみに作用 → **story index / iframe レンダリング / 既存 VRT は無傷**(`theming-theme-audit--overview` を iframe 直叩きでレンダリング確認済)。
- 復元方法は各ファイルのコメントに明記。

### 2. parity story(「React vs Vanilla HTML」)を各コンポーネントの末尾へ
`<Name>.parity.stories.tsx` がファイル名順で `<Name>.stories.tsx` より先にロードされ**先頭**に来ていたのを末尾へ。

- `storySort` をオブジェクト(`order` 配列)から比較関数に変更。
- トップレベルのグループ順は不変。同一コンポーネント内で id が `--parity` の story だけ末尾へ送り、他は `0` を返して authored 順を保持。
- `getStorySortParameter` が関数を静的 eval する制約(inline arrow 必須・param 型注釈不可)を回避するため、`a`/`b` の implicit any は理由コメント付き `@ts-expect-error` で限定的に抑制。
- [storybook-guideline.md](.claude/rules/storybook-guideline.md) の `storySort` 参照を関数形に更新。

## 検証
- 実機 Storybook(10.4.1)で確認:
  - サイドバーから THEMING グループが消失、他グループ(Tokens / CSS API / Patterns / Components)は無傷。
  - Switch / Button とも parity が末尾、他 story は authored 順を維持。
  - index ビルド成功・14 parity entry 健在。
- `pnpm typecheck` / `biome check` パス(pre-commit hook 含む)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)