### PR TITLE
test(docs): CSS API Reference が全 lv1 を網羅していることを保証する test を追加

### DIFF
--- a/scripts/lv1-slugs.d.mts
+++ b/scripts/lv1-slugs.d.mts
@@ -1,0 +1,27 @@
+// TypeScript declarations for scripts/lv1-slugs.mjs. The .mjs carries
+// JSDoc-typed annotations, but typed consumers (e.g.
+// src/docs/CSSApi.coverage.test.ts) import the functions from a .ts module —
+// an explicit .d.mts gives TypeScript a strongly-typed view of the exported
+// symbols without converting the script to .ts. Mirrors the
+// generate-manifest.d.mts / csp-hash.d.mts pattern.
+
+export interface Lv1Entry {
+  /** Component name (e.g. "Button", "FieldSet"). */
+  readonly name: string
+  /** Lowercased name (e.g. "button", "fieldset") — matches the `.st-<block>` slug. */
+  readonly slug: string
+  /** Component directory relative to repo root. */
+  readonly dir: string
+  /** `<Name>.tsx` path. */
+  readonly tsx: string
+  /** `<Name>.css` path (may not exist — see `hasCss`). */
+  readonly css: string
+  /** Whether the `.css` file exists on disk. */
+  readonly hasCss: boolean
+}
+
+/** Discover every lv1 component directory (dir with `<Name>.tsx`) on disk. */
+export function discoverLv1(): Lv1Entry[]
+
+/** Like {@link discoverLv1} but throws when any component lacks its `.css`. */
+export function discoverLv1WithCss(): Lv1Entry[]

--- a/src/docs/CSSApi.coverage.test.ts
+++ b/src/docs/CSSApi.coverage.test.ts
@@ -1,0 +1,108 @@
+import { readFileSync } from 'node:fs'
+import * as ts from 'typescript'
+import { describe, expect, it } from 'vitest'
+import { discoverLv1WithCss } from '../../scripts/lv1-slugs.mjs'
+
+/**
+ * Mechanical guard for the CSS API `Reference` story's "every lv1 component"
+ * claim.
+ *
+ * The Reference is a hand-curated page: each lv1 gets a `<Section id="<slug>">`
+ * plus a side-effect `import` of its `.css`. Both are easy to forget when a new
+ * lv1 lands — which is exactly how the page drifted to 16/23 (title still said
+ * "18") before #433 re-synced it. This test turns "remembered to update the
+ * Reference" into an enforced contract, so the drift cannot silently recur.
+ *
+ * Two failure classes it catches:
+ * - **Missing section** — a new lv1 with no Reference entry (coverage drift).
+ * - **Missing CSS import** — a sectioned component whose `.css` is not imported.
+ *   In the Storybook *build*, per-story code-splitting drops the un-imported
+ *   chunk and the vanilla markup renders un-styled (the #313 regression class);
+ *   it looks fine in dev, so neither VRT nor a manual dev check catches it.
+ *
+ * The story source is read through the TypeScript AST (not regex), so the
+ * extraction is independent of prop order on `<Section>` and of incidental
+ * formatting. lv1 discovery comes from `scripts/lv1-slugs.mjs` — the SSOT also
+ * used by the build (`build-component-css` / `ensure-dist`).
+ */
+
+const STORY_PATH = 'src/docs/CSSApi.stories.tsx'
+const AST = ts.createSourceFile(
+  STORY_PATH,
+  readFileSync(STORY_PATH, 'utf8'),
+  ts.ScriptTarget.Latest,
+  /* setParentNodes */ true,
+  ts.ScriptKind.TSX,
+)
+
+/** Collect a value for every AST node the picker matches. */
+function collect<T>(pick: (node: ts.Node) => T | undefined): T[] {
+  const out: T[] = []
+  const visit = (node: ts.Node): void => {
+    const value = pick(node)
+    if (value !== undefined) out.push(value)
+    ts.forEachChild(node, visit)
+  }
+  visit(AST)
+  return out
+}
+
+/** lv1 slugs (SSOT: scripts/lv1-slugs.mjs). */
+function lv1Slugs(): string[] {
+  return discoverLv1WithCss()
+    .map((entry) => entry.slug)
+    .sort()
+}
+
+/** ids of every `<Section id="…">` element, regardless of prop order. */
+function sectionIds(): string[] {
+  return collect((node) => {
+    if (!ts.isJsxOpeningElement(node) && !ts.isJsxSelfClosingElement(node)) return undefined
+    if (!ts.isIdentifier(node.tagName) || node.tagName.text !== 'Section') return undefined
+    for (const attr of node.attributes.properties) {
+      if (
+        ts.isJsxAttribute(attr) &&
+        ts.isIdentifier(attr.name) &&
+        attr.name.text === 'id' &&
+        attr.initializer &&
+        ts.isStringLiteral(attr.initializer)
+      ) {
+        return attr.initializer.text
+      }
+    }
+    return undefined
+  }).sort()
+}
+
+/** slugs whose CSS is side-effect-imported (`import '../components/lv1/X/X.css'`). */
+function importedSlugs(): string[] {
+  return collect((node) => {
+    if (!ts.isImportDeclaration(node) || !ts.isStringLiteral(node.moduleSpecifier)) return undefined
+    const match = node.moduleSpecifier.text.match(/^\.\.\/components\/lv1\/\w+\/(\w+)\.css$/)
+    return match ? match[1].toLowerCase() : undefined
+  }).sort()
+}
+
+/** The N in the story name `Reference (all N lv1 components)`, or null. */
+function titleCount(): number | null {
+  for (const text of collect((node) => (ts.isStringLiteralLike(node) ? node.text : undefined))) {
+    const match = text.match(/^Reference \(all (\d+) lv1 components\)$/)
+    if (match) return Number(match[1])
+  }
+  return null
+}
+
+describe('CSS API Reference coverage', () => {
+  it('documents exactly the set of lv1 components (no missing or stale sections)', () => {
+    expect(sectionIds()).toEqual(lv1Slugs())
+  })
+
+  it('imports the CSS of every documented component (guards the #313 un-styled build)', () => {
+    const imported = importedSlugs()
+    expect(sectionIds().filter((id) => !imported.includes(id))).toEqual([])
+  })
+
+  it('states the correct component count in the story name', () => {
+    expect(titleCount()).toBe(lv1Slugs().length)
+  })
+})


