### PR TITLE
docs(readme): clarify vanilla-CSS scope + drop stale v0.8.0 constraints

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,15 @@ no build step required.**
 <button class="st-btn st-btn--primary">Click me</button>
 ```
 
+> **Scope note:** the stylesheet ships every lv1 component's *visual*
+> classes, but it cannot ship behavior. Static components (Button, Badge,
+> Callout, Table, …) and native form controls (Input, Checkbox, Switch, …)
+> work with CSS alone — the browser handles their state. Interactive
+> compound components — Dialog, DropdownMenu, Popover, Select, Tabs,
+> Toast, Tooltip (and Avatar's image→fallback swap) — render as static
+> markup only; opening, closing, positioning, and selection require the
+> React layer or your own JavaScript.
+
 ### React
 
 ```sh
@@ -651,18 +660,6 @@ import { Button } from '@yasmro/schatten'
 For static, non-interactive markup you can skip React entirely and apply the
 CVA variant classes to a plain element — see
 [Astro / Vue / Svelte](#astro--vue--svelte) under Quick start.
-
-### Known constraints (v0.8.0)
-
-- **Class-based (no-React) usage is limited.** The `.st-*` component
-  classes (`.st-btn`, `.st-input`, …) do not exist yet, so vanilla HTML
-  and Astro cannot style components by class name alone. Use the exported
-  `buttonVariants()` / `inputVariants()` … bridge in the meantime. Full
-  class API (per [css-api.md](.claude/rules/css-api.md)) lands in
-  **v0.9.0** ([#58](https://github.com/yasmro/schatten/issues/58) /
-  [#154](https://github.com/yasmro/schatten/issues/154)).
-- **`ThemeProvider` / FOUC snippet are not available yet** — both arrive in
-  **v0.9.0** (see the two sections above).
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -40,13 +40,42 @@ no build step required.**
 ```
 
 > **Scope note:** the stylesheet ships every lv1 component's *visual*
-> classes, but it cannot ship behavior. Static components (Button, Badge,
-> Callout, Table, …) and native form controls (Input, Checkbox, Switch, …)
-> work with CSS alone — the browser handles their state. Interactive
-> compound components — Dialog, DropdownMenu, Popover, Select, Tabs,
-> Toast, Tooltip (and Avatar's image→fallback swap) — render as static
-> markup only; opening, closing, positioning, and selection require the
-> React layer or your own JavaScript.
+> classes, but it cannot ship behavior. In the matrix below, ✅ means the
+> component works with CSS alone (static rendering, or the browser
+> handles its state natively); ⚠️ means only the visual classes ship —
+> the interactive behavior (opening, closing, positioning, selection;
+> Avatar's image→fallback swap) requires the React layer or your own
+> JavaScript.
+
+<!-- generated:lv1-support-matrix:start -->
+| Component | React | HTML + CSS only |
+| --- | :-: | :-: |
+| `Avatar` | ✅ | ⚠️ |
+| `Badge` | ✅ | ✅ |
+| `Button` | ✅ | ✅ |
+| `Callout` | ✅ | ✅ |
+| `Card` | ✅ | ✅ |
+| `Checkbox` | ✅ | ✅ |
+| `Dialog` | ✅ | ⚠️ |
+| `DropdownMenu` | ✅ | ⚠️ |
+| `Field` | ✅ | ✅ |
+| `FieldSet` | ✅ | ✅ |
+| `Icon` | ✅ | ✅ |
+| `Input` | ✅ | ✅ |
+| `Popover` | ✅ | ⚠️ |
+| `Radio` | ✅ | ✅ |
+| `Select` | ✅ | ⚠️ |
+| `Separator` | ✅ | ✅ |
+| `Skeleton` | ✅ | ✅ |
+| `Spinner` | ✅ | ✅ |
+| `Switch` | ✅ | ✅ |
+| `Table` | ✅ | ✅ |
+| `Tabs` | ✅ | ⚠️ |
+| `Text` | ✅ | ✅ |
+| `Textarea` | ✅ | ✅ |
+| `Toast` | ✅ | ⚠️ |
+| `Tooltip` | ✅ | ⚠️ |
+<!-- generated:lv1-support-matrix:end -->
 
 ### React
 

--- a/scripts/sync-readme-components.mjs
+++ b/scripts/sync-readme-components.mjs
@@ -1,59 +1,67 @@
 #!/usr/bin/env node
-// Sync the README's "Available components" list against the actual set of
-// lv1 components on disk.
+// Sync the README's generated lv1 blocks against the actual set of lv1
+// components on disk.
 //
 // Why this script exists:
 //
 // The Per-component CSS section in README.md lists every lv1 subpath
-// (`badge` · `button` · … · `tooltip`). The list is consumer-facing — it
-// is the answer to "which components can I import from
-// `@yasmro/schatten/css/<x>`?". When a new lv1 lands, the package.json
-// `./css/*` wildcard exposes it automatically, but the README sentence
-// does not — leading to silent "subpath ships but README doesn't mention
-// it" drift. This script makes the README a derived artifact instead.
+// (`badge` · `button` · … · `tooltip`), and the Quick start §Vanilla HTML
+// section carries a per-component support matrix (React vs HTML+CSS-only).
+// Both are consumer-facing — the answers to "which components can I import
+// from `@yasmro/schatten/css/<x>`?" and "which components work without
+// React?". When a new lv1 lands, the package.json `./css/*` wildcard
+// exposes it automatically, but the README does not — leading to silent
+// drift. This script makes both blocks derived artifacts instead.
 //
 // Source of truth:
 //   - lv1 component directories under `src/components/lv1/`
 //   - filter: must contain `<Name>.tsx` AND `<Name>.css`
 //     (matches `build-component-css.mjs`'s contract)
 //   - slug: lowercased `<Name>` (matches the `.st-<block>` convention)
+//   - HTML+CSS-only column: `PARITY_EXEMPT` from audit-coverage.mjs — the
+//     区分 C/D set (vrt-spec-guideline §Parity stories). Exempt = the CSS
+//     ships visual classes only; behavior needs React or BYO-JS.
 //
-// Markers in README:
-//   <!-- generated:lv1-components:start -->
-//   `badge` · `button` · ... · `tooltip`
-//   <!-- generated:lv1-components:end -->
+// Markers in README (each block is regenerated between its pair):
+//   <!-- generated:lv1-components:start --> … <!-- generated:lv1-components:end -->
+//   <!-- generated:lv1-support-matrix:start --> … <!-- generated:lv1-support-matrix:end -->
 //
 // Modes:
-//   default        write the regenerated list into README.md (idempotent)
+//   default        write the regenerated blocks into README.md (idempotent)
 //   --check        compare without writing; exit 1 if drift; print the
 //                  diff so CI fails with an actionable message. Same shape
 //                  as `check-manifest-diff.mjs`.
 
 import { existsSync, readFileSync, readdirSync, statSync, writeFileSync } from 'node:fs'
 import { join } from 'node:path'
+import { PARITY_EXEMPT } from './audit-coverage.mjs'
 
 const LV1_DIR = 'src/components/lv1'
 const README_PATH = 'README.md'
-const MARKER_START = '<!-- generated:lv1-components:start -->'
-const MARKER_END = '<!-- generated:lv1-components:end -->'
 
-function discoverSlugs() {
+function discoverNames() {
   if (!existsSync(LV1_DIR)) {
     throw new Error(`sync-readme-components: lv1 directory "${LV1_DIR}" not found`)
   }
-  const slugs = []
+  const names = []
   for (const name of readdirSync(LV1_DIR)) {
     const dir = join(LV1_DIR, name)
     if (!statSync(dir).isDirectory()) continue
     const tsxFile = join(dir, `${name}.tsx`)
     const cssFile = join(dir, `${name}.css`)
     if (!existsSync(tsxFile) || !existsSync(cssFile)) continue
-    slugs.push(name.toLowerCase())
+    names.push(name)
   }
-  if (slugs.length === 0) {
+  if (names.length === 0) {
     throw new Error(`sync-readme-components: no lv1 components discovered under "${LV1_DIR}"`)
   }
-  return slugs.sort()
+  return names.sort()
+}
+
+function discoverSlugs() {
+  return discoverNames()
+    .map((n) => n.toLowerCase())
+    .sort()
 }
 
 function renderBlock(slugs) {
@@ -78,47 +86,79 @@ function renderBlock(slugs) {
   return lines.join('\n')
 }
 
+function renderMatrix(names) {
+  // Per-component support matrix (Quick start §Vanilla HTML). The
+  // HTML+CSS-only column derives from PARITY_EXEMPT (区分 C/D): those
+  // components ship visual classes only — behavior needs React / BYO-JS.
+  const lines = ['| Component | React | HTML + CSS only |', '| --- | :-: | :-: |']
+  for (const name of names) {
+    const cssOnly = PARITY_EXEMPT.has(name) ? '⚠️' : '✅'
+    lines.push(`| \`${name}\` | ✅ | ${cssOnly} |`)
+  }
+  return lines.join('\n')
+}
+
+// Each generated README block: marker pair + its renderer.
+const BLOCKS = [
+  {
+    label: 'Available components',
+    start: '<!-- generated:lv1-components:start -->',
+    end: '<!-- generated:lv1-components:end -->',
+    render: () => renderBlock(discoverSlugs()),
+  },
+  {
+    label: 'Support matrix',
+    start: '<!-- generated:lv1-support-matrix:start -->',
+    end: '<!-- generated:lv1-support-matrix:end -->',
+    render: () => renderMatrix(discoverNames()),
+  },
+]
+
 function rewriteReadme({ check }) {
   if (!existsSync(README_PATH)) {
     throw new Error(`sync-readme-components: ${README_PATH} not found`)
   }
   const source = readFileSync(README_PATH, 'utf8')
-  const startIdx = source.indexOf(MARKER_START)
-  const endIdx = source.indexOf(MARKER_END)
-  if (startIdx === -1 || endIdx === -1 || endIdx < startIdx) {
-    throw new Error(
-      `sync-readme-components: ${README_PATH} is missing the marker pair ` +
-        `(${MARKER_START} ... ${MARKER_END}). Wrap the "Available components" ` +
-        'line with the markers before running this script.',
-    )
+  let next = source
+  const drifted = []
+
+  for (const block of BLOCKS) {
+    const startIdx = next.indexOf(block.start)
+    const endIdx = next.indexOf(block.end)
+    if (startIdx === -1 || endIdx === -1 || endIdx < startIdx) {
+      throw new Error(
+        `sync-readme-components: ${README_PATH} is missing the marker pair ` +
+          `(${block.start} ... ${block.end}). Wrap the "${block.label}" ` +
+          'block with the markers before running this script.',
+      )
+    }
+    // The block lives between the markers on dedicated lines so the
+    // rendered Markdown is well-formed.
+    const replacement = `${block.start}\n${block.render()}\n${block.end}`
+    const current = next.slice(startIdx, endIdx + block.end.length)
+    if (current !== replacement) drifted.push({ block, current, replacement })
+    next = next.slice(0, startIdx) + replacement + next.slice(endIdx + block.end.length)
   }
 
-  const slugs = discoverSlugs()
-  const block = renderBlock(slugs)
-  // The block lives between the markers on dedicated lines, with leading
-  // newlines so the rendered Markdown is well-formed.
-  const replacement = `${MARKER_START}\n${block}\n${MARKER_END}`
-  const next =
-    source.slice(0, startIdx) + replacement + source.slice(endIdx + MARKER_END.length)
-
+  const count = discoverNames().length
   if (next === source) {
-    console.log(`✓ README ${check ? '(check) ' : ''}in sync (${slugs.length} components)`)
+    console.log(`✓ README ${check ? '(check) ' : ''}in sync (${count} components)`)
     return
   }
 
   if (check) {
-    const oldBlock = source.slice(startIdx, endIdx + MARKER_END.length)
-    const newBlock = replacement
-    console.error(`✗ README "Available components" drift detected — run \`pnpm sync:readme\``)
-    console.error('--- current (in README.md) ---')
-    console.error(oldBlock)
-    console.error('--- expected (from src/components/lv1/) ---')
-    console.error(newBlock)
+    for (const { block, current, replacement } of drifted) {
+      console.error(`✗ README "${block.label}" drift detected — run \`pnpm sync:readme\``)
+      console.error('--- current (in README.md) ---')
+      console.error(current)
+      console.error('--- expected (from src/components/lv1/) ---')
+      console.error(replacement)
+    }
     process.exit(1)
   }
 
   writeFileSync(README_PATH, next)
-  console.log(`✓ README rewritten (${slugs.length} components)`)
+  console.log(`✓ README rewritten (${count} components)`)
 }
 
 const args = process.argv.slice(2)


### PR DESCRIPTION
## Summary

README-only + sync-script fixes, feeding the v1.0.0 release (#480):

1. **Quick start §Vanilla HTML — scope note added.** The section read as "every lv1 works with one `<link>`, no JavaScript runtime", which over-promises for the JS-driven compound components. The note now states the split and explains the ✅/⚠️ legend of the new matrix below it. This is the minimal "1-line nuance" #297 scoped for the v0.9.0 window that never landed.
2. **Per-component support matrix (React vs HTML + CSS only), machine-synced.** `sync-readme-components.mjs` now generates a second README block between `generated:lv1-support-matrix` markers. The HTML+CSS-only column derives from `PARITY_EXEMPT` (`audit-coverage.mjs`, the 区分 C/D set — itself pinned by `audit-coverage.test.ts`), and rows come from lv1 directory discovery — so the matrix cannot drift: a new lv1 without `pnpm sync:readme` fails the existing `check:readme` CI gate, same contract as the 'Available components' block.
3. **Removed the stale "Known constraints (v0.8.0)" section**, which still claimed the `.st-*` class API and ThemeProvider / FOUC snippet "do not exist yet" — contradicting the rest of the README since v0.9.0 shipped both.

The full #297 deliverable (css-api.md 区分 table + `examples/vanilla-html/` + Getting Started rewrite) stays deferred / non-blocking for v1.0.0 — this PR fixes the actively-misleading claims and ships the evaluator-facing matrix before the API-stability commitment goes live.

## Checks

- `pnpm sync:readme` → `pnpm check:readme` ✅ (25 components, both blocks in sync)
- `pnpm check:doc-links` ✅ (272 links)
- Biome ignores `scripts/*.mjs` (no lint surface); no `.d.mts` needed (no typed consumer imports the sync script)
- docs + dev-tooling only → no changeset

Refs #297 / #480

🤖 Generated with [Claude Code](https://claude.com/claude-code)