### PR TITLE
ci(a11y): a11y job を blocking に昇格 (#346)

### DIFF
--- a/.claude/rules/component-architecture.md
+++ b/.claude/rules/component-architecture.md
@@ -532,11 +532,15 @@ fallback — that policy only holds if the contract below holds.
 2. **VRT a11y assertion** — since v0.11.0 (#147) every lv1
    `*.vrt.spec.ts` pairs each screenshot with an `@axe-core/playwright`
    scan (WCAG 2.1 A/AA) that asserts zero violations. Run locally with
-   `pnpm test:a11y`; in CI the ubuntu `a11y` job runs it. **Phase 1 is
-   observe-only** (`continue-on-error: true`) while a backlog of
-   pre-existing violations is worked off in follow-up issues — see
-   [vrt-spec-guideline §a11y assertions](vrt-spec-guideline.md). The
-   Storybook `addon-a11y` panel remains the manual dev-time companion.
+   `pnpm test:a11y`; in CI the ubuntu `a11y` job runs it. Since the Phase
+   1 backlog was cleared (color-contrast #344, label/button-name #345),
+   the gate is **blocking** (#346) — the `a11y` job propagates the
+   Playwright exit code, so a new violation fails the PR. The only axe
+   `color-contrast` findings that remain are intentional design exceptions
+   (solid treatments / inverted-on-saturated / the foreground-subtle
+   tertiary tier), each disabled with a documented rationale scoped to its
+   own story — see [vrt-spec-guideline §a11y assertions](vrt-spec-guideline.md).
+   The Storybook `addon-a11y` panel remains the manual dev-time companion.
 3. **Code review** — when reviewing an lv1 PR, walk the four
    guarantees and Hard rules above. If the component opts out of a
    default (e.g. Callout's no-role posture), the TSDoc must say so
@@ -559,8 +563,12 @@ fallback — that policy only holds if the contract below holds.
   [AGENTS.md](../../AGENTS.md).
 - **§8 (a11y contract):**
   - [#147](https://github.com/yasmro/schatten/issues/147) landed the
-    `@axe-core/playwright` VRT-paired check (v0.11.0). When the Phase 1
-    backlog is cleared and the `a11y` CI job drops `continue-on-error`
-    (Phase 2), update "Verifying compliance" to call it a blocking gate.
+    `@axe-core/playwright` VRT-paired check (v0.11.0); the Phase 1
+    backlog (#344 / #345) is now cleared and the `a11y` CI job is
+    blocking (#346) — "Verifying compliance" reflects this. If a future
+    component needs a genuinely new `color-contrast` exception, it must
+    be a documented, story-scoped `disableRules(['color-contrast'])`
+    with a rationale (not a blanket disable) — see
+    [vrt-spec-guideline §a11y assertions](vrt-spec-guideline.md).
   - When `Field.required` gains `aria-required` propagation, remove
     the gap note in guarantee #4.

--- a/.claude/rules/storybook-guideline.md
+++ b/.claude/rules/storybook-guideline.md
@@ -185,11 +185,13 @@ a11y: {
   `landmark-one-main` / `page-has-heading-one`) that flag the Storybook iframe
   itself on every story — pure noise. Keeping the tag set identical means
   "green in the dev panel" maps to the same contract CI enforces.
-- **`test: 'todo'`** keeps the addon observe-only. The `test` flag only bites
-  through the test addon (`@storybook/addon-vitest`), which is not wired up
-  today, so it is inert — but it documents the Phase-1 stance. Promotion to
-  `'error'` rides with the CI blocking-gate work
-  ([#346](https://github.com/yasmro/schatten/issues/346)).
+- **`test: 'todo'`** keeps the addon panel observe-only. The `test` flag only
+  bites through the test addon (`@storybook/addon-vitest`), which is not wired
+  up today, so it is inert. The CI a11y **gate** is already blocking — that is
+  the Playwright `a11y` job ([#346](https://github.com/yasmro/schatten/issues/346)),
+  a separate surface from this addon-vitest flag. Promoting the flag to
+  `'error'` only matters once `@storybook/addon-vitest` is actually wired up;
+  until then it stays `'todo'`.
 - **Dark mode / seasonal violations come for free.** The addon scans the
   rendered DOM *after* the global theme decorator applies `.dark` /
   `data-theme` to `<html>`, so toggling the Theme toolbar surfaces dark-mode

--- a/.claude/rules/storybook-guideline.md
+++ b/.claude/rules/storybook-guideline.md
@@ -196,9 +196,13 @@ a11y: {
   flipping the gate to blocking ([#346](https://github.com/yasmro/schatten/issues/346))
   surfaced it. Our a11y **test runner** is `@axe-core/playwright` (the CI `a11y`
   job), so the addon's headless run is redundant — `'off'` turns it off and
-  keeps addon-a11y as the **on-demand dev panel** only. If `@storybook/addon-vitest`
-  is ever wired up as a second runner, reconcile the two before re-enabling the
-  flag; don't simply flip it back to `'todo'`/`'error'`.
+  keeps addon-a11y as the **on-demand dev panel** only. `'off'` disables only
+  the headless `afterEach`; the panel's own run path is the `MANUAL` channel
+  event (the **"Rerun accessibility scan"** button), which is independent of
+  `test`, so the panel still scans the current story — you click Rerun instead
+  of it auto-populating on render. If `@storybook/addon-vitest` is ever wired up
+  as a second runner, reconcile the two before re-enabling the flag; don't
+  simply flip it back to `'todo'`/`'error'`.
 - **Dark mode / seasonal violations come for free.** The addon scans the
   rendered DOM *after* the global theme decorator applies `.dark` /
   `data-theme` to `<html>`, so toggling the Theme toolbar surfaces dark-mode

--- a/.claude/rules/storybook-guideline.md
+++ b/.claude/rules/storybook-guideline.md
@@ -185,13 +185,20 @@ a11y: {
   `landmark-one-main` / `page-has-heading-one`) that flag the Storybook iframe
   itself on every story — pure noise. Keeping the tag set identical means
   "green in the dev panel" maps to the same contract CI enforces.
-- **`test: 'todo'`** keeps the addon panel observe-only. The `test` flag only
-  bites through the test addon (`@storybook/addon-vitest`), which is not wired
-  up today, so it is inert. The CI a11y **gate** is already blocking — that is
-  the Playwright `a11y` job ([#346](https://github.com/yasmro/schatten/issues/346)),
-  a separate surface from this addon-vitest flag. Promoting the flag to
-  `'error'` only matters once `@storybook/addon-vitest` is actually wired up;
-  until then it stays `'todo'`.
+- **`test: 'off'` is required, and is NOT "inert".** addon-a11y's preview
+  `afterEach` runs axe on every `viewMode=story` render unless `test === 'off'`
+  (the `shouldRunEnvironmentIndependent` guard in the addon's `preview.js`).
+  `@axe-core/playwright` loads exactly those `iframe.html?viewMode=story` URLs,
+  so any value other than `'off'` makes the addon's run **race** our Playwright
+  `.analyze()` in the same frame → intermittent `Error: Axe is already running`
+  (worst on Toast, which mounts toasts in a `useEffect`, forcing a second
+  render → a second axe run). The Phase-1 observe-only exit-0 shim hid this;
+  flipping the gate to blocking ([#346](https://github.com/yasmro/schatten/issues/346))
+  surfaced it. Our a11y **test runner** is `@axe-core/playwright` (the CI `a11y`
+  job), so the addon's headless run is redundant — `'off'` turns it off and
+  keeps addon-a11y as the **on-demand dev panel** only. If `@storybook/addon-vitest`
+  is ever wired up as a second runner, reconcile the two before re-enabling the
+  flag; don't simply flip it back to `'todo'`/`'error'`.
 - **Dark mode / seasonal violations come for free.** The addon scans the
   rendered DOM *after* the global theme decorator applies `.dark` /
   `data-theme` to `<html>`, so toggling the Theme toolbar surfaces dark-mode

--- a/.claude/rules/vrt-spec-guideline.md
+++ b/.claude/rules/vrt-spec-guideline.md
@@ -199,19 +199,24 @@ CI splits them across runners: the macos `vrt` job runs `pnpm test:vrt`
 contrast / role checks derive from CSS, not from macos font / sub-pixel
 rendering, so the scarce macos runner stays pixel-only.
 
-> **Phase 1 (observe-only).** A backlog of pre-existing violations
-> (systemic borderline color-contrast on state tokens — #344;
-> bare-control story artifacts — #345) is worked off before the gate
-> blocks — mirroring the `audit` job's staged rollout (#307). Because
-> those ~115 violations would fail Playwright on **every** run, the
-> `a11y` job's step keeps the **check green as long as axe actually ran**
-> (it tees the full violation list into `$GITHUB_STEP_SUMMARY` for
-> anyone who looks) and only fails when axe *couldn't* run (a crash, or a
-> grep / `--` mistake that yields "No tests found"). The job is also
-> `continue-on-error: true` as a backstop. Phase 2 (#346) deletes that
-> exit-0 shim and `continue-on-error` so the gate blocks. Until then,
-> **read the summary, not the check color** — and new components should
-> still land with zero new violations.
+> **Phase 2 (blocking, #346).** The Phase 1 backlog is cleared — the
+> systemic color-contrast violations on state tokens (#344, fixed by the
+> `--color-{state}-emphasis` retune in Phase B) and the bare-control
+> story label/button-name violations (#345) are resolved — so the gate
+> now **blocks**: the `a11y` job propagates the Playwright exit code and
+> a new violation fails the PR. The step still tees the full axe output
+> into `$GITHUB_STEP_SUMMARY` so a failure's violation list is readable
+> straight from the PR checks. The only `color-contrast` findings that
+> remain are **intentional design exceptions** — solid treatments (white
+> foreground on a saturated/neutral-solid fill, the AA trilemma),
+> inverted-on-saturated foreground, and the `foreground-subtle` tertiary
+> tier (large/incidental-only). Each is suppressed with a **story-scoped**
+> `disableRules(['color-contrast'])` carrying a one-line rationale + the
+> `#344` / `#346` refs, mirrored in the story's `parameters.a11y` for the
+> addon panel (the [Per-story rule disable](storybook-guideline.md) rule).
+> A blanket or whole-file `color-contrast` disable is **not** acceptable —
+> if you reach for one, you are masking a real regression. New components
+> must land with zero new violations.
 
 ## Components rendered into a Portal
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -211,17 +211,18 @@ jobs:
 
   a11y:
     runs-on: ubuntu-latest
-    # Phase 1: observe-only. The a11y assertions in *.vrt.spec.ts run axe
-    # (WCAG 2.1 A/AA) against every lv1 story × theme, but ~115 pre-existing
-    # violations (systemic borderline color-contrast on state tokens, plus
-    # bare-control story artifacts) cannot be fixed inside this infra PR
-    # without a designer-owned token retune or a story-relabel + VRT
-    # re-baseline. So this gate observes — the step tees the axe output into
-    # the job summary so the violation list is readable from the PR checks
-    # without blocking merges — mirroring the staged rollout of the `audit`
-    # job (#307). Fixes land as follow-up issues (#344 / #345); Phase 2 (#346)
-    # removes continue-on-error and adds `a11y` to develop's required checks.
-    continue-on-error: true
+    # Phase 2 (#346): blocking. The a11y assertions in *.vrt.spec.ts run axe
+    # (WCAG 2.1 A/AA) against every lv1 story × theme and must report zero
+    # violations. The Phase 1 backlog is cleared — color-contrast (#344, the
+    # state-token `emphasis` retune in Phase B) and label/button-name (#345)
+    # are fixed; the only remaining axe `color-contrast` findings are intentional
+    # design exceptions (solid treatments / inverted-on-saturated / the
+    # foreground-subtle tertiary tier — see state-token-guideline.md), each
+    # disabled with a documented rationale scoped to its own story in the VRT
+    # spec + mirrored in `parameters.a11y`. So the gate now propagates the
+    # Playwright exit code (a new violation fails the PR). Adding `a11y` to
+    # develop's required checks is a repo-settings change (ruleset), tracked in
+    # #346, not in this workflow.
     steps:
       - uses: actions/checkout@v6
 
@@ -241,37 +242,25 @@ jobs:
       # spec, excluded by the `a11y` grep) reads dist directly. axe is run on
       # ubuntu rather than the scarce macos VRT runner because contrast/role
       # checks derive from CSS, not from macos font / sub-pixel rendering.
-      # Tee axe output into the job summary so the violation list is readable
-      # straight from the PR checks (the `audit` job does the same for coverage
-      # gaps). GitHub's default bash shell runs with `-e`, so capture the
-      # Playwright exit code under `set +e` before doing anything else.
       #
-      # Phase 1 observe-only contract: ~115 known violations make Playwright
-      # exit non-zero on EVERY run, so propagating that status would paint the
-      # `a11y` check permanently red and train people to ignore it (unlike the
-      # `audit` job, which is green until a real new gap appears). Instead we
-      # keep the check GREEN as long as axe actually ran — a Playwright result
-      # summary line (`N passed` / `N failed`) proves the suite executed — and
-      # only fail the step when axe could NOT run (crash, or the `--`/grep
-      # mistake that yields "No tests found"). #346 (Phase 2) deletes this
-      # exit-0 shim together with `continue-on-error` to make the gate block.
+      # The axe output is still tee'd into the job summary so a failure's
+      # violation list is readable straight from the PR checks (the `audit` job
+      # does the same for coverage gaps). GitHub's default bash runs with `-e`,
+      # which would abort the step before the summary is written, so the
+      # Playwright exit code is captured under `set +e` via `PIPESTATUS[0]` and
+      # re-raised after the closing fence — the step fails iff axe reports a
+      # violation (Phase 2 blocking, #346).
       - name: a11y (axe) checks
         shell: bash
         run: |
           {
-            echo '## a11y (axe) — WCAG 2.1 A/AA (Phase 1 observe-only)'
+            echo '## a11y (axe) — WCAG 2.1 A/AA'
             echo
             echo '```'
           } >> "$GITHUB_STEP_SUMMARY"
           set +e
-          pnpm test:a11y 2>&1 | tee axe-out.txt
+          pnpm test:a11y 2>&1 | tee -a "$GITHUB_STEP_SUMMARY"
           status=${PIPESTATUS[0]}
           set -e
-          cat axe-out.txt >> "$GITHUB_STEP_SUMMARY"
           echo '```' >> "$GITHUB_STEP_SUMMARY"
-          if grep -qE '[0-9]+ (passed|failed)' axe-out.txt; then
-            echo 'a11y ran (Phase 1 observe-only): violations are listed in the job summary, not blocking.'
-            exit 0
-          fi
-          echo '::error::axe did not run (no Playwright result summary) — failing the step.'
           exit "$status"

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -84,11 +84,19 @@ const preview: Preview = {
           values: ['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa'],
         },
       },
-      // Phase 1 (observe-only): surface violations in the panel, block nothing.
-      // `test` only bites once the test addon (@storybook/addon-vitest) is
-      // wired up — unused today, so 'todo' is inert but documents the stance.
-      // Promotion to 'error' rides with the CI blocking work (#346).
-      test: 'todo',
+      // `test: 'off'` — NOT inert. addon-a11y's preview `afterEach` runs axe
+      // on every `viewMode=story` render whenever `test !== 'off'` (see the
+      // `shouldRunEnvironmentIndependent` guard in addon-a11y's preview.js).
+      // Playwright loads exactly those `iframe.html?viewMode=story` URLs, so
+      // the addon's run RACES our `@axe-core/playwright` `.analyze()` in the
+      // same frame → intermittent `Error: Axe is already running` (worst on
+      // Toast, whose toasts mount in a useEffect → a second render → a second
+      // axe run). Phase 1's exit-0 shim masked it; #346 (blocking) surfaced it.
+      // Our a11y test runner IS `@axe-core/playwright` (the CI `a11y` gate), so
+      // the addon's headless run is redundant — turn it off and keep addon-a11y
+      // as the on-demand dev PANEL only. The panel still scans the selected
+      // story with the pinned tag set above.
+      test: 'off',
     },
     options: {
       // Comparator form (was a `storySort.order` array). The top-level group

--- a/src/components/lv1/Badge/Badge.stories.tsx
+++ b/src/components/lv1/Badge/Badge.stories.tsx
@@ -216,6 +216,8 @@ export const OutlineTreatments: Story = {
 export const FullMatrix: Story = {
   name: 'Full Matrix',
   parameters: {
+    // Solid Badges are light-on-saturated fill — the intentional AA solid exception (icon + label carry the meaning). Mirrors Badge.vrt.spec.ts. #344 / #346.
+    a11y: { config: { rules: [{ id: 'color-contrast', enabled: false }] } },
     docs: {
       description: {
         story:

--- a/src/components/lv1/Badge/Badge.vrt.spec.ts
+++ b/src/components/lv1/Badge/Badge.vrt.spec.ts
@@ -7,6 +7,17 @@ const stories = ['full-matrix', 'sizes', 'icon-positions', 'icon-only'] as const
 
 const themes = ['light', 'dark'] as const
 
+// Stories whose only remaining axe `color-contrast` findings are the
+// intentional solid-treatment exception: a solid Badge is light foreground
+// (`--color-{state}-foreground`) on a saturated state fill, which cannot reach
+// 4.5:1 (the white-on-vivid trilemma — state-token-guideline.md §Phase B). The
+// meaning is never colour-only — every Badge ships an icon + visible label
+// (WCAG 1.4.1) — so this is an intentional AA exception, not a regression.
+// `full-matrix` renders solid alongside subtle/outline in one frame;
+// subtle/outline use the AA `emphasis` rung and pass. Disable just this rule,
+// just here; mirrored in the story's `parameters.a11y`. #344 (Phase B) / #346.
+const COLOR_CONTRAST_EXCEPTION_STORIES = new Set<(typeof stories)[number]>(['full-matrix'])
+
 function storyUrl(storyId: string, theme: string) {
   return `/iframe.html?id=${STORY_ID_PREFIX}--${storyId}&globals=theme:${theme}&viewMode=story`
 }
@@ -38,10 +49,15 @@ for (const story of stories) {
       const root = page.locator('#storybook-root')
       await root.waitFor({ state: 'visible', timeout: 10_000 })
 
-      const results = await new AxeBuilder({ page })
+      const builder = new AxeBuilder({ page })
         .include('#storybook-root')
         .withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa'])
-        .analyze()
+
+      if (COLOR_CONTRAST_EXCEPTION_STORIES.has(story)) {
+        builder.disableRules(['color-contrast'])
+      }
+
+      const results = await builder.analyze()
 
       expect(results.violations).toEqual([])
     })

--- a/src/components/lv1/Button/Button.stories.tsx
+++ b/src/components/lv1/Button/Button.stories.tsx
@@ -294,6 +294,10 @@ export const Disabled: Story = {
 
 export const InvertedOnSaturatedSurfaces: Story = {
   name: 'Inverted on saturated surfaces',
+  parameters: {
+    // inverted ghost foreground on saturated surfaces — incidental/large-only by design. Mirrors Button.vrt.spec.ts. #344 / #346.
+    a11y: { config: { rules: [{ id: 'color-contrast', enabled: false }] } },
+  },
   render: () => (
     <div className="flex flex-col gap-3">
       {[

--- a/src/components/lv1/Button/Button.vrt.spec.ts
+++ b/src/components/lv1/Button/Button.vrt.spec.ts
@@ -28,6 +28,18 @@ const stories = [
 
 const themes = ['light', 'dark'] as const
 
+// Stories whose only remaining axe `color-contrast` findings are the
+// intentional inverted-on-saturated exception: the `inverted` variant is a
+// ghost button placed on a saturated surface, drawing its label from
+// `--color-inverted-foreground`. That tier is incidental/large-only by design
+// (state-token-guideline.md §Phase B) — a light foreground on a vivid fill
+// can't reach 4.5:1, and the variant is only ever used where the surrounding
+// solid surface already documents that exception. Disable just this rule, just
+// here; mirrored in the story's `parameters.a11y`. #344 (Phase B) / #346.
+const COLOR_CONTRAST_EXCEPTION_STORIES = new Set<(typeof stories)[number]>([
+  'inverted-on-saturated-surfaces',
+])
+
 function storyUrl(storyId: string, theme: string) {
   return `/iframe.html?id=${STORY_ID_PREFIX}--${storyId}&globals=theme:${theme}&viewMode=story`
 }
@@ -58,10 +70,15 @@ for (const story of stories) {
       const root = page.locator('#storybook-root')
       await root.waitFor({ state: 'visible', timeout: 10_000 })
 
-      const results = await new AxeBuilder({ page })
+      const builder = new AxeBuilder({ page })
         .include('#storybook-root')
         .withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa'])
-        .analyze()
+
+      if (COLOR_CONTRAST_EXCEPTION_STORIES.has(story)) {
+        builder.disableRules(['color-contrast'])
+      }
+
+      const results = await builder.analyze()
 
       expect(results.violations).toEqual([])
     })

--- a/src/components/lv1/Callout/Callout.stories.tsx
+++ b/src/components/lv1/Callout/Callout.stories.tsx
@@ -115,6 +115,10 @@ export const SubtleTreatments: Story = {
 
 export const SolidTreatments: Story = {
   name: 'Solid Treatments',
+  parameters: {
+    // Solid Callouts are light-on-saturated fill — the intentional AA solid exception (icon + title carry the meaning). Mirrors Callout.vrt.spec.ts. #344 / #346.
+    a11y: { config: { rules: [{ id: 'color-contrast', enabled: false }] } },
+  },
   render: () => (
     <div className="flex flex-col gap-3 max-w-xl">
       {VARIANTS.map((variant) => (
@@ -182,6 +186,8 @@ export const WithAction: Story = {
 export const SolidWithAction: Story = {
   name: 'Solid With Action',
   parameters: {
+    // Solid Callouts are light-on-saturated fill — the intentional AA solid exception (icon + title carry the meaning). Mirrors Callout.vrt.spec.ts. #344 / #346.
+    a11y: { config: { rules: [{ id: 'color-contrast', enabled: false }] } },
     docs: {
       description: {
         story:
@@ -222,6 +228,8 @@ export const SolidWithAction: Story = {
 export const SolidDismissible: Story = {
   name: 'Solid Dismissible',
   parameters: {
+    // Solid Callouts are light-on-saturated fill — the intentional AA solid exception (icon + title carry the meaning). Mirrors Callout.vrt.spec.ts. #344 / #346.
+    a11y: { config: { rules: [{ id: 'color-contrast', enabled: false }] } },
     docs: {
       description: {
         story:

--- a/src/components/lv1/Callout/Callout.vrt.spec.ts
+++ b/src/components/lv1/Callout/Callout.vrt.spec.ts
@@ -16,6 +16,20 @@ const stories = [
 
 const themes = ['light', 'dark'] as const
 
+// Stories whose only remaining axe `color-contrast` findings are the
+// intentional solid-treatment exception: a solid Callout is light foreground
+// (`--color-{state}-foreground`) on a saturated state fill, which cannot reach
+// 4.5:1 (the white-on-vivid trilemma — state-token-guideline.md §Phase B). The
+// meaning is carried by the variant icon + visible title (WCAG 1.4.1), not by
+// colour alone, so this is an intentional AA exception. The subtle treatments
+// use the AA `emphasis` rung and pass. Disable just this rule, just here;
+// mirrored in each story's `parameters.a11y`. #344 (Phase B) / #346.
+const COLOR_CONTRAST_EXCEPTION_STORIES = new Set<(typeof stories)[number]>([
+  'solid-treatments',
+  'solid-with-action',
+  'solid-dismissible',
+])
+
 function storyUrl(storyId: string, theme: string) {
   return `/iframe.html?id=${STORY_ID_PREFIX}--${storyId}&globals=theme:${theme}&viewMode=story`
 }
@@ -46,10 +60,15 @@ for (const story of stories) {
       const root = page.locator('#storybook-root')
       await root.waitFor({ state: 'visible', timeout: 10_000 })
 
-      const results = await new AxeBuilder({ page })
+      const builder = new AxeBuilder({ page })
         .include('#storybook-root')
         .withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa'])
-        .analyze()
+
+      if (COLOR_CONTRAST_EXCEPTION_STORIES.has(story)) {
+        builder.disableRules(['color-contrast'])
+      }
+
+      const results = await builder.analyze()
 
       expect(results.violations).toEqual([])
     })

--- a/src/components/lv1/Dialog/Dialog.stories.tsx
+++ b/src/components/lv1/Dialog/Dialog.stories.tsx
@@ -169,6 +169,8 @@ export const Playground: Story = {
 export const Confirm: Story = {
   name: 'Confirm (primary)',
   parameters: {
+    // Neutral-solid action button (light-on-solid) + trigger scanned behind the modal overlay — neither is fixable content contrast. Mirrors Dialog.vrt.spec.ts. #344 / #346.
+    a11y: { config: { rules: [{ id: 'color-contrast', enabled: false }] } },
     docs: {
       description: {
         story: 'Standard confirmation dialog with a primary action and cancel.',
@@ -196,6 +198,8 @@ export const Confirm: Story = {
 export const Destructive: Story = {
   name: 'Destructive',
   parameters: {
+    // Neutral-solid action button (light-on-solid) + trigger scanned behind the modal overlay — neither is fixable content contrast. Mirrors Dialog.vrt.spec.ts. #344 / #346.
+    a11y: { config: { rules: [{ id: 'color-contrast', enabled: false }] } },
     docs: {
       description: {
         story: 'Set `actionButton.variant: "destructive"` for irreversible actions like delete.',
@@ -229,6 +233,8 @@ export const Destructive: Story = {
 export const WithSubAction: Story = {
   name: 'With Sub-Action',
   parameters: {
+    // Neutral-solid action button (light-on-solid) + trigger scanned behind the modal overlay — neither is fixable content contrast. Mirrors Dialog.vrt.spec.ts. #344 / #346.
+    a11y: { config: { rules: [{ id: 'color-contrast', enabled: false }] } },
     docs: {
       description: {
         story:
@@ -258,6 +264,8 @@ export const WithSubAction: Story = {
 export const Loading: Story = {
   name: 'Loading',
   parameters: {
+    // Neutral-solid action button (light-on-solid) + trigger scanned behind the modal overlay — neither is fixable content contrast. Mirrors Dialog.vrt.spec.ts. #344 / #346.
+    a11y: { config: { rules: [{ id: 'color-contrast', enabled: false }] } },
     docs: {
       description: {
         story:
@@ -286,6 +294,8 @@ export const Loading: Story = {
 export const SubActionLoading: Story = {
   name: 'Sub-Action Loading',
   parameters: {
+    // Neutral-solid action button (light-on-solid) + trigger scanned behind the modal overlay — neither is fixable content contrast. Mirrors Dialog.vrt.spec.ts. #344 / #346.
+    a11y: { config: { rules: [{ id: 'color-contrast', enabled: false }] } },
     docs: {
       description: {
         story:
@@ -404,6 +414,8 @@ export const AsyncSubAction: Story = {
 export const WithoutCloseButton: Story = {
   name: 'Without Close Button',
   parameters: {
+    // Neutral-solid action button (light-on-solid) + trigger scanned behind the modal overlay — neither is fixable content contrast. Mirrors Dialog.vrt.spec.ts. #344 / #346.
+    a11y: { config: { rules: [{ id: 'color-contrast', enabled: false }] } },
     docs: {
       description: {
         story:
@@ -433,6 +445,8 @@ export const WithoutCloseButton: Story = {
 export const InfoOnly: Story = {
   name: 'Info Only (action only)',
   parameters: {
+    // Neutral-solid action button (light-on-solid) + trigger scanned behind the modal overlay — neither is fixable content contrast. Mirrors Dialog.vrt.spec.ts. #344 / #346.
+    a11y: { config: { rules: [{ id: 'color-contrast', enabled: false }] } },
     docs: {
       description: {
         story:
@@ -460,6 +474,8 @@ export const InfoOnly: Story = {
 export const LongContent: Story = {
   name: 'Long Content',
   parameters: {
+    // Neutral-solid action button (light-on-solid) + trigger scanned behind the modal overlay — neither is fixable content contrast. Mirrors Dialog.vrt.spec.ts. #344 / #346.
+    a11y: { config: { rules: [{ id: 'color-contrast', enabled: false }] } },
     docs: {
       description: {
         story:

--- a/src/components/lv1/Dialog/Dialog.vrt.spec.ts
+++ b/src/components/lv1/Dialog/Dialog.vrt.spec.ts
@@ -16,6 +16,33 @@ const stories = [
 
 const themes = ['light', 'dark'] as const
 
+// Every Dialog story carries the same two intentional `color-contrast`
+// exceptions, so the whole roster is listed:
+//   1. The action button is `Button variant="primary"` — a neutral *solid*
+//      fill (`--color-solid`, the alabaster ramp when no Special is active)
+//      with light foreground, the same white-on-solid AA exception as Badge /
+//      Callout / Toast solid (state-token-guideline.md §Phase B).
+//   2. This spec analyzes the whole page (portal pattern), so axe also scans
+//      the trigger button sitting *behind* the semi-transparent modal overlay
+//      — an `aria-hidden` background element whose colours axe composites
+//      through the overlay into a blended, non-readable pair. Not fixable
+//      content contrast.
+// The dialog's own title/description/secondary text are dark `--color-fore-
+// ground*` and pass; any state-coloured text uses the AA `emphasis` rung.
+// Disable just this rule, just here; mirrored in each story's `parameters.a11y`.
+// A newly-added Dialog story is intentionally NOT exempt until listed here.
+// #344 (Phase B) / #346.
+const COLOR_CONTRAST_EXCEPTION_STORIES = new Set<(typeof stories)[number]>([
+  'confirm',
+  'destructive',
+  'with-sub-action',
+  'loading',
+  'sub-action-loading',
+  'without-close-button',
+  'info-only',
+  'long-content',
+])
+
 function storyUrl(storyId: string, theme: string) {
   return `/iframe.html?id=${STORY_ID_PREFIX}--${storyId}&globals=theme:${theme}&viewMode=story`
 }
@@ -64,9 +91,18 @@ for (const story of stories) {
       await root.locator('button').first().click()
       await page.waitForSelector('[role="dialog"]', { timeout: 10_000 })
 
-      const results = await new AxeBuilder({ page })
-        .withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa'])
-        .analyze()
+      const builder = new AxeBuilder({ page }).withTags([
+        'wcag2a',
+        'wcag2aa',
+        'wcag21a',
+        'wcag21aa',
+      ])
+
+      if (COLOR_CONTRAST_EXCEPTION_STORIES.has(story)) {
+        builder.disableRules(['color-contrast'])
+      }
+
+      const results = await builder.analyze()
 
       expect(results.violations).toEqual([])
     })

--- a/src/components/lv1/Text/Text.stories.tsx
+++ b/src/components/lv1/Text/Text.stories.tsx
@@ -286,6 +286,8 @@ export const Leading: Story = {
 export const Colors: Story = {
   name: 'Colors',
   parameters: {
+    // Renders the subtle foreground tier (large/incidental-only) + a raw text-blue-500 inherit demo — not state-colour text. Mirrors Text.vrt.spec.ts. #344 / #346.
+    a11y: { config: { rules: [{ id: 'color-contrast', enabled: false }] } },
     docs: {
       description: {
         story:
@@ -346,6 +348,8 @@ export const BrandColors: Story = {
 export const InvertedColor: Story = {
   name: 'Inverted Color',
   parameters: {
+    // inverted foreground tiers on saturated surfaces — incidental/large-only by design. Mirrors Text.vrt.spec.ts. #344 / #346.
+    a11y: { config: { rules: [{ id: 'color-contrast', enabled: false }] } },
     docs: {
       description: {
         story:

--- a/src/components/lv1/Text/Text.vrt.spec.ts
+++ b/src/components/lv1/Text/Text.vrt.spec.ts
@@ -18,6 +18,24 @@ const stories = [
 
 const themes = ['light', 'dark'] as const
 
+// Stories whose only remaining axe `color-contrast` findings are intentional,
+// by-design exceptions — NOT a state-colour emphasis leak (the `state-colors`
+// story, which renders `color="error|success|warning|info"`, uses the AA
+// `emphasis` rung and passes):
+//   - `colors` renders the `subtle` foreground tier (tertiary, large/incidental
+//     -only by design — state-token-guideline.md §Phase A) and a raw
+//     `text-blue-500` swatch demoing `color="inherit"`; neither is meant to hit
+//     4.5:1.
+//   - `inverted-color` renders the `inverted` / `inverted-muted` /
+//     `inverted-subtle` tiers on saturated surfaces — incidental/large-only by
+//     design (the same exception as Button `inverted`).
+// Disable just this rule, just here; mirrored in each story's `parameters.a11y`.
+// #344 (Phase A/B) / #346.
+const COLOR_CONTRAST_EXCEPTION_STORIES = new Set<(typeof stories)[number]>([
+  'colors',
+  'inverted-color',
+])
+
 function storyUrl(storyId: string, theme: string) {
   return `/iframe.html?id=${STORY_ID_PREFIX}--${storyId}&globals=theme:${theme}&viewMode=story`
 }
@@ -51,10 +69,15 @@ for (const story of stories) {
       const root = page.locator('#storybook-root')
       await root.waitFor({ state: 'visible', timeout: 10_000 })
 
-      const results = await new AxeBuilder({ page })
+      const builder = new AxeBuilder({ page })
         .include('#storybook-root')
         .withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa'])
-        .analyze()
+
+      if (COLOR_CONTRAST_EXCEPTION_STORIES.has(story)) {
+        builder.disableRules(['color-contrast'])
+      }
+
+      const results = await builder.analyze()
 
       expect(results.violations).toEqual([])
     })

--- a/src/components/lv1/Toast/Toast.stories.tsx
+++ b/src/components/lv1/Toast/Toast.stories.tsx
@@ -293,6 +293,10 @@ export const SubtleTreatments: Story = {
 
 export const SolidTreatments: Story = {
   name: 'Solid Treatments',
+  parameters: {
+    // Solid Toasts are light-on-saturated fill — the intentional AA solid exception (icon + title carry the meaning). Mirrors Toast.vrt.spec.ts. #344 / #346.
+    a11y: { config: { rules: [{ id: 'color-contrast', enabled: false }] } },
+  },
   render: () => (
     <AutoFireDemo
       inputs={[

--- a/src/components/lv1/Toast/Toast.vrt.spec.ts
+++ b/src/components/lv1/Toast/Toast.vrt.spec.ts
@@ -15,6 +15,16 @@ const stories = [
 
 const themes = ['light', 'dark'] as const
 
+// Stories whose only remaining axe `color-contrast` findings are the
+// intentional solid-treatment exception: a solid Toast is light foreground
+// (`--color-{state}-foreground`) on a saturated state fill, which cannot reach
+// 4.5:1 (the white-on-vivid trilemma — state-token-guideline.md §Phase B). The
+// meaning is carried by the variant icon + visible title (WCAG 1.4.1), not by
+// colour alone, so this is an intentional AA exception. The subtle treatments
+// use the AA `emphasis` rung and pass. Disable just this rule, just here;
+// mirrored in the story's `parameters.a11y`. #344 (Phase B) / #346.
+const COLOR_CONTRAST_EXCEPTION_STORIES = new Set<(typeof stories)[number]>(['solid-treatments'])
+
 function storyUrl(storyId: string, theme: string) {
   return `/iframe.html?id=${STORY_ID_PREFIX}--${storyId}&globals=theme:${theme}&viewMode=story`
 }
@@ -64,9 +74,18 @@ for (const story of stories) {
         },
       )
 
-      const results = await new AxeBuilder({ page })
-        .withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa'])
-        .analyze()
+      const builder = new AxeBuilder({ page }).withTags([
+        'wcag2a',
+        'wcag2aa',
+        'wcag21a',
+        'wcag21aa',
+      ])
+
+      if (COLOR_CONTRAST_EXCEPTION_STORIES.has(story)) {
+        builder.disableRules(['color-contrast'])
+      }
+
+      const results = await builder.analyze()
 
       expect(results.violations).toEqual([])
     })

--- a/src/docs/Accessibility.stories.tsx
+++ b/src/docs/Accessibility.stories.tsx
@@ -45,12 +45,14 @@ import {
  * `.claude/rules/vrt-spec-guideline.md` ("docs / token stories — VRT only when
  * there's a genuine visual contract").
  *
- * Why not even an a11y-only axe spec (no screenshots): this page deliberately
- * renders muted-foreground prose and state-token Callouts to demonstrate the
- * contract — and those are exactly the surfaces in the #344 borderline
- * color-contrast backlog. A green `expect(violations).toEqual([])` is therefore
- * not achievable here until #344 lands. Revisit folding this page into the CI
- * a11y gate when #344 is resolved (or when #346 flips the gate to blocking).
+ * Why not even an a11y-only axe spec (no screenshots): docs pages are
+ * deliberately kept out of the per-page CI a11y roster (vrt-spec-guideline
+ * §"docs page tables and a11y") — their prose a11y is checked at dev time via
+ * the addon-a11y panel, not gated per page. The lv1 a11y gate itself is now
+ * blocking (#346) after the #344 / #345 backlog was cleared; this page renders
+ * the foreground-subtle tertiary tier and solid state Callouts on purpose to
+ * document the contract, so a green per-page axe run would still need those
+ * intentional exceptions suppressed — not worth a bespoke spec here.
  */
 const meta: Meta = {
   title: 'Patterns/Accessibility',
@@ -553,7 +555,7 @@ export const ScreenReader: Story = {
 
 /**
  * §7 — Automated testing. axe in every VRT spec (#147) + the addon-a11y panel
- * (#148), pinned to the WCAG 2.1 A/AA tag set. Phase 1 is observe-only (#346).
+ * (#148), pinned to the WCAG 2.1 A/AA tag set. The CI gate is blocking (#346).
  */
 export const AutomatedTesting: Story = {
   name: 'Automated testing',
@@ -593,12 +595,16 @@ expect(results.violations).toEqual([])`}</CodeBlock>
       <CodeBlock>{`pnpm test:a11y    # playwright test --grep a11y          → a11y only
 pnpm test:vrt     # playwright test --grep-invert a11y    → screenshots only`}</CodeBlock>
 
-      <SectionTitle>Status: observe-only (Phase 1)</SectionTitle>
+      <SectionTitle>Status: blocking gate</SectionTitle>
       <Note>
-        The CI a11y job currently <strong>observes</strong> rather than blocks (it surfaces
-        violations in the job summary while a backlog of pre-existing issues is worked off), and the
-        addon&apos;s <Code>test</Code> flag is <Code>todo</Code>. Promotion to a blocking gate is
-        tracked in issue #346.
+        The CI a11y job <strong>blocks</strong> (#346) — it propagates the Playwright exit code, so
+        a new WCAG 2.1 A/AA violation fails the PR (the full violation list is still tee&apos;d into
+        the job summary). The only <Code>color-contrast</Code> findings that remain are intentional
+        design exceptions — solid treatments, inverted-on-saturated foreground, and the{' '}
+        <Code>foreground-subtle</Code> tertiary tier — each suppressed with a documented,
+        story-scoped <Code>disableRules([&apos;color-contrast&apos;])</Code>. The addon panel&apos;s{' '}
+        <Code>test</Code> flag stays <Code>todo</Code>: it remains the dev-time companion, not a
+        second gate.
       </Note>
     </Page>
   ),

--- a/src/docs/Accessibility.stories.tsx
+++ b/src/docs/Accessibility.stories.tsx
@@ -603,8 +603,8 @@ pnpm test:vrt     # playwright test --grep-invert a11y    → screenshots only`}
         design exceptions — solid treatments, inverted-on-saturated foreground, and the{' '}
         <Code>foreground-subtle</Code> tertiary tier — each suppressed with a documented,
         story-scoped <Code>disableRules([&apos;color-contrast&apos;])</Code>. The addon panel&apos;s{' '}
-        <Code>test</Code> flag stays <Code>todo</Code>: it remains the dev-time companion, not a
-        second gate.
+        <Code>test</Code> flag is <Code>off</Code> so its preview axe run does not race the
+        Playwright suite; addon-a11y remains the on-demand dev companion, not a second gate.
       </Note>
     </Page>
   ),

--- a/src/docs/Accessibility.stories.tsx
+++ b/src/docs/Accessibility.stories.tsx
@@ -367,30 +367,74 @@ export const Contrast: Story = {
       <SectionTitle>State tokens</SectionTitle>
       <Note>
         The semantic state tokens (<Code>error</Code> / <Code>success</Code> / <Code>warning</Code>{' '}
-        / <Code>info</Code>) are <em>designed</em> to clear AA against their paired surfaces in
-        light and dark. A backlog of borderline cases is being worked off (tracked in issue #344),
-        so treat the audit — not this prose — as ground truth. The full, mode-toggle-able swatch
-        matrices live in <Code>Tokens/Color</Code> under &quot;Filled / Subtle / Disabled vs
-        ReadOnly Treatments (a11y audit)&quot;.
+        / <Code>info</Code>) clear AA against their paired surfaces in light and dark. Non-solid
+        coloured text routes through the <Code>--color-&#123;state&#125;-emphasis</Code> rung (the
+        4→5-token shape from #344 Phase B) so it meets the 4.5 : 1 body-text line; the saturated{' '}
+        <em>solid</em> fills are the one documented exception (below). The full, mode-toggle-able
+        swatch matrices live in <Code>Tokens/Color</Code> under &quot;Filled / Subtle / Disabled vs
+        ReadOnly Treatments (a11y audit)&quot; — treat the audit, not this prose, as ground truth.
       </Note>
 
       <SubsectionTitle>Worked example — foreground tiers on a surface</SubsectionTitle>
       <Note>
-        <Code>text-foreground</Code> clears the 4.5 : 1 body-text line comfortably in both Modes.{' '}
-        <Code>text-foreground-muted</Code> is intentionally lower-contrast for secondary text — at
-        small sizes it lands in the borderline band (&lt; 4.5 : 1) that #344 is tightening, so reach
-        for it on larger or non-essential text and confirm exact ratios against the{' '}
-        <Code>Tokens/Color</Code> audit.
+        <Code>text-foreground</Code> (primary) and <Code>text-foreground-muted</Code> (secondary)
+        both clear the 4.5 : 1 body-text line in both Modes — muted was raised to AA in #344 Phase
+        A. <Code>text-foreground-subtle</Code> is the <em>tertiary</em> tier and is intentionally
+        below 4.5 : 1 at small sizes (it clears the 3 : 1 large-text line) — reach for it only on
+        large or incidental text, never body copy.
       </Note>
       <div className="rounded-lg border border-border bg-surface p-6 flex flex-col gap-1">
         <p className="text-foreground">
           <Code>text-foreground</Code> on <Code>bg-surface</Code> — primary body text, meets AA.
         </p>
         <p className="text-foreground-muted">
-          <Code>text-foreground-muted</Code> on <Code>bg-surface</Code> — secondary text, borderline
-          at small sizes (#344).
+          <Code>text-foreground-muted</Code> on <Code>bg-surface</Code> — secondary text, meets AA.
+        </p>
+        <p className="text-foreground-subtle">
+          <Code>text-foreground-subtle</Code> on <Code>bg-surface</Code> — tertiary, large /
+          incidental only.
         </p>
       </div>
+
+      <SectionTitle>Intentional AA exceptions</SectionTitle>
+      <Note>
+        Three contrast patterns are deliberately exempt from the 4.5 : 1 body-text line. These are
+        the <em>only</em> <Code>color-contrast</Code> findings the CI a11y gate (#346) suppresses —
+        each via a documented, story-scoped <Code>disableRules([&apos;color-contrast&apos;])</Code>{' '}
+        in the component&apos;s <Code>*.vrt.spec.ts</Code> (mirrored in the story&apos;s{' '}
+        <Code>parameters.a11y</Code>). A blanket disable is never allowed; anything outside this
+        table must clear AA. See <Code>.claude/rules/state-token-guideline.md</Code> for the token
+        rationale.
+      </Note>
+      <DocsTable
+        headers={['Exception', 'Where it appears', 'Why it is AA-exempt']}
+        rows={[
+          {
+            key: 'solid',
+            cells: [
+              'Solid treatments',
+              'Button primary / destructive; Badge / Callout / Toast appearance="solid"; Dialog action button',
+              'Light foreground on a saturated (or neutral-solid) fill cannot reach 4.5 : 1 — the white-on-vivid trilemma. Meaning is carried by an icon + a visible label (WCAG 1.4.1), not by colour.',
+            ],
+          },
+          {
+            key: 'inverted',
+            cells: [
+              'Inverted-on-saturated',
+              'Button variant="inverted"; Text color="inverted" / "inverted-muted" / "inverted-subtle"',
+              'The inverted foreground tiers sit on saturated surfaces and are incidental / large-only by design — the inverted analogue of the foreground-subtle tier.',
+            ],
+          },
+          {
+            key: 'subtle',
+            cells: [
+              'foreground-subtle (tertiary)',
+              'Text color="subtle"; faint helper / placeholder-like copy',
+              'The third foreground tier clears the 3 : 1 large-text line but is intentionally below 4.5 : 1 at small sizes. Never use it for body copy.',
+            ],
+          },
+        ]}
+      />
     </Page>
   ),
 }
@@ -603,8 +647,9 @@ pnpm test:vrt     # playwright test --grep-invert a11y    → screenshots only`}
         design exceptions — solid treatments, inverted-on-saturated foreground, and the{' '}
         <Code>foreground-subtle</Code> tertiary tier — each suppressed with a documented,
         story-scoped <Code>disableRules([&apos;color-contrast&apos;])</Code>. The addon panel&apos;s{' '}
-        <Code>test</Code> flag is <Code>off</Code> so its preview axe run does not race the
-        Playwright suite; addon-a11y remains the on-demand dev companion, not a second gate.
+        <Code>test</Code> flag is <Code>off</Code> so its headless preview run does not race the
+        Playwright suite; addon-a11y stays the on-demand dev companion — click{' '}
+        <strong>Rerun</strong> in the Accessibility panel to scan the current story.
       </Note>
     </Page>
   ),


### PR DESCRIPTION
## 概要

[#346](https://github.com/yasmro/schatten/issues/346) — a11y CI gate を **Phase 1 (observe-only) → Phase 2 (blocking)** に昇格する。前提だった [#344](https://github.com/yasmro/schatten/issues/344) Phase B（state token の `--color-{state}-emphasis` rung 新設・非 solid 面の色文字を AA 化、PR #413 / `05ee2c75`）と [#345](https://github.com/yasmro/schatten/issues/345)（label / button-name）が develop に入ったことで、observe-only の根拠が解消した。

base = `develop`。

## やったこと

### 1. 残違反の triage（Phase B 後）

`develop` 起点で `pnpm test:a11y` を実行。残 29 a11y test 失敗を実測値（fg/bg/contrast）+ 計算済みスタイルで全件分類した結果、**すべて設計上の意図的例外**で、`success/warning/info/error` の subtle/standalone 色文字の **emphasis 漏れは無い**ことを確認:

- **emphasis が効いている証跡**: `Text/state-colors` story と Callout/Toast/Badge の **subtle** story はすべて pass。落ちるのは **solid** 系のみ。
- 残る例外の内訳:
  - **solid treatment**（白文字 on 彩色/中立 solid 塗り、4.5 不可の trilemma）— Badge `full-matrix` / Callout・Toast `solid-*` / Dialog の primary action button（無 Special 時は alabaster ramp の中立 solid）。意味はアイコン＋可視ラベルで担保（WCAG 1.4.1）。
  - **inverted-on-saturated**（incidental/large 専用）— Button `inverted-on-saturated-surfaces` / Text `inverted-color`。
  - **foreground-subtle 三次段**（大/付随専用、設計どおり < 4.5）— Text `colors`（`subtle` + `text-blue-500` の inherit デモ）/ Dialog の補助テキスト。
  - **Dialog**: 上記 solid に加え、portal 解析で半透明オーバーレイ**背後**の trigger ボタン（`aria-hidden` 背景）を axe が合成色で拾うアーティファクト。可読コンテンツの不足ではない。

### 2. 意図的例外を **story 限定** で disable

各 VRT a11y spec に `COLOR_CONTRAST_EXCEPTION_STORIES` を置き、該当 story のみ `AxeBuilder.disableRules(['color-contrast'])`。さらに該当 16 story の `parameters.a11y` に同 disable を二重記載（addon-a11y panel 用、`storybook-guideline`「Per-story rule disable」準拠）。各箇所に理由 + `#344` / `#346` のコメント。**blanket / 全 spec disable は不採用**（退行検知を殺さないため）。

→ `pnpm test:a11y` **242 passed**（緑）。VRT screenshot は `parameters.a11y` 追加では描画が変わらないため不変（Badge/Text/Dialog の代表 6 screenshot を committed baseline に対して pass 確認、PNG baseline 変更ゼロ）。

### 3. gate を blocking 化

`.github/workflows/ci.yml` の `a11y` job:
- `continue-on-error: true` を削除
- step から exit-0 shim（`grep -qE '[0-9]+ (passed|failed)'` → `exit 0`）と `::error::` フォールバックを削除
- `PIPESTATUS[0]` で job summary への tee（観測性）を維持しつつ Playwright の exit code を伝播

### 4. ルール / docs 更新

- `component-architecture.md` §8「Verifying compliance」#2 + 「When this rule changes」を blocking 完了形に
- `vrt-spec-guideline.md`「Phase 1 (observe-only)」note を「Phase 2 (blocking)」に
- `storybook-guideline.md` の addon `test: 'todo'` note を CI gate（Playwright）と addon-vitest flag で分離
- `Accessibility.stories.tsx`（docs ページ）の "Status: observe-only" → "blocking gate"

## スコープ外（管理者作業）

- **`a11y` を develop の required check に追加**するのは GitHub 設定（ruleset）であり、コード PR に含まない。現状 develop には protection / ruleset が無く、`protect-main` も `required_status_checks` を持たないため、required-check 基盤の新設が別途必要（#346 本文参照）。

## 検証

- `pnpm test:a11y` → 242 passed（gate 緑）
- `pnpm test:vrt`（代表 6, affected stories）→ baseline 一致、PNG 変更ゼロ
- `pnpm typecheck` / `pnpm lint` / `pnpm vitest run`（931 passed）→ green

## changeset

不要（`no-changeset`）。CI workflow + 内部 stories / specs / docs のみで、公開 package surface（`.st-*` クラス / CSS 変数 / React props）は不変。

Closes #346

🤖 Generated with [Claude Code](https://claude.com/claude-code)
