### PR TITLE
refactor(tokens): CSS 変数命名 audit — 4 層モデル確定 + Tailwind 名リーク撤去 (closes #231)

### DIFF
--- a/.changeset/css-var-namespace-audit-b3e1.md
+++ b/.changeset/css-var-namespace-audit-b3e1.md
@@ -1,0 +1,14 @@
+---
+'@yasmro/schatten': patch
+---
+
+CSS API: 公開 CSS 変数の命名 audit (#231) を確定。命名規約を 4 層モデル
+(プリミティブ=非公開 / Tailwind 慣習=bare / セマンティック `--color-*`=bare・
+衝突は文書化して回避側は consumer scoping / schatten 固有=`--st-` prefix) として
+api-stability.md に一本化した。
+
+公開面に残っていた唯一の Tailwind 規約名 `--default-font-family` /
+`--default-mono-font-family` を撤去 (consumer 自前 Tailwind v4 preflight と
+`@layer theme` 内で衝突するため)。vendored preflight は `var(--font-sans, …)` /
+`var(--font-mono, …)` を直参照するよう書き換え — 間接層は元々これらを指すだけなので
+**解決値・レンダリング不変**。公開 CSS 変数は 129 → 127。

--- a/.claude/rules/api-stability.md
+++ b/.claude/rules/api-stability.md
@@ -54,6 +54,15 @@ release — including a `patch` — without notice:
   documented class is **not** a breaking change.
 - File paths inside `dist/` other than the ones declared in `package.json`'s
   `exports` map.
+- **Primitive-scale CSS variables** (`--vermillion-*`, `--red-*`, `--blue-*`,
+  `--gray-*`, `--sumi-*`, `--alabaster-*`, `--paper-*`, `--ink-*`, …). They
+  ship in the dist `:root` (unlayered) but are **not** in the registrar /
+  manifest, so they are not public surface — renaming or retuning them is
+  **not** a breaking change and does not require the pre-1.0 settle. Consumers
+  reference the semantic layer (`--color-vermillion`, `--color-error`, the
+  `--color-theme-*` scale) instead. This is decided, not deferred — see
+  [CSS variable naming — the four-layer model](#css-variable-naming--the-four-layer-model)
+  (layer 1) and the #231 decision log.
 
 If a consumer reaches into one of these, that's a usage outside the contract —
 we will not consider their breakage when scoping a release.
@@ -326,26 +335,59 @@ The class-name audit is tracked by
 every public class into the manifest below. Once #154 ships, the manifest
 becomes the diff a reviewer sees on every CSS change.
 
-## CSS variable naming — settle before 1.0
+## CSS variable naming — the four-layer model
 
-A CSS variable rename is `major` after 1.0. So names like `--vermillion-600`
-need to be intentional now, not later. Two checkpoints:
+A CSS variable rename is `major` after 1.0, so the public variable surface
+was audited and settled pre-1.0 by
+[#231](https://github.com/yasmro/schatten/issues/231). The audit's finding is
+that **collision with a consumer's own tokens is harmful only where the two
+sides put a *different meaning* on the same name** — a consumer's `--spacing-4`
+means the same 1rem Schatten's does (harmless, even useful to share), but a
+shadcn consumer's `--color-background` means something different from
+Schatten's (harmful). That principle sorts every public variable into one of
+four layers, each with its own naming rule:
 
-1. **Primitive scale names** (`--vermillion-*`, `--green-*`) — if we ever want
-   to rename to brand-neutral names (`--brand-red-*`), it must happen pre-1.0.
-2. **Semantic token names** (`--color-error`, `--color-destructive`) — these
-   are intentionally meaning-based and should age better, but verify the
-   shape (`base / hover / foreground / subtle` — see
-   [state-token-guideline](state-token-guideline.md)) is final before 1.0.
+| # | Layer | Names | Public? | Rule |
+|---|---|---|---|---|
+| 1 | **Primitive** | `--vermillion-*` `--red-*` `--blue-*` `--gray-*` `--sumi-*` `--alabaster-*` `--paper-*` `--ink-*` | **No** — ships in dist `:root` but not in the registrar/manifest | Internal. Rename/retune freely (see [What is not public API](#what-is-not-public-api)). Consumers use the semantic layer instead. |
+| 2 | **Tailwind-convention** | `--spacing-*` `--text-*` `--leading-*` `--font-*` `--radius-sm..2xl` `--shadow-sm..xl` | Yes, **bare** | Keep the Tailwind-scale names. The value is a shared convention, so a consumer overriding / colliding is **intended** — it lets their Tailwind pick Schatten's scale up. |
+| 3 | **Semantic** | `--color-*` (surfaces / foregrounds / state / inverted / brand / `--color-theme-*`), the schatten-specific aliases `--radius-control` `--radius-surface` `--radius-pill` `--shadow-card/popover/modal/toast` `--z-*` `--motion-*` | Yes, **bare** | The meaning is Schatten's, so these **can** collide with another full design system (shadcn defines `--color-background` too). Not namespaced — the collision is **documented, not renamed away** (see below). Consumers with a conflicting token scope Schatten (below). |
+| 4 | **Schatten-namespaced** | `--st-duration-*` `--st-spinner-*` | Yes, **`--st-` prefix** | For axes with no Tailwind-convention counterpart (raw enter/exit timing, spinner cadence). `--st-` mirrors the `.st-` class prefix ([css-api.md](css-api.md)). New schatten-specific tokens that don't fit layers 2–3 go here. |
 
-The class-name audit is scheduled for v0.9.0 (#58 Phase 2, implemented by
-[#154](https://github.com/yasmro/schatten/issues/154) — pulled forward from
-v0.14.0 so it lands before the lv2 components, see #154 for the rationale).
-The CSS variable audit is tracked by
-[#231](https://github.com/yasmro/schatten/issues/231) (currently milestoned at
-v0.15.0 as a backstop); the only hard requirement is that it lands **before
-v1.0.0**. CONTRIBUTING.md (planned for v0.15.0) will reference this document as
-the source of truth for what consumers can rely on.
+### Why the semantic `--color-*` layer stays bare (not `--st-color-*`)
+
+The audit **considered and rejected** namespacing the whole semantic layer to
+`--st-color-*`. Full namespacing would make collision mechanically impossible,
+but at the cost of (a) ~50 color-variable renames + a migration guide, (b)
+uglier token names for *every* consumer, and (c) breaking the layer-2 win
+where Schatten's `--spacing-*` / `--text-*` share Tailwind's names on purpose.
+The harmful-collision case — Schatten used **alongside another full design
+system** on the same `:root` — is rare, and a consumer in that situation can
+scope Schatten's tokens under a wrapper rather than pay a global rename. So the
+DoD's "collision avoided **or** the un-avoidable collision is documented" is
+satisfied on the *documented* side for layer 3: this table **is** that
+documentation, and the consumer-facing escape hatch (scope Schatten's `:root`
+tokens under a container, or lower them into a `@layer` the consumer's own
+`:root` beats) is the mitigation. See the #231 decision log,
+`docs/decisions/2026-07-css-variable-namespace.md`.
+
+**Semantic token shape.** The state token names (`--color-error`,
+`--color-destructive`, …) are meaning-based and their 5-slot shape
+(`base / hover / foreground / subtle / emphasis` — see
+[state-token-guideline](state-token-guideline.md)) is final for 1.0.
+
+**No Tailwind-convention names on the public surface.** #231 removed the last
+two — `--default-font-family` / `--default-mono-font-family` (Tailwind's own
+preflight variable names, which collided with a consumer's Tailwind v4
+preflight in the shared `@layer theme`). The vendored preflight now references
+`--font-sans` / `--font-mono` directly; the change was value-identical (the
+indirection already resolved to those). See the decision log.
+
+The class-name audit shipped in v0.9.0 (#58 Phase 2, implemented by
+[#154](https://github.com/yasmro/schatten/issues/154)). The CSS-variable audit
+([#231](https://github.com/yasmro/schatten/issues/231)) settled the four-layer
+model above before v1.0.0. CONTRIBUTING.md (planned for v0.15.0) will reference
+this document as the source of truth for what consumers can rely on.
 
 ## Manifest as the authoritative API listing
 

--- a/.claude/rules/api-stability.md
+++ b/.claude/rules/api-stability.md
@@ -350,11 +350,21 @@ four layers, each with its own naming rule:
 | # | Layer | Names | Public? | Rule |
 |---|---|---|---|---|
 | 1 | **Primitive** | `--vermillion-*` `--red-*` `--blue-*` `--gray-*` `--sumi-*` `--alabaster-*` `--paper-*` `--ink-*` | **No** — ships in dist `:root` but not in the registrar/manifest | Internal. Rename/retune freely (see [What is not public API](#what-is-not-public-api)). Consumers use the semantic layer instead. |
-| 2 | **Tailwind-convention** | `--spacing-*` `--text-*` `--leading-*` `--font-*` `--radius-sm..2xl` `--shadow-sm..xl` | Yes, **bare** | Keep the Tailwind-scale names. The value is a shared convention, so a consumer overriding / colliding is **intended** — it lets their Tailwind pick Schatten's scale up. |
+| 2 | **Tailwind-convention** | `--spacing-*` `--text-*` `--leading-*` `--font-*` `--radius-none/sm..2xl/full` `--shadow-sm..xl` | Yes, **bare** | Keep the Tailwind-scale names. The value is a shared convention, so a consumer overriding / colliding is **intended** — it lets their Tailwind pick Schatten's scale up. |
 | 3 | **Semantic** | `--color-*` (surfaces / foregrounds / state / inverted / brand / `--color-theme-*`), the schatten-specific aliases `--radius-control` `--radius-surface` `--radius-pill` `--shadow-card/popover/modal/toast` `--z-*` `--motion-*` | Yes, **bare** | The meaning is Schatten's, so these **can** collide with another full design system (shadcn defines `--color-background` too). Not namespaced — the collision is **documented, not renamed away** (see below). Consumers with a conflicting token scope Schatten (below). |
 | 4 | **Schatten-namespaced** | `--st-duration-*` `--st-spinner-*` | Yes, **`--st-` prefix** | For axes with no Tailwind-convention counterpart (raw enter/exit timing, spinner cadence). `--st-` mirrors the `.st-` class prefix ([css-api.md](css-api.md)). New schatten-specific tokens that don't fit layers 2–3 go here. |
 
-### Why the semantic `--color-*` layer stays bare (not `--st-color-*`)
+The table is **exhaustive over the public surface**: every variable in the
+manifest (`src/__generated__/schatten.manifest.json` `cssVariables`) maps to
+exactly one layer above — layer 2 = the Tailwind-convention scales, layer 3 =
+the `--color-*` semantics plus the schatten-specific `--radius-control` /
+`--radius-surface` / `--radius-pill` / `--shadow-{card,popover,modal,toast}` /
+`--z-*` / `--motion-*` aliases, layer 4 = the two `--st-*` families. Primitives
+(layer 1) are deliberately **absent** from the manifest. When you add a public
+token, it must fit one of these four layers; if it doesn't, that's a signal to
+discuss before shipping, not to invent a fifth naming shape.
+
+### Why the semantic layer stays bare
 
 The audit **considered and rejected** namespacing the whole semantic layer to
 `--st-color-*`. Full namespacing would make collision mechanically impossible,
@@ -366,9 +376,14 @@ system** on the same `:root` — is rare, and a consumer in that situation can
 scope Schatten's tokens under a wrapper rather than pay a global rename. So the
 DoD's "collision avoided **or** the un-avoidable collision is documented" is
 satisfied on the *documented* side for layer 3: this table **is** that
-documentation, and the consumer-facing escape hatch (scope Schatten's `:root`
-tokens under a container, or lower them into a `@layer` the consumer's own
-`:root` beats) is the mitigation. See the #231 decision log,
+documentation, and the mitigation is a **consumer-facing escape-hatch recipe**
+— Schatten's token values ship **unlayered** on `:root`, so a consumer either
+imports Schatten into a cascade layer (`@import "…schatten.css"
+layer(schatten)`, their own `:root` then wins globally) or scopes Schatten onto
+a container for true subtree isolation. The worked recipes (and the honest
+"deeply-interleaved → alias one side" caveat) live in the
+[README](../../README.md#using-schatten-alongside-another-design-system-token-collisions);
+the full rationale is in the #231 decision log,
 `docs/decisions/2026-07-css-variable-namespace.md`.
 
 **Semantic token shape.** The state token names (`--color-error`,

--- a/.claude/rules/css-api.md
+++ b/.claude/rules/css-api.md
@@ -613,6 +613,19 @@ This is the mechanical enforcement of
 [api-stability.md](api-stability.md): a CSS rename can't slip through
 review unnoticed because the manifest is the diff a reviewer sees.
 
+### CSS variable naming lives in api-stability.md
+
+This document owns the `.st-*` **class** naming contract; the public
+**CSS-variable** naming contract (the four-layer model — primitives are
+internal, Tailwind-convention tokens stay bare, semantic `--color-*` stays
+bare but can collide with another design system, and schatten-specific axes
+take the `--st-` prefix that mirrors this document's `st-` class prefix) is
+settled in
+[api-stability.md §CSS variable naming](api-stability.md#css-variable-naming--the-four-layer-model)
+(the #231 audit). Author component CSS against the semantic tokens either way;
+reach for that section when you need to decide whether a **new** token is
+public and how to name it.
+
 ## Adding or modifying a class
 
 1. **Pick the block name.** Match the React component, lowercased

--- a/.claude/rules/theme-architecture.md
+++ b/.claude/rules/theme-architecture.md
@@ -182,8 +182,10 @@ not a `--st-`-prefixed one. Two consequences the theme machinery relies on:
   consumer who *also* defines `--color-theme-*` on `:root` will collide by
   last-wins — exactly the layer-3 case the audit decided to **document rather
   than rename away**. A consumer in that situation scopes Schatten's tokens
-  under a container instead of overriding globally (see
-  [api-stability.md](api-stability.md#why-the-semantic---color--layer-stays-bare-not---st-color-)).
+  under a container (or imports Schatten into a cascade layer) instead of
+  overriding globally — the worked recipes are in the
+  [README](../../README.md#using-schatten-alongside-another-design-system-token-collisions),
+  the rationale in [api-stability.md](api-stability.md#why-the-semantic-layer-stays-bare).
   This does not affect `data-theme` switching, which mutates the attribute on
   `<html>` and re-resolves the same bare `--color-theme-*` names at paint time.
 

--- a/.claude/rules/theme-architecture.md
+++ b/.claude/rules/theme-architecture.md
@@ -163,6 +163,30 @@ If a future product use case genuinely needs theme-aware disabled coloring
 example — do not work around it by adding the tokens to a Special
 allowlist informally.
 
+### Naming: the theme scale stays public and bare (`--color-theme-*`)
+
+The CSS-variable-naming audit
+([#231](https://github.com/yasmro/schatten/issues/231)) kept `--color-theme-*`
+**public and un-namespaced** — it is a layer-3 *semantic* variable in the
+[four-layer model](api-stability.md#css-variable-naming--the-four-layer-model),
+not a `--st-`-prefixed one. Two consequences the theme machinery relies on:
+
+- **The name is the contract for Specials.** Every seasonal palette in
+  [`themes/seasonal/themes.css`](../../src/themes/seasonal/themes.css) writes
+  `--color-theme-*`, and the allowlist is literally `['--color-theme-*']`.
+  Namespacing the scale to `--st-color-theme-*` would have rippled through
+  every Special selector and the allowlist checker for no theming benefit, so
+  the audit left it bare.
+- **A consumer's own `--color-theme-*` can collide.** Because the name is bare
+  and the value is Schatten's semantic (not a shared Tailwind convention), a
+  consumer who *also* defines `--color-theme-*` on `:root` will collide by
+  last-wins — exactly the layer-3 case the audit decided to **document rather
+  than rename away**. A consumer in that situation scopes Schatten's tokens
+  under a container instead of overriding globally (see
+  [api-stability.md](api-stability.md#why-the-semantic---color--layer-stays-bare-not---st-color-)).
+  This does not affect `data-theme` switching, which mutates the attribute on
+  `<html>` and re-resolves the same bare `--color-theme-*` names at paint time.
+
 ## Cascade
 
 CSS specificity decides the cascade — load order is only a tie-breaker
@@ -446,3 +470,4 @@ prescribes:
 - **Solid** → `--color-solid*` is declared as rungs of the theme ramp (light 700-on-100, dark 300-on-800). Mode picks the rung, the Special supplies the ramp — an active Special recolors every solid surface without writing a single solid token. Default ramp = neutral alabaster (value-preserving).
 - **Never** touch Mode-owned tokens or `info-*` from a Special.
 - **Components** keep referencing semantic tokens (`bg-theme-500`, `text-foreground`, …) — they don't need to know which axes are active.
+- **Naming** → `--color-theme-*` is public + bare (a layer-3 semantic var, [api-stability.md](api-stability.md#css-variable-naming--the-four-layer-model)); #231 kept it un-namespaced so the Special allowlist stays `['--color-theme-*']`. A consumer's own `--color-theme-*` can collide — documented, not renamed away.

--- a/README.md
+++ b/README.md
@@ -107,6 +107,59 @@ Stable from **v1.0.0**: class names and CSS custom properties are
 part of the public API contract (see
 [`.claude/rules/api-stability.md`](.claude/rules/api-stability.md)).
 
+#### Using Schatten alongside another design system (token collisions)
+
+Schatten's semantic tokens are **bare** (`--color-background`, `--color-error`,
+the `--color-theme-*` scale, …) — the meaning is Schatten's, but the name is
+not namespaced. This is deliberate: it lets Schatten share Tailwind's scale
+names (`--spacing-4`, `--text-sm`) with your own Tailwind on purpose. The
+trade-off is that if you run Schatten **alongside another full design system**
+that also declares `--color-background` on `:root` (shadcn/ui does), the two
+collide by last-wins. The naming rationale is the
+[four-layer model](.claude/rules/api-stability.md#css-variable-naming--the-four-layer-model).
+
+Schatten declares its token values **unlayered** on `:root` (unlayered wins
+over any `@layer`), so pick the recipe that matches your situation:
+
+**A consumer's own tokens should win globally** — import Schatten into a
+cascade layer. Your unlayered `:root` then beats Schatten's layered values
+deterministically (no reliance on import order):
+
+```css
+@import "@yasmro/schatten/schatten.css" layer(schatten);
+:root {
+  --color-background: #fff; /* your value — wins everywhere */
+}
+```
+
+Note this is a *global* override: Schatten's own components read
+`var(--color-background)` too, so they will adopt your value. Use it when you
+*want* Schatten to inherit your surface, not when the two meanings genuinely
+differ.
+
+**True isolation for separable subtrees** — scope Schatten's tokens onto a
+container. Custom properties resolve to the nearest declaring ancestor, so
+Schatten components inside the wrapper stay on Schatten's values while your
+`:root` keeps its own meaning everywhere else:
+
+```html
+<div class="schatten-scope"><!-- Schatten UI here --></div>
+```
+
+```css
+/* Re-assert only the tokens you actually collide on, scoped to the subtree. */
+.schatten-scope {
+  --color-background: #fafafa; /* Schatten's intended surface */
+}
+```
+
+**Deeply interleaved with conflicting meanings** is the rare irreducible case
+the naming audit named explicitly: when both systems render on the same
+elements and disagree on what `--color-background` means, no cascade trick
+isolates them — alias one side's token in your own build. Because this case is
+uncommon, Schatten does not pay a global `--st-color-*` rename to pre-empt it
+(see the [decision log](docs/decisions/2026-07-css-variable-namespace.md)).
+
 ### Layer B — Optional React components
 
 When React is on the table, the same tokens drive a typed component layer

--- a/docs/decisions/2026-07-css-variable-namespace.md
+++ b/docs/decisions/2026-07-css-variable-namespace.md
@@ -1,0 +1,95 @@
+# 公開 CSS 変数は 4 層命名モデルで確定 — セマンティック `--color-*` は名前空間化せず据え置く
+
+- **Status**: Accepted
+- **Related**: [#231](https://github.com/yasmro/schatten/issues/231) (本判断),
+  [#116](https://github.com/yasmro/schatten/issues/116) (起点: SSR 検証でクラス名カニバルと変数軸の分離が判明),
+  [#154](https://github.com/yasmro/schatten/issues/154) (クラス名側カニバルを解決),
+  [#185](https://github.com/yasmro/schatten/issues/185) (semantic brand tokens — 完了済み),
+  [#239](https://github.com/yasmro/schatten/issues/239) (危険赤 vs 朱の色味分岐 — designer 所掌),
+  [#317](https://github.com/yasmro/schatten/issues/317) (dist 脱 Tailwind — `--default-*-font-family` 論点の送り元) /
+  [api-stability.md](../../.claude/rules/api-stability.md),
+  [theme-architecture.md](../../.claude/rules/theme-architecture.md),
+  [css-api.md](../../.claude/rules/css-api.md)
+
+## Context
+
+#154（v0.9.0）で `.st-*` **クラス名**のカニバル（外部 Tailwind との衝突）は解決した。
+しかし schatten が `:root` に配る **CSS 変数（トークン）** は別軸で未解決だった:
+`--color-background` / `--color-error` / `--color-theme-*` 等のセマンティックトークンは、
+自前のデザイントークンを持つ消費者（shadcn ベース等）が同名を定義していると `:root` 上で
+last-wins で潰し合う。CSS 変数の改称は api-stability.md 上 1.0 後 `major`。よって 1.0 RC
+（契約凍結点）**前に** 公開変数の命名規約を確定する必要があった。
+
+監査時点で命名規約は 3 つ混在していた: 素の generic（`--color-*` `--spacing-*` …）、
+`--st-` prefix 済み（`--st-duration-*` `--st-spinner-*`）、`--schatten-` component 内部
+（`--schatten-callout-*`、非公開）。加えてプリミティブ（`--blue-500` `--vermillion-*` …）は
+dist `:root` に unlayered で出荷されるが manifest 非掲載。`--st-` prefix は既に稼働中で
+`.st-` クラス prefix（css-api.md）と揃っており、名前空間 prefix 候補は事実上 `--st-` に確定。
+
+## Decision
+
+### 判断原則
+
+> **衝突は、両者が名前に載せる「意味」が食い違うときだけ有害。値が慣習で一致する
+> トークンの衝突は無害（むしろ利点）。**
+
+`--spacing-4`=1rem は Tailwind/consumer と慣習一致で無害・共有が正しい。
+`--color-background` は DS ごとに意味が違い有害（shadcn の ≠ Schatten の）。
+
+### 4 層命名モデル（api-stability.md に規約本体を集約）
+
+| 層 | 名前 | 公開 | ルール |
+|---|---|---|---|
+| 1 プリミティブ | `--blue-500` `--vermillion-*` `--red-*` `--gray-*` … | **非公開**（dist `:root` に出るが manifest 非掲載） | 内部。自由に改称/retune 可。consumer は semantic 層を使う |
+| 2 Tailwind 慣習 | `--spacing-*` `--text-*` `--leading-*` `--font-*` `--radius-sm..2xl` `--shadow-sm..xl` | 公開・bare | Tailwind スケール名を維持。値は共有慣習なので衝突は意図的 |
+| 3 セマンティック | `--color-*`（surfaces/foregrounds/state/inverted/brand/`--color-theme-*`）、schatten 固有別名 `--radius-control/surface/pill` `--shadow-card/popover/modal/toast` `--z-*` `--motion-*` | 公開・bare | 意味は Schatten 固有。別フル DS と衝突しうる — **名前空間化せず、衝突を文書化して回避側は consumer scoping** |
+| 4 schatten 名前空間 | `--st-duration-*` `--st-spinner-*` | 公開・`--st-` | Tailwind 慣習に無い軸（enter/exit timing、spinner cadence）。`.st-` クラス prefix と整合。新規 schatten 固有トークンはここ |
+
+### 確定した個別判断
+
+1. **セマンティック `--color-*` 層 = 据え置き（全 prefix 化しない）。** `--st-color-*` への
+   全面 prefix 化は検討の上 **却下**。理由は下記 Rationale。DoD「衝突が機構的に回避 **or**
+   回避できないトークンを明示」の **明示側** で満たす: 4 層表がその文書化であり、消費者向け
+   回避策（Schatten の `:root` トークンをコンテナ配下に scope する）が緩和策。
+2. **`--default-font-family` / `--default-mono-font-family` = 撤去（#317 からの論点、案 (c)）。**
+   公開面に残る唯一の Tailwind 規約名で、consumer 自前 Tailwind v4 preflight と `@layer theme`
+   内で衝突する。vendored preflight（[preflight.css](../../src/styles/preflight.css)）を
+   `var(--font-sans, …)` / `var(--font-mono, …)` 直参照に書換え、2 変数削除。間接層は元々
+   `--font-sans` / `--font-mono` を指すだけなので **解決値不変**（同一フォント）。
+   manifest −2（129→127）、`CSS API:` changeset。
+3. **プリミティブのブランド中立化（`--vermillion-* → --brand-red-*`）= 見送り。** プリミティブは
+   manifest 非掲載＝非公開。manifest-authoritative（api-stability.md）に従えば非公開トークンの
+   改称は破壊的変更に当たらず「1.0 前必須」の対象外。#185（CLOSED）が公開経路 `--color-vermillion` /
+   `--color-indigo` を既に提供済み。色味の分岐は `--vermillion-*` / `--red-*` の primitive 分離で
+   表現済み。名前の美観は designer spike #239 の所掌。api-stability.md「What is not public API」に
+   プリミティブ CSS 変数を明記して checkpoint を解消。
+
+## Rationale
+
+- **全 prefix 化（案 A / `--st-color-*`）を却下した理由。** 機構的に衝突ゼロになる一方、
+  (a) 約50色変数のリネーム + migration ガイド、(b) 全 consumer のトークン名が冗長化、
+  (c) layer-2 の「`--spacing-*` / `--text-*` が Tailwind 名を意図的に共有する」利点を破壊。
+  有害衝突は「Schatten + 別フル DS を同一 `:root` で併用」の稀ケースのみで、その消費者は
+  global rename を全員に強いるより Schatten トークンを scope して自衛できる。コスト/便益が
+  見合わない。
+- **`--color-theme-*` を bare のまま残す理由（theme-architecture 連動）。** seasonal パレットは
+  全て `--color-theme-*` を書き、allowlist は `['--color-theme-*']`。名前空間化すると全 Special
+  セレクタと allowlist チェッカに波及し theming 上の便益ゼロ。`data-theme` 切替は属性 mutation で
+  同名を paint time に再解決するため影響なし。
+- **manifest が公開面の権威。** プリミティブ非公開の根拠はこの一点に尽きる。同じ governance で
+  `destructive` / `error` を同値でも別 semantic に保つのと整合。
+
+## Consequences
+
+- (+) 値変更ゼロ・VRT 影響ゼロ（`--default-*` 撤去は解決値不変）。公開 surface は −2 のみ。
+- (+) 命名規約が api-stability.md に一本化され、新規トークンの公開/命名判断に指針ができた。
+- (−) セマンティック `--color-*` の衝突は機構的にはゼロにならない（稀ケースは consumer scoping で
+  自衛）。これは意図した trade-off。
+- **持ち越しなし。** プリミティブ改称は行わない確定判断。#239（色味）と CONTRIBUTING.md
+  （v0.15.0、本 doc を SSOT として参照）は別トラック。
+
+## Review
+
+- 2026-07-07 — #231 の refinement で 4 層モデル・案 B 採用・#317(c)・プリミティブ据え置きを確定。
+  実装は preflight.css / public-tokens.css / manifest（−2）+ ルール文書3本（api-stability /
+  theme-architecture / css-api）+ 本 decision log。`CSS API:` changeset 1本（patch）。

--- a/scripts/__tests__/build-css.test.ts
+++ b/scripts/__tests__/build-css.test.ts
@@ -50,13 +50,19 @@ describe('buildSchattenCss', () => {
     expect(css).toContain('-webkit-text-size-adjust')
   })
 
-  it('wires the vendored preflight to Schatten font tokens via the registrar', () => {
-    // public-tokens.css must keep the two load-bearing --default-* rows —
-    // they are the only definition the preflight html / code rules resolve
-    // against (see src/styles/public-tokens.css header).
-    expect(css).toContain('--default-font-family:var(--font-sans)')
-    expect(css).toContain('--default-mono-font-family:var(--font-mono)')
-    expect(css).toMatch(/code,kbd,samp,pre\{font-family:var\(--default-mono-font-family/)
+  it('wires the vendored preflight to Schatten font tokens directly', () => {
+    // #231: the preflight html / code rules reference --font-sans / --font-mono
+    // DIRECTLY, not through the Tailwind-named --default-*-font-family
+    // indirection they carried upstream. Those two variables were the last
+    // Tailwind-convention names on the public surface (they collide with a
+    // consumer's own Tailwind v4 preflight in the shared @layer theme), so the
+    // CSS-variable audit removed them — value-identical, since the indirection
+    // already resolved to these tokens. Do not regress by re-adding them.
+    // See docs/decisions/2026-07-css-variable-namespace.md.
+    expect(css).not.toContain('--default-font-family')
+    expect(css).not.toContain('--default-mono-font-family')
+    expect(css).toMatch(/[{;]font-family:var\(--font-sans,/)
+    expect(css).toMatch(/code,kbd,samp,pre\{font-family:var\(--font-mono,/)
   })
 
   it('opens with the MIT attribution banner for the vendored preflight', () => {

--- a/src/__generated__/schatten.manifest.json
+++ b/src/__generated__/schatten.manifest.json
@@ -327,8 +327,6 @@
     "--color-warning-foreground",
     "--color-warning-hover",
     "--color-warning-subtle",
-    "--default-font-family",
-    "--default-mono-font-family",
     "--font-mono",
     "--font-sans",
     "--font-serif",

--- a/src/styles/preflight.css
+++ b/src/styles/preflight.css
@@ -6,10 +6,20 @@
  * https://tailwindcss.com — source: `tailwindcss/preflight.css`). Vendored
  * from the COMPILED output, not the source file: the source expresses the
  * font-family rules through the build-time `--theme(--default-font-family, …)`
- * function, which is not valid runtime CSS; the compiled form has it expanded
- * to `var(--default-font-family, …)`. Those `var()` references are wired to
- * Schatten's font tokens by `src/styles/public-tokens.css`
- * (`--default-font-family: var(--font-sans)` etc.).
+ * function, which is not valid runtime CSS; the compiled form had it expanded
+ * to `var(--default-font-family, …)`.
+ *
+ * #231 divergence from the verbatim copy — the `html` / `code` font-family
+ * rules reference `--font-sans` / `--font-mono` DIRECTLY, not through the
+ * Tailwind-named `--default-font-family` / `--default-mono-font-family`
+ * indirection they carried upstream. Those two variables were the only
+ * Tailwind-convention names left on Schatten's public surface (they collide
+ * with a consumer's own Tailwind v4 preflight in the shared `@layer theme`),
+ * so the CSS-variable-naming audit removed them: the indirection pointed at
+ * `--font-sans` / `--font-mono` anyway, so referencing the token directly is
+ * value-identical (same resolved font) while shrinking the public surface by
+ * two variables. See docs/decisions/2026-07-css-variable-namespace.md.
+ * When re-syncing to a newer Tailwind (below), re-apply this substitution.
  *
  * Why vendored at all: Schatten's component CSS depends on preflight
  * behaviour — e.g. `Button.css` relies on `svg { display: block }` and
@@ -48,7 +58,7 @@
     tab-size: 4;
     line-height: 1.5;
     font-family: var(
-      --default-font-family,
+      --font-sans,
       ui-sans-serif,
       system-ui,
       sans-serif,
@@ -95,7 +105,7 @@
   samp,
   pre {
     font-family: var(
-      --default-mono-font-family,
+      --font-mono,
       ui-monospace,
       SFMono-Regular,
       Menlo,

--- a/src/styles/public-tokens.css
+++ b/src/styles/public-tokens.css
@@ -27,16 +27,20 @@
  * (unlayered beats layered), so these rows exist to mark the variable as
  * public, not to define its value. The exceptions are load-bearing REAL
  * definitions with no unlayered counterpart:
- *   - `--default-font-family: var(--font-sans)` and
- *     `--default-mono-font-family: var(--font-mono)` — the runtime wiring
- *     that routes Schatten's font tokens into the vendored preflight's
- *     `html` / `code, kbd, samp, pre` rules (see src/styles/preflight.css).
- *     Do NOT drop them as "Tailwind leftovers" — `code` elements would fall
- *     back to the browser mono stack. Their naming is a #231 agenda item.
  *   - `--font-sans` / `--font-serif` carry the brand stacks registered by
  *     `src/themes/default/fonts.css`. In the dist these are inert defaults —
  *     `src/styles/entry.css` re-declares `--font-sans` unlayered (fallback
  *     stack) and consumers override it; kept verbatim for value parity.
+ *
+ * #231 — the vendored preflight's `html` / `code` rules used to reach
+ * Schatten's fonts through `--default-font-family` / `--default-mono-font-
+ * family` (Tailwind-convention names). Those were the last Tailwind-named
+ * variables on the public surface — they collide with a consumer's own
+ * Tailwind v4 preflight in this same `@layer theme` — so the CSS-variable
+ * audit removed them and pointed `preflight.css` at `--font-sans` /
+ * `--font-mono` directly (value-identical; the indirection already resolved
+ * to those). Do NOT re-add them. See
+ * docs/decisions/2026-07-css-variable-namespace.md.
  *
  * MAINTENANCE
  * When a new public variable ships: declare its real value in the token
@@ -74,8 +78,6 @@
     --shadow-md: var(--shadow-md);
     --shadow-lg: var(--shadow-lg);
     --shadow-xl: var(--shadow-xl);
-    --default-font-family: var(--font-sans);
-    --default-mono-font-family: var(--font-mono);
     --color-background: var(--color-background);
     --color-surface: var(--color-surface);
     --color-surface-hover: var(--color-surface-hover);


### PR DESCRIPTION
## What

公開 CSS 変数の命名 audit (#231) を確定。命名規約を **4 層モデル**として
api-stability.md に一本化し、公開面に残っていた唯一の Tailwind 規約名
`--default-font-family` / `--default-mono-font-family` を撤去した。

- **4 層モデル**: ① プリミティブ=非公開（manifest 非掲載、自由改称可）② Tailwind 慣習
  (`--spacing-*` 等)=bare・衝突は意図的共有 ③ セマンティック `--color-*`=bare・別 DS と
  衝突しうるが**文書化して回避側は consumer scoping** ④ schatten 固有=`--st-` prefix。
- **`--default-*-font-family` 撤去**: preflight を `var(--font-sans,…)` / `var(--font-mono,…)`
  直参照へ。解決値不変（間接層は元々これらを指すだけ）。公開 CSS 変数 129→127。
- **プリミティブ改称は見送り**を確定（非公開のため 1.0 前必須の対象外）。

## Why

CSS 変数改称は 1.0 後 `major`。1.0 RC（契約凍結）前に公開変数の命名を settle する必要が
あった。セマンティック `--color-*` の全 prefix 化（`--st-color-*`）は約50変数の major 級
リネームと Tailwind 慣習共有の喪失を招くため却下し、稀な dual-DS 衝突は consumer scoping で
自衛する方針に決定（DoD「回避 **or** 明示」の明示側で充足）。

## Related rules / decisions

- `.claude/rules/api-stability.md` — 4 層モデル本体 + プリミティブを「What is not public API」に明記
- `.claude/rules/theme-architecture.md` — `--color-theme-*` が public/bare である旨
- `.claude/rules/css-api.md` — 変数命名は api-stability に集約（相互リンク）
- `docs/decisions/2026-07-css-variable-namespace.md` — 決定ログ（案 A 却下理由・(c)・プリミティブ据え置き）

## Test plan

- [x] `pnpm lint` 緑
- [x] `pnpm test --run` 緑（1061 passed。`build-css.test.ts` を preflight 直参照 pin へ更新）
- [x] `pnpm typecheck` 緑
- [x] `check:registrar` / `check:manifest` / `check:layer-order` / `check:body-reset` 緑
- [ ] VRT (CI) — 解決値不変につき green 見込み（`CSSApiDist` の computed font は同一）

## Follow-up (別 PR)

- Storybook `CSS API` に「`--color-*` 衝突時の consumer scoping レシピ」節を追加（本 PR では
  VRT baseline 影響を避けるため見送り。契約自体は上記 rule docs で SSOT 化済み）。

closes #231

🤖 Generated with [Claude Code](https://claude.com/claude-code)
