### PR TITLE
ci(audit): audit job を blocking に昇格 (#307 Phase 2)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,11 +173,14 @@ jobs:
 
   audit:
     runs-on: ubuntu-latest
-    # Phase 1: observe-only. continue-on-error keeps the check from blocking
-    # merges while we watch the real-world failure rate over ~1 week of PRs
-    # (see #307 staged rollout). Phase 2 removes this line and adds `audit`
-    # to develop's required checks.
-    continue-on-error: true
+    # Phase 2 (blocking). The Phase-1 observe window (#307) is over: every lv1
+    # currently passes `pnpm audit:coverage --check`, so the gate now blocks —
+    # a missing required companion (test / VRT spec / class-API CSS /
+    # __snapshots__ baseline / index.ts re-export, plus the parity series for
+    # classification A/B) fails the PR. The step already exits 1 on a gap via
+    # `set -o pipefail`; dropping `continue-on-error` lets that surface as a red
+    # check. Adding `audit` to develop's required checks is a repo-settings
+    # change (ruleset), tracked alongside #346, not in this workflow.
     steps:
       - uses: actions/checkout@v6
 


### PR DESCRIPTION
## 概要

companion-coverage gate（`audit` job、[#307](https://github.com/yasmro/schatten/issues/307)）を **Phase 1 observe-only → Phase 2 blocking** に昇格する。`/code-review 414` のセルフレビューで挙がった改善項目（audit job が #307 close 後も Phase 1 のまま `continue-on-error: true` だった）への対応。

base = `develop`。

## やったこと

`.github/workflows/ci.yml` の `audit` job から `continue-on-error: true` を除去し、ジョブコメントを Phase 2 に更新。step 本体（`pnpm audit:coverage --check | tee` + `set -o pipefail`）は不変 — 既に gap 時 exit 1 する設計なので、`continue-on-error` を外すだけで赤シグナルが PR checks に伝播する。

## 安全性

着手前に現状 develop の tree で `pnpm audit:coverage --check` を実行し **exit 0（全 lv1 が required companion を保有）** を確認済み。よって blocking 化しても既存 PR を即座に赤くしない。以降は companion（test / VRT spec / class-API CSS / `__snapshots__` baseline / `index.ts` re-export ＋ 区分 A/B の parity 系）の欠落で PR が落ちる。

## スコープ外

`audit` を develop の **required check** に追加するのは GitHub 設定（ruleset）であり本 PR 外。#346 の required-check 整備（`a11y` 等）と同時に実施する。

## changeset

不要（`no-changeset`）。CI workflow のみで公開 package surface は不変。

Refs #307

🤖 Generated with [Claude Code](https://claude.com/claude-code)
