### PR TITLE
docs: 基盤アーキテクチャ ADR (ADR-0001〜0010) を整備 (closes #158)

### DIFF
--- a/.changeset/adr-directory-158.md
+++ b/.changeset/adr-directory-158.md
@@ -1,0 +1,11 @@
+---
+'@yasmro/schatten': patch
+---
+
+docs: add foundational ADRs (ADR-0001〜0010) to the decision log (#158). The
+numbered records live in `docs/decisions/` as an `ADR-NNNN-<slug>.md` series
+alongside the existing dated incremental logs — shadcn base / npm distribution /
+framework-agnostic CSS / Tailwind v4 + CVA / Radix / variant vocabulary /
+lv1-lv2 layering / seasonal theme / no-polymorphic-as / no-layout-primitives.
+`docs/decisions/README.md` now documents the two entry types and indexes the
+ADRs, and the root README links to the decision log.

--- a/README.md
+++ b/README.md
@@ -1091,6 +1091,11 @@ a changeset is required.
 `.claude/rules/` conventions so generated code lands consistent with the design
 system.
 
+**Why is it built this way?** The **[decision log](docs/decisions/README.md)**
+records the *why* behind Schatten's architecture — the foundational ADRs
+(shadcn base, npm distribution, framework-agnostic CSS, the two-axis theme, …)
+plus incremental token / API trade-offs.
+
 ## License
 
 MIT

--- a/docs/decisions/ADR-0001-shadcn-base.md
+++ b/docs/decisions/ADR-0001-shadcn-base.md
@@ -1,0 +1,56 @@
+# ADR-0001: shadcn/ui をベースに採用する
+
+- **Status**: Accepted
+- **Date**: 2026-03（発足期。git 履歴以前の判断を遡及記録）
+- **Related**: #158（本 ADR 群） / [CLAUDE.md](../../CLAUDE.md)（冒頭）,
+  [component-architecture.md](../../.claude/rules/component-architecture.md),
+  [ADR-0004](ADR-0004-tailwind-v4-cva.md)（Tailwind + CVA）,
+  [ADR-0005](ADR-0005-radix-primitives.md)（Radix）
+
+## Context
+
+Schatten は Schatten ブランド向けのデザインシステムコンポーネントライブラリを、
+ゼロから設計するのではなく確立された下地の上に構築する必要があった。純粋な自作は
+アクセシビリティ・キーボード操作・variant 設計・トークン構成といった「解けた問題」を
+再発明することになり、portfolio / 学習目的に対してもコストが見合わない。
+
+## Decision
+
+**[shadcn/ui](https://ui.shadcn.com/) の規約を baseline として採用する。**
+コンポーネント設計の既定は「shadcn/ui + Radix conventions」とし、明示的に上書きした
+点だけを `.claude/rules/` に記録する（[component-architecture.md](../../.claude/rules/component-architecture.md)
+冒頭「Anything not covered here defaults to shadcn/ui + Radix conventions」）。
+
+技術的帰結として shadcn の 3 本柱をそのまま引く:
+
+- **Radix UI**（プリミティブ / a11y）→ [ADR-0005](ADR-0005-radix-primitives.md)
+- **CVA**（variant 定義）→ [ADR-0004](ADR-0004-tailwind-v4-cva.md)
+- **`cn` ユーティリティ**（クラス合成）
+
+## Rationale
+
+- **検討した他案:**
+  - **完全自作** — a11y / variant / トークンを一から設計。学習価値はあるが、解決済み
+    問題の再発明で、真に差別化したい「rule-driven な運用パターン」に投資できなくなる。棄却。
+  - **MUI / Chakra 等のフル DS 採用** — スタイルが重く、`.st-*` のような framework-agnostic
+    CSS 層（[ADR-0003](ADR-0003-framework-agnostic.md)）を後付けしにくい。テーマ機構も
+    それぞれ固有で、二軸テーマ（Mode × Special）を載せる自由度が乏しい。棄却。
+  - **Headless UI のみ** — Radix と役割が重なるが、shadcn ほどの「copy-in してカスタムする」
+    エコシステムと variant 慣習の蓄積がない。棄却。
+- **shadcn を選んだ決め手:** copy-in 方式で内部を完全に所有できる（依存としてブラックボックス化
+  しない）ため、`.st-*` クラス API や二軸テーマといった Schatten 固有の拡張を無理なく被せられる。
+
+## Consequences
+
+- (+) a11y / キーボード / variant の土台を継承し、Schatten 固有の価値（rule-driven 運用、
+  framework-agnostic CSS、季節テーマ）に集中できる。
+- (+) 規約が「shadcn 既定 + 差分だけ明文化」になり、`.claude/rules/` が薄く保てる。
+- (−) shadcn / Radix の設計思想に縛られる。polymorphic API を持たない（[ADR-0009](ADR-0009-no-polymorphic-as.md)）等、
+  shadcn の選択を追認する場面が生じる。
+- (neutral) shadcn は「配布ライブラリ」ではなく「copy-in レシピ」なので、npm 配布
+  （[ADR-0002](ADR-0002-npm-distribution.md)）は Schatten 側の独立判断になった。
+
+## Review
+
+- 2026-03 — 発足時に採用（遡及記録）。以降のコンポーネント設計は本 ADR を既定とし、
+  逸脱のみ `.claude/rules/` に記録している。

--- a/docs/decisions/ADR-0002-npm-distribution.md
+++ b/docs/decisions/ADR-0002-npm-distribution.md
@@ -1,0 +1,58 @@
+# ADR-0002: npm パッケージとして配布する（copy-in ではなく）
+
+- **Status**: Accepted
+- **Date**: 2026-03（発足期。遡及記録）
+- **Related**: #158（本 ADR 群） / [api-stability.md](../../.claude/rules/api-stability.md),
+  [ADR-0001](ADR-0001-shadcn-base.md)（shadcn ベース）,
+  [ADR-0003](ADR-0003-framework-agnostic.md)（framework-agnostic 層）
+
+## Context
+
+ベースの shadcn/ui は「コンポーネントをリポジトリに copy-in してから所有・改変する」
+配布モデルを採る。一方 Schatten は複数の消費側（React アプリ、および将来的な
+vanilla / Vue / Astro などの非 React 経路）から**同一のバージョン付き契約**として
+参照される必要があった。copy-in はバージョン管理・更新伝播・公開 API 契約の凍結
+（1.0 の api-stability）と相性が悪い。
+
+## Decision
+
+**`@yasmro/schatten` を npm パッケージとして配布する。**
+
+- **単一パッケージのまま** tsup の multi-entry で複数サブパスを公開する
+  （`.` / `./variants` / `./tokens` / `./themes/*` / `./css/*` / `./providers` /
+  `./theme-init` / `./schatten.css` / `./schatten.manifest.json` …）。
+- React は **`peerDependenciesMeta.react.optional = true`**。CSS 層と
+  トークン / variants サブパスは React 非依存で、React を入れない消費者でも解決できる
+  （[ADR-0003](ADR-0003-framework-agnostic.md)）。
+- 公開面は `dist/schatten.manifest.json` に列挙され、1.0 以降は
+  [api-stability.md](../../.claude/rules/api-stability.md) の破壊的変更ポリシーで凍結される。
+
+## Rationale
+
+- **検討した他案:**
+  - **copy-in（shadcn 素の方式）** — バージョン契約・更新伝播ができず、`.st-*` の manifest
+    凍結や CSP hash 固定（`THEME_INIT_SCRIPT`）のような「バイト単位の公開契約」を持てない。棄却。
+  - **monorepo で React 版 / CSS 版をパッケージ分割** — 境界は綺麗になるが、発足段階では
+    実需（React を入れたくない消費者の具体例）が薄く、公開・バージョニング・リリースの
+    運用コストだけが先行する。**v1.x で実需が出てから**に先送りし、当面は 1 パッケージ +
+    `peerDependenciesMeta.optional` + Biome の境界 lint（`src/core|variants|themes` から
+    React/Radix import を禁止、[lint-rules-guideline.md](../../.claude/rules/lint-rules-guideline.md)）で
+    core / react を分離する。
+- **単一パッケージを選んだ決め手:** multi-entry で「framework-agnostic なサブパス」を
+  提供でき、per-component CSS subpath（`@yasmro/schatten/css/<slug>`、PageSpeed 対策）も
+  同一パッケージ内で完結する。境界維持は [lint-rules-guideline.md](../../.claude/rules/lint-rules-guideline.md)
+  の `noRestrictedImports` scope で機構的に守る。
+
+## Consequences
+
+- (+) バージョン付き公開契約（manifest / api-stability / size budgets）が成立する。
+- (+) 消費者は `import '@yasmro/schatten/schatten.css'` 一発で CSS を使え、React も
+  optional peer なので非 React 経路が壊れない。
+- (−) 単一パッケージゆえ、tree-shaking と境界維持を lint / exports で機構的に守る必要がある
+  （Biome 境界 lint、`peerDependenciesMeta`、multi-entry）。
+- (future) monorepo split は v1.x の実需待ち。判断を本 ADR に固定しておく。
+
+## Review
+
+- 2026-03 — 発足時に npm 配布を採用（遡及記録）。
+- v0.9.0（#291）— multi-entry exports と per-component CSS subpath を確定。

--- a/docs/decisions/ADR-0003-framework-agnostic.md
+++ b/docs/decisions/ADR-0003-framework-agnostic.md
@@ -1,0 +1,54 @@
+# ADR-0003: Framework-Agnostic 路線（二層デザインシステム）を採る
+
+- **Status**: Accepted（実現済み — #58 / #154 / #317）
+- **Date**: 2026-03 起点（路線決定）/ v0.9.0 実装（#154）/ v0.15.0 で dist 脱 Tailwind（#317）
+- **Related**: [#58](https://github.com/yasmro/schatten/issues/58)（framework-agnostic ロードマップ）,
+  [#154](https://github.com/yasmro/schatten/issues/154)（`.st-*` クラス API + manifest）,
+  [#317](https://github.com/yasmro/schatten/issues/317)（dist 脱 Tailwind） /
+  [css-api.md](../../.claude/rules/css-api.md),
+  [api-stability.md](../../.claude/rules/api-stability.md),
+  [ADR-0002](ADR-0002-npm-distribution.md), [ADR-0004](ADR-0004-tailwind-v4-cva.md)
+
+## Context
+
+React コンポーネントだけを配ると、非 React（vanilla HTML / Astro / Vue …）の消費者は
+Schatten のビジュアルを一切使えない。一方、shadcn ベース（[ADR-0001](ADR-0001-shadcn-base.md)）の
+素の形は Tailwind ユーティリティを JSX に直書きするため、CSS だけを切り出して配ることが
+できなかった。ビジュアル契約（見た目）を React 実装から独立させる必要があった。
+
+## Decision
+
+**二層で提供する:**
+
+1. **React 層** — `<Button variant="primary">…</Button>`
+2. **Framework-agnostic な CSS 層** — `<button class="st-btn st-btn--primary">…</button>`
+
+両経路は**同一のクラス文字列を出力し、同一の `dist/schatten.css` に当たり、ピクセル一致**する
+（[css-api.md](../../.claude/rules/css-api.md)）。CSS 層は prefix `st-` + BEM + 属性駆動 state
+（`[aria-invalid]` / `[data-state]` …）の契約を持ち、公開クラス / state hook / CSS 変数は
+`dist/schatten.manifest.json` に列挙され 1.0 で凍結される。
+
+消費者は `import '@yasmro/schatten/schatten.css'` 一発で、Tailwind も PostCSS もビルド工程も
+不要でクラス API を使える。
+
+## Rationale
+
+- **検討した他案:**
+  - **React のみ配布** — 非 React 経路を最初から諦める。portfolio としての射程が狭い。棄却。
+  - **Tailwind を消費者にも要求（`@apply` ソースを配る）** — 消費者に Tailwind セットアップを
+    強制し、"framework-agnostic" と言えない。棄却 → これが #317（下記）の動機。
+- **CVA 出力を `.st-*` に一本化した効果:** variant タプル → クラス連鎖が決定的になり、CVA 出力
+  文字列自体を公開契約にできた（[api-stability.md](../../.claude/rules/api-stability.md) CVA output stability）。
+
+## Consequences
+
+- (+) vanilla / Astro / Vue から同一ビジュアルを利用可能（[framework-agnostic.md](../verification/framework-agnostic.md)）。
+- (+) manifest による公開面の機械検証（`pnpm check:manifest`）が成立。
+- (−) React 経路と CSS 経路の**視覚的一致を恒久的に保証**する責務が生じる（区分 A/B は parity VRT、
+  区分 C/D は manifest + unit + interaction test、[vrt-spec-guideline.md](../../.claude/rules/vrt-spec-guideline.md)）。
+- **#317 との連鎖:** この路線を完遂するため dist から Tailwind を除去した（[ADR-0004](ADR-0004-tailwind-v4-cva.md)）。
+
+## Review
+
+- v0.9.0（#154）— `.st-*` クラス API + manifest パイプラインを実装（全 lv1 カバー）。
+- v0.15.0（#317）— dist を lightningcss で Tailwind-free コンパイル、路線を完遂。

--- a/docs/decisions/ADR-0004-tailwind-v4-cva.md
+++ b/docs/decisions/ADR-0004-tailwind-v4-cva.md
@@ -1,0 +1,57 @@
+# ADR-0004: スタイリングに Tailwind CSS v4 + CVA を採用する（後に dist からは Tailwind を除外）
+
+- **Status**: Accepted（採用は有効）。ただし **dist 配布物からの Tailwind 除外は #317 で確定**
+  — 現在 Tailwind は dev / Storybook 専用（下記 Consequences）
+- **Date**: 2026-03（採用）/ v0.15.0（#317, dist 脱 Tailwind）
+- **Related**: [#317](https://github.com/yasmro/schatten/issues/317)（dist 脱 Tailwind → lightningcss）,
+  [2026-07-css-variable-namespace.md](2026-07-css-variable-namespace.md) /
+  [css-api.md](../../.claude/rules/css-api.md),
+  [theme-architecture.md](../../.claude/rules/theme-architecture.md),
+  [ADR-0001](ADR-0001-shadcn-base.md), [ADR-0003](ADR-0003-framework-agnostic.md),
+  [ADR-0006](ADR-0006-variant-vocabulary.md)
+
+## Context
+
+shadcn ベース（[ADR-0001](ADR-0001-shadcn-base.md)）の既定スタイリングは Tailwind +
+class-variance-authority（CVA）+ `cn` 合成。トークンを CSS 変数で持ち、二軸テーマ
+（Mode × Special、[theme-architecture.md](../../.claude/rules/theme-architecture.md)）を
+`var()` の paint-time 解決に載せるには、CSS 変数ネイティブな Tailwind v4（`@theme` 登録）が
+噛み合っていた。
+
+## Decision
+
+- **スタイリング = Tailwind CSS v4 + CVA。** variant は CVA で定義し、トークンは
+  `@theme` 登録して `bg-theme-500` 等のユーティリティを生む。
+- **後日（#317）: dist からは Tailwind を除外する。** framework-agnostic 路線
+  （[ADR-0003](ADR-0003-framework-agnostic.md)）を完遂するため、`dist/schatten.css` は
+  **lightningcss** が plain-CSS ソース（raw トークン + 手書き `@layer theme` registrar +
+  vendored preflight + `.st-*` component rules）をバンドルしてコンパイルする。
+  **Tailwind は dev-only 依存**として Storybook 経路（`src/styles/globals.css` 経由）にのみ残る。
+
+## Rationale
+
+- **CVA を選んだ理由:** variant タプル → クラス連鎖が決定的で、出力文字列を公開契約にできる
+  （[api-stability.md](../../.claude/rules/api-stability.md) CVA output stability）。
+- **Tailwind v4 を選んだ理由:** `@theme` 登録が CSS 変数と直結し、二軸テーマの paint-time
+  解決とゼロ JS のテーマ切替に噛み合う。
+- **dist から外した理由（#317）:** Tailwind を出荷し続けると、消費者が `@apply` 解決や
+  Tailwind セットアップに縛られ "framework-agnostic" が成立しない。component CSS は
+  raw CSS + `var(--color-*)` 直書きに統一し（[css-api.md](../../.claude/rules/css-api.md)
+  「raw CSS over `@apply`」）、lightningcss でコンパイルする経路に一本化した。
+
+## Consequences
+
+- (+) CVA 出力 + `.st-*` が公開契約として凍結可能（manifest）。
+- (+) **消費者は Tailwind 不要**（#317 以降、dist も Tailwind-free）。
+- (−) Storybook 経路のみ Tailwind 依存が残るため、Tailwind bump が **component / docs VRT
+  baseline** をドリフトさせうる（[api-stability.md](../../.claude/rules/api-stability.md)
+  visual-contract-affecting deps）。dist / manifest には影響しない。
+- (−) component `.css` に Tailwind directive（`@apply` / `@theme` / `@utility`）を書くと
+  lightningcss が invalid at-rule として素通しし壊れる。raw CSS 必須が **ビルド要件**化した。
+
+## Review
+
+- 2026-03 — Tailwind v4 + CVA を採用（遡及記録）。
+- v0.15.0（#317）— dist を lightningcss で Tailwind-free 化。Tailwind を dev-only に縮小。
+  本 ADR はこの縮小を後日談として併記する（別 supersede ADR は切らない — 採用判断自体は
+  今も有効なため）。

--- a/docs/decisions/ADR-0005-radix-primitives.md
+++ b/docs/decisions/ADR-0005-radix-primitives.md
@@ -1,0 +1,54 @@
+# ADR-0005: プリミティブに Radix UI を採用する（型は継承せず境界を設ける）
+
+- **Status**: Accepted
+- **Date**: 2026-03（採用）/ v0.9.0+（#156, Radix 型境界）
+- **Related**: [#156](https://github.com/yasmro/schatten/issues/156)（Radix type boundary）,
+  [#318](https://github.com/yasmro/schatten/issues/318)（Toast は Radix → Sonner に移行） /
+  [component-architecture.md](../../.claude/rules/component-architecture.md),
+  [api-stability.md](../../.claude/rules/api-stability.md)（Radix type boundary）,
+  [ADR-0001](ADR-0001-shadcn-base.md)
+
+## Context
+
+Dialog / Tooltip / Select / Checkbox / Radio / Switch などは、フォーカストラップ・
+キーボードナビゲーション・ARIA 配線・ポータルといった「正しく実装するのが難しい」挙動を
+必要とする。shadcn ベース（[ADR-0001](ADR-0001-shadcn-base.md)）はこれらを Radix UI に委ねる。
+
+## Decision
+
+**インタラクティブ・プリミティブの土台に Radix UI を採用する。** ただし公開型は
+**Radix 由来ではなく Schatten が著述する**（[api-stability.md](../../.claude/rules/api-stability.md)
+Radix type boundary, #156）:
+
+- Radix コンポーネントインスタンスを直接 re-export しない。
+- 公開 Props は **native element props + curated redeclarations**。`ComponentPropsWithoutRef<typeof XPrimitive.Y>`
+  を継承しない（継承すると Radix のバージョン差が公開型面をゼロ diff で動かす）。
+- compound 部品は Radix の part 名に 1:1 対応させる（[component-architecture.md](../../.claude/rules/component-architecture.md) §2）。
+
+## Rationale
+
+- **検討した他案:**
+  - **a11y を自作** — フォーカストラップ・ロービングタブインデックス等を再発明。バグ温床。棄却。
+  - **Radix の型をそのまま公開** — 実装は楽だが、Radix は `dependencies`（caret）で入るため
+    公開型面が消費者の lockfile 解決に追従して動く。1.0 の api-stability（patch で surface 不変）と
+    両立不能。→ #156 の型境界（anti-corruption layer）で解決。棄却。
+- **Radix を選んだ決め手:** a11y / キーボード / ポータルの正しさを継承しつつ、値レベルの
+  互換性は「curated props を Radix に spread する」形で Schatten 内の `pnpm typecheck` が
+  Radix bump を吸収する。
+
+## Consequences
+
+- (+) a11y 契約（[component-architecture.md](../../.claude/rules/component-architecture.md) §8）の
+  role / キーボード / ARIA を Radix が担い、Schatten は「壊さない」ことに集中できる。
+- (+) 型境界により Radix を caret 範囲に置いても公開型面が動かない。
+- (−) Radix が emit する `data-*` / `aria-*` の変化は視覚契約をソース無変更でドリフトさせうる
+  （区分 A/B は parity VRT、C/D は手動、[api-stability.md](../../.claude/rules/api-stability.md)
+  visual-contract-affecting deps）。
+- (neutral) Toast は後に Radix から **Sonner** に移行（#318）。プリミティブ選定は
+  コンポーネント個別に見直しうることを示す先例。
+
+## Review
+
+- 2026-03 — Radix UI を採用（遡及記録）。
+- #156 — 公開型を Radix 非継承に。値互換は spread + typecheck で吸収。
+- #318 — Toast のみ Sonner へ移行。

--- a/docs/decisions/ADR-0006-variant-vocabulary.md
+++ b/docs/decisions/ADR-0006-variant-vocabulary.md
@@ -1,0 +1,61 @@
+# ADR-0006: Variant 語彙を 2 パターン（Role 単軸 / Tone × Shape 二軸）に統一する
+
+- **Status**: Accepted
+- **Date**: 2026-03 起点 / v0.7.0（#108, treatment→appearance / default→neutral の統一）
+- **Related**: [#108](https://github.com/yasmro/schatten/issues/108)（語彙統一の実装） /
+  [component-api-conventions.md](../../.claude/rules/component-api-conventions.md),
+  [state-token-guideline.md](../../.claude/rules/state-token-guideline.md),
+  [css-api.md](../../.claude/rules/css-api.md),
+  [ADR-0004](ADR-0004-tailwind-v4-cva.md)
+
+## Context
+
+variant 名がコンポーネントごとに漂流すると、AI コーディング支援も人も存在しない variant を
+発明する（`<Button variant="success">`、`<Badge variant="primary">` など）。語彙を固定し、
+1 コンポーネント = 1 パターンに統一する必要があった。当初は state コンポーネントで
+`treatment` / `default` という語が混在していた。
+
+## Decision
+
+**すべての variant を 2 パターンのいずれか一つに割り当てる**（[component-api-conventions.md](../../.claude/rules/component-api-conventions.md)）:
+
+- **Pattern A — Role ベース（単軸）**: `variant` のみ。各値が「役割」（色 × 形を内包）を表す。
+  **アクション系（Button）**。例: `primary` / `secondary` / `tertiary` / `destructive` /
+  `inverted` / `link`。`appearance` prop は持たない。
+- **Pattern B — Tone × Shape（二軸）**: `variant`（tone）× `appearance`（shape）。**state /
+  通知系（Badge / Callout / Toast）**。tone = `neutral` / `success` / `error` / `warning` / `info`、
+  shape = `solid` / `outline` / `subtle`。
+
+> ⚠️ 「color tone × appearance」は **Pattern B のみ**の話。Button は Pattern A（role 単軸）で
+> `appearance` を持たない。両パターンの併記が正確な語彙。
+
+選択規準:「色を視覚的重みと独立に動かしたいか」→ No なら Pattern A、Yes なら Pattern B。
+フォーム系（Input 等）はどちらでもなく `variant` を持たず、エラーは `isError` boolean。
+`Text` は唯一の例外で `variant` をタイポグラフィ role（`body`/`label`/`heading`）に再利用する。
+
+v0.7.0（#108）で旧語彙を一掃: `treatment` → `appearance`、Pattern B の `default` → `neutral`。
+
+## Rationale
+
+- **Pattern A で色 × 形を分解しない理由:** アクションは少数の既知 role を持ち、分解すると
+  `destructive + link` のような無意味な組合せが生まれ、共通ケースのエルゴノミクスも悪化する。
+  shadcn の Button も単軸。
+- **Pattern B で二軸にする理由:** state は「error solid Toast」と「error subtle Callout」が
+  同じ意味で異なる視覚的重みで両立する。各ペアに個別名（`error-solid`…）を付けると語彙が爆発する。
+- **`accent` tone を Pattern B に足さなかった理由:** `neutral + solid` と視覚が重複し、区別できる
+  role を足さない（2026-05-17 レビューで却下）。ブランド表現はテーマ層（Mode × Special）に委ねる。
+
+## Consequences
+
+- (+) variant 語彙が固定され、存在しない variant の発明を防げる（AI 支援にも効く）。
+- (+) CSS 側は Pattern B を double-class セレクタ（`.st-callout--success.st-callout--subtle`）で
+  表現し、CVA が side-by-side にクラスを emit する契約と一致（[css-api.md](../../.claude/rules/css-api.md)）。
+- (−) 新コンポーネントは必ずどちらかのパターンを選ぶ必要がある。どちらにも収まらない場合は
+  「まず議論」（分解の兆候）。
+- **将来:** 語彙違反を Biome custom rule で機械化する案は v0.8.0 で検討（未実装、
+  [lint-rules-guideline.md](../../.claude/rules/lint-rules-guideline.md)）。
+
+## Review
+
+- 2026-03 — 2 パターン方針を採用（遡及記録）。
+- v0.7.0（#108）— `treatment→appearance` / `default→neutral` を一掃し語彙統一を完了。

--- a/docs/decisions/ADR-0007-lv1-lv2-layering.md
+++ b/docs/decisions/ADR-0007-lv1-lv2-layering.md
@@ -1,0 +1,49 @@
+# ADR-0007: コンポーネントを lv1 / lv2 の二層構造にする
+
+- **Status**: Accepted（lv1 稼働中 / lv2 は post-1.0 で空）
+- **Date**: 2026-03（採用。遡及記録）
+- **Related**: #158（本 ADR 群） /
+  [component-architecture.md](../../.claude/rules/component-architecture.md) §1・§6,
+  [ADR-0009](ADR-0009-no-polymorphic-as.md), [ADR-0010](ADR-0010-no-layout-primitives.md)
+
+## Context
+
+コンポーネントには粒度の差がある: 単一責務のプリミティブ（Button / Input …）と、
+それらを組み合わせた合成（例: `FormField` = Field + Label + Input + error msg）。両者を
+1 つのフォルダ・1 つの依存規約に混ぜると、依存方向が曖昧になり「プリミティブが合成に依存する」
+逆流が起きやすい。
+
+## Decision
+
+**二層に分ける**（[component-architecture.md](../../.claude/rules/component-architecture.md) §1）:
+
+- **lv1（primitive）** — `src/components/lv1/`。単一責務の低レベルプリミティブ
+  （Button / Input / Field / Select / Dialog / Tooltip …）。
+- **lv2（composite）** — `src/components/lv2/`。複数 lv1 を 1 コンポーネントに合成したもの。
+
+**依存方向は厳密に一方向**（§6）: `lib → contexts/variants → lv1 → lv2`。
+`lv1 → lv2` は禁止（必要になったらそれは lv1 の誤分類 = lv2 に昇格すべき兆候）。
+`lv1 → 他 lv1` は許可（Dialog が Button を構造部品として内包する等）。
+
+## Rationale
+
+- **検討した他案:**
+  - **フラットな 1 層** — 依存方向を機械的に守れず、プリミティブが合成に逆流しうる。棄却。
+  - **shadcn 素のフラット構成** — Schatten は「合成を機能として自作する」場面（FormField 等）を
+    lv2 として隔離したい。1 層だと合成を compound lv1 に押し込む誘惑が生まれる。棄却。
+- **二層を選んだ決め手:** 依存方向を層で表現でき、Biome の境界 lint / 依存表で機構的に守れる。
+
+## Consequences
+
+- (+) 依存方向が明示され、逆流を規約 + lint で防げる。
+- (+) 「3 つ以上の lv1 の合成」は lv2 候補、という判断基準を持てる。
+- (neutral) **lv2 は現在空**。1.0 は lv1 + CSS 契約を凍結し、lv2（lv1 の合成）はその後に
+  additive な `minor` として出す（post-1.0 スコープ）。昇格基準（recurring composition →
+  lv2）は最初の lv2 が来る時に別ルールで定義する（§1 で意図的に deferred）。
+- (−) 層を跨ぐ barrel-export laundering（高層経由で低層に届く）は禁止。直接 import を強制。
+
+## Review
+
+- 2026-03 — lv1 / lv2 の二層を採用（遡及記録）。lv1 のみ稼働。
+- lv2 昇格基準・lv0/lv3 の導入は post-1.0 の follow-up
+  （[component-architecture.md](../../.claude/rules/component-architecture.md) §1「When this rule changes」）。

--- a/docs/decisions/ADR-0008-seasonal-theme.md
+++ b/docs/decisions/ADR-0008-seasonal-theme.md
@@ -1,0 +1,59 @@
+# ADR-0008: 季節テーマを Special 軸として持つ（24節気に着想、8 パレットで実装）
+
+- **Status**: Accepted
+- **Date**: 2026-03 起点 / v0.6.x（`data-theme` / `--color-theme-*` rename）
+- **Related**: [#150](https://github.com/yasmro/schatten/issues/150)（solid が theme ramp を参照） /
+  [theme-architecture.md](../../.claude/rules/theme-architecture.md),
+  [2026-06-solid-theme-rung.md](2026-06-solid-theme-rung.md),
+  [state-token-guideline.md](../../.claude/rules/state-token-guideline.md),
+  [ADR-0004](ADR-0004-tailwind-v4-cva.md)
+
+## Context
+
+Schatten ブランドは季節性という表現軸を持ちたかった。しかし surface / foreground / border /
+state 色まで季節で動かすと a11y 検証の組合せが爆発し、意味（disabled は「使えない」等）まで
+ドリフトする。表現軸を、基盤の Mode（light/dark）から分離する必要があった。
+
+## Decision
+
+**テーマを 2 つの独立軸でモデル化する**（[theme-architecture.md](../../.claude/rules/theme-architecture.md)）:
+
+- **Mode**（排他: light / dark）— 基盤層（surface / foreground / border / state のシェード）を所有。
+- **Special**（排他: `data-theme="<name>"` または無し）— 表現層（`--color-theme-*` スケール、
+  ブランド名トークン）を所有。**季節テーマは Special 軸の一員**。
+
+**季節は「24節気」を着想元とし、実装は 8 パレット**にまとめる（`season--spring-early` /
+`spring-late` / `summer-early` / `summer-peak` / `autumn-early` / `autumn-late` /
+`winter-early` / `winter-deep`）。各パレットは **theme スケール（`--color-theme-*`）のみ**を
+override し、allowlist は `['--color-theme-*']`。
+
+> ⚠️ 実装粒度は **24 ではなく 8**。24節気はネーミング／期間区切りの発想源であり、
+> 出荷しているパレット数は 8。
+
+Special は specificity（`:root[data-theme=…]` = (0,2,0)）で Mode に勝つため、ロード順ではなく
+カスケードで合成される。solid ファミリーは Mode が rung を選び Special が ramp を供給する
+（[2026-06-solid-theme-rung.md](2026-06-solid-theme-rung.md)、#150）。
+
+## Rationale
+
+- **Mode / Special を分けた理由:** 「シェードを light/dark で反転するもの」は Mode、
+  「ブランド性を表現するもの」は Special、と所有を明確化。Special が Mode 所有トークン
+  （surface / foreground / disabled / `info-*`）を触るのは誤分類。
+- **累積 Special（家族ごとに別 DOM 属性）を却下:** カスケードのタイブレーク・allowlist の交差・
+  複数属性の同期という組合せコストが、想定ユースケースに見合わない。Special は単一 `data-theme`・排他。
+- **24 → 8 に丸めた理由:** 24 パレットは a11y 検証（各 Special × Mode）の行数を過剰に増やす。
+  8 で季節感を表現でき、全 ramp が共通の明度ラダーを共有するので solid 上の fg コントラストが
+  構造的に安定する。
+
+## Consequences
+
+- (+) コンポーネントは semantic トークン（`bg-theme-500` 等）を参照するだけで、どの軸が
+  効いているか知らなくてよい。SSR も `data-theme` 属性で hydration mismatch なし。
+- (+) `info-*` は blue 固定で季節に引きずられない（[state-token-guideline.md](../../.claude/rules/state-token-guideline.md)）。
+- (−) 各 Special は両 Mode で可読性を要検証（8 × 2 = 16 通り）。16-pattern audit story は v0.7.0。
+- (−) Special が全 11 rung（50–950）を宣言しないと solid 上で季節色と alabaster が混ざる。
+
+## Review
+
+- 2026-03 — Mode × Special 二軸を採用、季節を Special として持つ（遡及記録）。
+- #150 — solid を theme ramp の rung 参照に変更、季節が solid も recolor するようになった。

--- a/docs/decisions/ADR-0009-no-polymorphic-as.md
+++ b/docs/decisions/ADR-0009-no-polymorphic-as.md
@@ -1,0 +1,58 @@
+# ADR-0009: 汎用 Polymorphic API（`as` prop）は不採用（`Text` のみ carved exception）
+
+- **Status**: Accepted
+- **Date**: 2026-03 起点 / v0.11.0（`Text` の `asChild` 撤去、`as` + `textVariants()` に集約）
+- **Related**: [#192](https://github.com/yasmro/schatten/issues/192)（asChild adoption criteria） /
+  [component-architecture.md](../../.claude/rules/component-architecture.md) §4,
+  [component-api-conventions.md](../../.claude/rules/component-api-conventions.md)（asChild vs `*Variants()`）,
+  [ADR-0001](ADR-0001-shadcn-base.md)
+
+## Context
+
+「Button を `<a>` として描きたい」「Text を `<h2>` にしたい」といった多態ニーズがある。
+汎用 polymorphic（`<Button as="a" href=…>`、`as: ElementType`）はこれを一発で解くが、
+型推論に重いジェネリック（`ElementType` + `PolymorphicComponentProp`）が要り、`forwardRef` と
+競合し、大規模消費者アプリでエディタ性能を劣化させる。
+
+## Decision
+
+**汎用 polymorphic `as` は採らない**（shadcn / Radix と同じ方針、
+[component-architecture.md](../../.claude/rules/component-architecture.md) §4）。代替は
+**CVA variants 関数のエクスポート**: `buttonVariants()` / `textVariants()` を
+`@yasmro/schatten/variants` から公開し、消費者が自分の要素に適用する。
+
+```tsx
+<a href="/docs" className={buttonVariants({ variant: 'primary' })}>Docs</a>
+```
+
+> ⚠️ **carved exception — `Text` は `as` を持つ。** `as?: 'p' | 'span' | 'h1'..'h6'` の
+> **閉じた列挙**（`ElementType` ではない union）。8 タグは同じ属性面・同じ DOM role（テキスト
+> コンテナ）を共有し、推論コストがゼロ。原則「不採用」＋「Text 例外」が正確な記述。
+
+`asChild`（Radix Slot）とは役割が違う: `*Variants()` は**クラス文字列だけ**を渡す
+（見た目だけ欲しい時）。`asChild` は className + props/ref を子に転送する（要素を button として
+「振る舞わせたい」時）。新 lv1 は既定で `asChild` を付けない（[component-api-conventions.md](../../.claude/rules/component-api-conventions.md)）。
+
+## Rationale
+
+- **汎用 polymorphic を却下した理由:** 型推論コストと `forwardRef` 競合、エディタ性能劣化。
+  `*Variants()` で同じユースケース（framework `<Link>` を含む）を、消費者の要素を完全に型付けした
+  まま解ける。
+- **`Text` を例外にできる理由:** 8 タグは属性面と役割が同一で union が小さい（≤8）ため推論コスト
+  ゼロ。`Button → a` は role（interactive → navigation）と必須属性（`type` → `href`）が変わり、
+  まさに polymorphic 型が narrow に苦しむ形 → `buttonVariants` に委ねる。
+
+## Consequences
+
+- (+) 公開型面が軽く、`forwardRef` と素直に両立。消費者の要素は native 型を保つ。
+- (+) framework `<Link>`（Next / Router / Remix）にそのまま `className` を渡せる。
+- (−) 「見た目だけ欲しい」と「button として振る舞わせたい」で `*Variants()` / `asChild` を
+  使い分ける必要がある（[component-api-conventions.md](../../.claude/rules/component-api-conventions.md)
+  に決定表）。
+- **判断の目安:** `as` が `ElementType` を受けるなら拒否。閉じた同族タグ集合（≤8、属性面共通）なら
+  可、ただし PR で正当化。
+
+## Review
+
+- 2026-03 — 汎用 polymorphic 不採用（遡及記録）。
+- v0.11.0 — `Text` の `asChild` を撤去し `as`（閉じた enum）+ `textVariants()` に集約。

--- a/docs/decisions/ADR-0010-no-layout-primitives.md
+++ b/docs/decisions/ADR-0010-no-layout-primitives.md
@@ -1,0 +1,55 @@
+# ADR-0010: Layout primitives（Stack / Box / Grid / Flex）は提供しない
+
+- **Status**: Accepted
+- **Date**: 2026-03（採用。遡及記録）
+- **Related**: #158（本 ADR 群） /
+  [css-api.md](../../.claude/rules/css-api.md)（`@layer` order — `utilities` は空・消費者用に予約）,
+  [component-architecture.md](../../.claude/rules/component-architecture.md) §7（lv1-local CSS: layout は Tailwind）,
+  [ADR-0003](ADR-0003-framework-agnostic.md), [ADR-0009](ADR-0009-no-polymorphic-as.md)
+
+## Context
+
+多くの DS は `<Stack>` / `<Box>` / `<Grid>` / `<Flex>` といった layout primitive を持つ。
+Schatten でもこれらを足すか検討したが、レイアウトは「見た目の chrome」ではなく「配置の関心」で、
+消費者が自分のグリッド／間隔システムを持っていることが多い。Schatten が layout primitive を
+出すと、その意見を消費者に押し付けることになる。
+
+## Decision
+
+**layout primitive は提供しない。** レイアウトは消費者の責務とし、Schatten は:
+
+- **コンポーネントの chrome（色・タイポ・state・アニメ）と design token**（`--spacing-*` /
+  `--radius-*` / `--z-*` …）だけを出荷する。
+- CSS の `@layer` は `theme, base, reset, tokens, components, utilities` で、**`utilities` 層は
+  既定で空**にして**消費者が自前の Tailwind ユーティリティを載せる場所として予約**する
+  （[css-api.md](../../.claude/rules/css-api.md)）。消費者のユーティリティは最後の層なので
+  `components` に勝つ。
+- Storybook のレイアウト足場は Tailwind ユーティリティ（`flex` / `gap-4` …）で組む（dev-only）。
+  component `.css` でも layout は Tailwind に委ね、lv1-local CSS には書かない
+  （[component-architecture.md](../../.claude/rules/component-architecture.md) §7）。
+
+## Rationale
+
+- **検討した他案:**
+  - **Stack / Box / Grid / Flex を lv1 として追加** — Tailwind の layout ユーティリティと
+    正面衝突し、公開面（props / `.st-*` クラス / manifest）を膨らませる。消費者が自前の
+    layout システムを持つ場合は不要な意見の押し付け。棄却。
+  - **CSS だけの layout ユーティリティ（`.st-stack` 等）を出荷** — `utilities` 層を Schatten が
+    埋めると、消費者が同層で上書きする余地（framework-agnostic の設計）を奪う。棄却。
+- **不採用を選んだ決め手:** [ADR-0009](ADR-0009-no-polymorphic-as.md) と同じ思想 — Schatten は
+  shadcn ベースの**コンポーネント** DS であり、layout / utility フレームワークではない。
+  レイアウトは Tailwind（または消費者自身の CSS）に委ね、Schatten は token + component 契約に集中する。
+
+## Consequences
+
+- (+) 公開面が小さく保たれ、Tailwind の layout ユーティリティと競合しない。
+- (+) `utilities` 層が空のまま予約され、消費者が自前ユーティリティで `components` を上書きできる。
+- (−) 「Schatten だけで完結するレイアウト」は提供されない。消費者は Tailwind か自前 CSS で配置する。
+- **将来:** もし lv0（foundation）や lv2 で layout 合成の実需が出たら、本 ADR を新採番で supersede
+  して再検討する（[component-architecture.md](../../.claude/rules/component-architecture.md) §1）。
+
+## Review
+
+- 2026-03 — layout primitive 不採用を採用（遡及記録）。
+- ⚠️ **一次判断の出典が薄い ADR。** 対応する `.claude/rules/` の明示ルールは無く、本 ADR が
+  唯一の記録。棄却理由の一次資料（評価レポート §1.6 等）が判明したら Rationale を補強する。

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -4,6 +4,37 @@ Schatten's `.claude/rules/` codifies *what is true*. This directory captures
 *why we chose it* — the trade-off analysis, the alternatives considered, the
 context that the codebase and git history alone do not preserve.
 
+## Two entry types
+
+This directory holds **two families of record**, distinguished by filename:
+
+| Family | Naming | Scope | Change frequency |
+|---|---|---|---|
+| **Foundational ADR** | `ADR-NNNN-<slug>.md` (4-digit, zero-padded) | The small set of project-shaping architecture decisions — adopted tech, distribution model, layer structure. | Rarely change. To reverse one, write a **new** ADR that supersedes it and set the old one's `Status` to `Superseded by ADR-00XX`. |
+| **Incremental log** | `YYYY-MM-<slug>.md` | Implementation-level trade-offs — a token shape, a single variant decision, a build tweak. | Added as work happens. |
+
+Both use the same [format](#format) and both are the *why* counterpart to a
+`.claude/rules/` *what*. The only difference is the naming and the durability:
+foundational ADRs are numbered and near-permanent; incremental logs are dated
+and accrete over time. (An ADR is just a decision log that earned a stable
+number because the whole project leans on it — CONTRIBUTING.md treats
+"decision log" and "ADR" as the same mechanism.)
+
+### Foundational ADR index
+
+| # | Decision | Rule it explains |
+|---|---|---|
+| [ADR-0001](ADR-0001-shadcn-base.md) | shadcn/ui をベースに採用 | component-architecture |
+| [ADR-0002](ADR-0002-npm-distribution.md) | npm パッケージ配布（copy-in ではなく） | api-stability |
+| [ADR-0003](ADR-0003-framework-agnostic.md) | Framework-Agnostic 二層 DS | css-api |
+| [ADR-0004](ADR-0004-tailwind-v4-cva.md) | Tailwind CSS v4 + CVA（dist は後に脱 Tailwind） | css-api / theme-architecture |
+| [ADR-0005](ADR-0005-radix-primitives.md) | Radix UI primitives（型は非継承） | component-architecture / api-stability |
+| [ADR-0006](ADR-0006-variant-vocabulary.md) | Variant 語彙統一（Pattern A / B） | component-api-conventions |
+| [ADR-0007](ADR-0007-lv1-lv2-layering.md) | lv1 / lv2 二層構造 | component-architecture |
+| [ADR-0008](ADR-0008-seasonal-theme.md) | 季節テーマ（Special 軸・8 パレット） | theme-architecture |
+| [ADR-0009](ADR-0009-no-polymorphic-as.md) | Polymorphic `as` 不採用（Text 例外） | component-architecture |
+| [ADR-0010](ADR-0010-no-layout-primitives.md) | Layout primitives 不採用 | css-api |
+
 ## When to add an entry
 
 Add a decision log when a change involves a non-obvious choice that future
@@ -28,7 +59,8 @@ Skip an entry when:
 ## Format
 
 ```
-docs/decisions/YYYY-MM-<kebab-slug>.md
+docs/decisions/YYYY-MM-<kebab-slug>.md   # incremental log
+docs/decisions/ADR-NNNN-<kebab-slug>.md  # foundational ADR (numbered)
 ```
 
 Each entry should include, at minimum:


### PR DESCRIPTION
## 概要

主要な設計判断を Architecture Decision Record (ADR) として記録する (#158)。

**当初案の `docs/adr/` 新設は既存 [`docs/decisions/`](../blob/develop/docs/decisions/README.md) と目的が重複する**ため、`docs/decisions/` に採番付きサブシリーズ (`ADR-NNNN-<slug>.md`) として統合した。CONTRIBUTING.md は既に「decision log = ADR」として `docs/decisions/` を指しており (#159 / #467)、既存 6 本の決定ログと inbound リンクも壊さない。

## 変更

- **新規 ADR-0001〜0010** (Status=Accepted、本文日本語): shadcn ベース / npm 配布 / framework-agnostic / Tailwind+CVA / Radix / variant 語彙 / lv1-lv2 / 季節テーマ / polymorphic 不採用 / layout primitives 不採用
- **`docs/decisions/README.md`**: 「2 系統 (採番 ADR / 日付ログ)」節 + 基盤 ADR インデックス表 + Format に ADR 命名を追記
- **`README.md`**: Contributing 節から decision log へリンク

## 起草時からの stale 是正

- **ADR-0004**: #317 で dist は脱 Tailwind (lightningcss)、Tailwind は dev/Storybook 専用 → 採用の後日談として併記
- **ADR-0006**: 「color tone × appearance」は Pattern B のみ → Pattern A (Button 単軸) も併記
- **ADR-0008**: 「24節気」→ 実装は 8 パレット (着想元が 24節気) と明記
- **ADR-0009**: `Text` の `as` は採用済み carved exception と明記
- **Status**: 全て Accepted (issue の Proposed は不適・全て出荷済み)
- **DoD「CONTRIBUTING に ADR 運用ルール追記」**: #159/#467 で達成済み → 追記不要

## 検証

- `pnpm check:doc-links` **green** (273 links / 23 files) — 本 issue 最重要ゲート
- changeset: `patch` を追加 (`.changeset/adr-directory-158.md`) — この repo は docs 変更も changeset gate 対象
- ⚠️ `pnpm lint` (Biome) は worktree の `node_modules` 未インストールで未実行。変更は Markdown のみ (Biome は `.md` 内容を実質 lint しない)。CI 環境で最終確認される想定

## 残る open question (ADR 本文にも記載)

- ADR-0010「layout primitives 不採用」の一次出典が薄い (対応 rule 無し・本 ADR が唯一の記録)。`評価レポート §1.6` 等が判明すれば Rationale を補強

🤖 Generated with [Claude Code](https://claude.com/claude-code)