### PR DESCRIPTION
## What

CSS API `Reference` story の「every lv1 component」契約を機械的に保証する unit test
（`src/docs/CSSApi.coverage.test.ts`）を追加。3 つを assert:

1. `<Section id="…">` の集合 == lv1 スラッグ集合（網羅 + stale 節なし）
2. 各節の component CSS が import 済み（未 import だと Storybook build の
   code-splitting で un-styled になる #313 回帰）
3. タイトル `Reference (all N lv1 components)` の N == 実 lv1 数

実装:
- 抽出は **TypeScript AST**（`typescript` compiler API）で、`<Section>` の prop 順や
  整形に非依存（regex 結合を排除）。
- lv1 検出は `scripts/lv1-slugs.mjs`（build でも使う SSOT）を使用。typed import の
  ため `scripts/lv1-slugs.d.mts` を追加（`generate-manifest.d.mts` 等の前例に倣う）。

## Why

#433 で Reference を手で 16/23 → 23/23 に揃えたが、次の lv1 追加時に「節 / CSS
import 忘れ」で再ドリフトする（症状を直しただけで根治していなかった）。本 test で
ドリフトと #313 を構造的に再発不能にする。

負の確認: 節 id を1つリネームすると網羅 + import の assertion が落ちることを確認済み。

## Test plan

- [x] `pnpm lint` / `typecheck`（`.d.mts` import + AST 解決）/ `pnpm test --run`（958）緑
- [x] 新 test 3/3 pass（現状 23/23）
- [x] 負の確認: 節 id リネームで該当 assertion が fail
- [x] test-only・公開 API 変更なし → no-changeset

🤖 Generated with [Claude Code](https://claude.com/claude-code)
