### PR TITLE
docs(rules): Spinner の CSS 変数参照を --st-spinner-* に更新

### DIFF
--- a/.claude/rules/component-architecture.md
+++ b/.claude/rules/component-architecture.md
@@ -372,7 +372,7 @@ Tailwind / CVA cannot reasonably express.
 | `@keyframes` animations (declarative, multi-stop) | Static colors, spacing, typography (use semantic tokens + CVA) |
 | `animation-play-state` / `animation-delay` conditional on `[data-state]` | Hover/focus state styles (use Tailwind variants) |
 | `prefers-reduced-motion` media queries that disable animation | Light/dark adjustments (use CSS variables + `dark:`) |
-| CSS variable definitions scoped to the component (e.g. `--schatten-spinner-duration`) | Layout / flexbox / grid (use Tailwind) |
+| CSS variable definitions scoped to the component (e.g. `--st-spinner-duration`) | Layout / flexbox / grid (use Tailwind) |
 
 **Existing exceptions today** (all animation-only, all comply):
 
@@ -388,7 +388,7 @@ Tailwind / CVA cannot reasonably express.
   dissolve-out keyframes and swipe-handoff animation.
 - [`Spinner.css`](../../src/components/lv1/Spinner/Spinner.css) — ripple
   and breathe keyframes; declares two component-scoped CSS variables
-  (`--schatten-spinner-duration`, `--schatten-spinner-ripple-delay`)
+  (`--st-spinner-duration`, `--st-spinner-ripple-delay`)
   that consumers can override.
 
 **Review check:** if a PR adds a `.css` file under `src/components/lv1/`,


### PR DESCRIPTION
## 概要

[.claude/rules/component-architecture.md](.claude/rules/component-architecture.md) §7（lv1-local CSS files）の Spinner 関連 CSS 変数参照が、sweep 前の旧名 `--schatten-spinner-duration` / `--schatten-spinner-ripple-delay` のままだったのを、実ソースの正名に更新しました。

## 変更点

`--schatten-spinner-*` → `--st-spinner-*`（`.st-*` クラス prefix に揃えた rename に追従）:

- 375 行目 — Allowed/Not-allowed テーブルの例示
- 391 行目 — `Spinner.css` の Existing exceptions エントリ

## 確認

- [src/components/lv1/Spinner/Spinner.css](src/components/lv1/Spinner/Spinner.css) を grep し、正名が `--st-spinner-duration`（default `2.8s`）/ `--st-spinner-ripple-delay`（default `1.1s`）であることを確認
- 修正後、ルールファイルに `schatten-spinner` が 0 件であることを確認
- ドキュメントのみの変更のため changeset は不要（公開 surface / package に影響なし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)