### PR TITLE
test(ThemeProvider): flaky な transition-suppressor テストを決定化

### DIFF
--- a/src/providers/ThemeProvider/ThemeProvider.test.tsx
+++ b/src/providers/ThemeProvider/ThemeProvider.test.tsx
@@ -553,18 +553,35 @@ describe('ThemeProvider', () => {
   describe('disableTransitionOnChange', () => {
     it('injects and removes a transition-blocking style tag on mode change', async () => {
       const user = userEvent.setup()
-      render(
-        <ThemeProvider defaultMode="light" disableTransitionOnChange>
-          <Consumer />
-        </ThemeProvider>,
-      )
-      await user.click(screen.getByRole('button', { name: 'set-dark' }))
-      // Style tag is inserted synchronously; cleanup is on the next frame.
-      const style = document.getElementById('schatten-theme-transition-suppressor')
-      expect(style).not.toBeNull()
-      // Wait one frame
-      await new Promise((resolve) => requestAnimationFrame(() => resolve(null)))
-      expect(document.getElementById('schatten-theme-transition-suppressor')).toBeNull()
+      // Capture the rAF callback instead of letting a real animation frame
+      // fire it. `suppressTransitionsOnce` inserts the <style> synchronously
+      // but schedules its removal via `requestAnimationFrame`; on real timers
+      // a frame can fire between the click and the first query (worse under CI
+      // scheduling), removing the tag before we assert it was inserted. By
+      // controlling the frame we pin the insert-then-cleanup sequence.
+      const rafCallbacks: FrameRequestCallback[] = []
+      const rafSpy = vi
+        .spyOn(window, 'requestAnimationFrame')
+        .mockImplementation((cb) => rafCallbacks.push(cb))
+      try {
+        render(
+          <ThemeProvider defaultMode="light" disableTransitionOnChange>
+            <Consumer />
+          </ThemeProvider>,
+        )
+        await user.click(screen.getByRole('button', { name: 'set-dark' }))
+        // Inserted synchronously; cleanup is deferred to the captured frame.
+        const style = document.getElementById('schatten-theme-transition-suppressor')
+        expect(style).not.toBeNull()
+        // Flush the captured frame — this runs the cleanup deterministically.
+        expect(rafCallbacks).toHaveLength(1)
+        act(() => {
+          for (const cb of rafCallbacks.splice(0)) cb(0)
+        })
+        expect(document.getElementById('schatten-theme-transition-suppressor')).toBeNull()
+      } finally {
+        rafSpy.mockRestore()
+      }
     })
 
     it('does not inject the style tag when disableTransitionOnChange is false', async () => {


### PR DESCRIPTION
## 背景

`ThemeProvider.test.tsx` の

> `disableTransitionOnChange › injects and removes a transition-blocking style tag on mode change`

が CI で flaky。[PR #463](https://github.com/yasmro/schatten/pull/463)（ThemeProvider に触れない docs-only 変更）で `AssertionError: expected null not to be null`（`expect(style).not.toBeNull()` 周辺）が発生。ローカルでは決定的に成功（3/3 runs）。

## 原因

本物の `requestAnimationFrame` とのレース。`suppressTransitionsOnce()` は transition-blocking な `<style>` を**同期挿入**し、削除を**次フレーム**に予約する。テストは実タイマーで走るため、`await user.click()` の解決から `getElementById` 検証までの間に実フレームが割り込んでタグを消してしまうことがある（CI のスケジューリング負荷で顕在化）。

- DOM ロジック自体は正常 — **アサーションが実フレームと競走**していただけ
- **実運用には影響なし**（本番に該当の検証コードは存在せず、レースする相手がいない）

## 修正

`requestAnimationFrame` をスパイして削除コールバックをキャプチャ（自動発火させない）し、順序を確定化:

1. click → `<style>` 同期挿入・フレームはキャプチャのみ
2. タグ存在を検証（`rafCallbacks` が1件であることも確認）
3. キャプチャしたフレームを明示 flush → cleanup 実行
4. タグ削除を検証

- **アサーションは弱めていない** — 挿入と削除の両方を引き続き検証
- **本体コード（ThemeProvider.tsx）は無変更** — テストのタイミング依存のみ修正
- スパイは `finally` で `mockRestore` し、隣接テストへ漏らさない

## 検証

- `for i in $(seq 20); do pnpm test --run …ThemeProvider.test.tsx; done` → **20/20 green**（各 32 tests）
- `biome check` / `tsc` 共に clean

テストのみの変更のため changeset は不要（test files は public API 外 / api-stability.md）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)