### PR TITLE
chore(docs): CDN 経由 framework-agnostic スモーク実施を記録 (closes #468)

### DIFF
--- a/docs/verification/framework-agnostic.md
+++ b/docs/verification/framework-agnostic.md
@@ -127,5 +127,7 @@ ad-hoc 検証（spec はコミットしない）— で確認。**計測値は�
 
 ## TODO
 
-- [ ] （後続 [#160](https://github.com/yasmro/schatten/issues/160)）この記録の
-  スクリーンショット + コードサンプルを公開 Storybook ページへ反映。
+- [ ] （後続 [#483](https://github.com/yasmro/schatten/issues/483)）この記録の
+  スクリーンショット + コードサンプル（CDN スモーク含む）を公開 Storybook
+  ページへ反映。旧参照先の #160 は本反映をスコープに含まないまま closed
+  だったため、#483 へ張り替え。

--- a/docs/verification/framework-agnostic.md
+++ b/docs/verification/framework-agnostic.md
@@ -16,16 +16,17 @@ Schatten の framework-agnostic (CSS class API) surface が Vanilla HTML / Astro
 | 環境 | 手段 | schatten の入り方 |
 |---|---|---|
 | Vanilla HTML | Playwright Chromium で `file://.../examples/vanilla-html/index.html` を開き、computed style を assert + スクリーンショット | `../../dist/schatten.css` を相対 `<link>`（ローカル dist 版） |
+| Vanilla HTML（CDN） | 同上（`<link>` を CDN へ一時反転、[#468](https://github.com/yasmro/schatten/issues/468)） | `https://cdn.jsdelivr.net/npm/@yasmro/schatten@0.15.0/dist/schatten.css`（`@0.15.0` ピン留め） |
 | Astro | `pnpm install --ignore-workspace && pnpm build`（Astro 5 + @astrojs/react 4 + React 19） | `import '@yasmro/schatten/schatten.css'`、`@yasmro/schatten` は `file:../..` |
 | Vue | `pnpm install --ignore-workspace && pnpm build`（Vue 3.5 + Vite 7） | `import '@yasmro/schatten/schatten.css'`、`@yasmro/schatten` は `file:../..` |
 
-CDN 版（`cdn.jsdelivr.net/npm/@yasmro/schatten/dist/schatten.css`）は publish
-後のみ叩けるため、pre-1.0 の本記録はローカル dist 版で成立させている。CDN 版の
-スモークは 1.0 publish 直後（下記 TODO）。
+CDN 版は lightningcss 産 dist が npm に載った最初のリリース（v0.15.0、
+2026-07-13 publish）に対して 2026-07-15 にスモーク済み — 下記
+「[CDN スモーク（jsdelivr）](#cdn-スモーク（jsdelivr）--468)」。
 
 ## チェック項目 × 環境
 
-✅ 実測で確認 / ⚠️ 区分 C/D の想定通りの制限（不具合ではない）/ 🕓 publish 後
+✅ 実測で確認 / ⚠️ 区分 C/D の想定通りの制限（不具合ではない）
 
 | チェック項目 | Vanilla | Astro | Vue | 根拠 |
 |---|:--:|:--:|:--:|---|
@@ -81,10 +82,50 @@ class + HTML/ARIA 属性だけで成立し、React 側と parity VRT でピク�
 - 区分 C/D は vanilla では role/focus/live-region が欠ける（例: `.st-toast` は
   Sonner の live region がないと読み上げされない）。
 
-## TODO（1.0 publish 後）
+## CDN スモーク（jsdelivr） — #468
 
-- [ ] `examples/vanilla-html/index.html` の CDN `<link>` を有効化し、
-  `cdn.jsdelivr.net/npm/@yasmro/schatten/dist/schatten.css` を実ブラウザで
-  スモーク。この表の各行を CDN 版でも ✅ 化。→ [#468](https://github.com/yasmro/schatten/issues/468) で追跡。
+**配信経路（npm tarball → jsdelivr）のスモーク**。コンポーネントの見た目契約
+自体は上記ローカル dist 版で実測済みのため、検証対象は配信経路のみに閉じる。
+v0.15.0（lightningcss 産 dist が npm に載った最初のリリース、2026-07-13
+publish）に対して **2026-07-15 実施**。
+
+### Phase 1 — 機械的確認（curl）
+
+| # | 確認 | 結果 |
+|---|---|---|
+| 1 | `@0.15.0` ピン留め URL が 200 + `text/css` | ✅ `HTTP/2 200`、`content-type: text/css; charset=utf-8` |
+| 2 | CDN のバイト列 == npm tarball のバイト列 | ✅ `cmp` 差分ゼロ（77,259 bytes） |
+| 3 | バージョン省略 URL の解決先（data.jsdelivr.com resolved API） | ✅ `"version": "0.15.0"` |
+| 4 | per-component subpath（`dist/css/button.css` / `dist/core/tokens/index.css` / `dist/themes/default/index.css`） | ✅ 3 本すべて 200 + `text/css` |
+
+### Phase 2 — 実ブラウザスモーク（7 項目）
+
+`examples/vanilla-html/index.html` の `<link>` を `@0.15.0` ピン留めの CDN URL
+へ**一時反転**し（コミットする既定状態はローカル dist 有効のまま）、#466 と同じ
+方法 — Playwright Chromium で `file://` を開き computed style を assert する
+ad-hoc 検証（spec はコミットしない）— で確認。**計測値はローカル dist 版の記録
+と完全一致**（Phase 1 手順 2 のバイト一致の帰結）。
+
+| チェック項目 | 結果 | 計測値 |
+|---|---|---|
+| CSS rule 適用（`@layer` 順が配信後も正しい — #277 型の事故検出） | ✅ | `.st-btn--primary` の `background-color` = `oklch(0.37 0.01 70)`（非透明） |
+| light/dark（`.dark` トグル） | ✅ | body bg `rgb(245, 243, 240)` → `rgb(30, 30, 28)` |
+| seasonal（`data-theme="season--spring-early"`） | ✅ | `--color-theme-500` が `oklch(58% .01 70)` → `oklch(64% .1 12)` にシフト |
+| hover / focus-visible ring | ✅ | hover で primary bg シフト、キーボード focus で 2px + 4px の ring（box-shadow） |
+| disabled | ✅ | bg == `--color-surface-disabled`（`oklch(0.96 0 0)`） |
+| form error（`aria-invalid="true"` 経由でのみ発火、class 単体不可） | ✅ | error border `oklch(0.56 0.17 22)`、属性なしの同 class は `oklch(0.18 0.01 250)` |
+| Spinner animation（純 CSS） | ✅ | `animation: schatten-spin 1s` |
+
+スクリーンショットは追加コミットしない — Phase 1 のバイト一致でローカル dist 版
+（上記 `screenshots/vanilla-*.png`）と同一描画が証明されるため、記録はこの結果表
+で足りる（#468 refinement で決定）。
+
+**1.0.0 publish 時の再確認**は Phase 1（curl 4 点）のみ再実行すれば足りる —
+[#480](https://github.com/yasmro/schatten/issues/480) の「publish 後」節に
+チェックボックス設置済み。#479（ESM-only 化）は JS エントリのみで CSS の dist
+パスに触れないため、本記録は 1.0.0 でも配信経路の証明として有効。
+
+## TODO
+
 - [ ] （後続 [#160](https://github.com/yasmro/schatten/issues/160)）この記録の
   スクリーンショット + コードサンプルを公開 Storybook ページへ反映。

--- a/examples/vanilla-html/README.md
+++ b/examples/vanilla-html/README.md
@@ -28,9 +28,13 @@ open index.html         # macOS  (or: xdg-open / just double-click)
 ## CDN vs local dist
 
 The `<head>` carries both `<link>` options (local dist active, CDN commented).
-The local path is the pre-1.0 verification gate; swap to the CDN `<link>` to
-smoke-test the published package after the 1.0 release. Only the `<link>`
-differs — the markup body is identical, so there is no drift.
+The local path stays the default — this harness verifies *unreleased* dist
+changes, which a CDN default would mask behind the published CSS. The CDN
+path was smoke-tested against `@0.15.0` (jsdelivr delivery path, byte-identical
+to the npm tarball) — see
+[docs/verification/framework-agnostic.md](../../docs/verification/framework-agnostic.md)
+(#468). Only the `<link>` differs — the markup body is identical, so there is
+no drift.
 
 ## Consumer wires ARIA
 

--- a/examples/vanilla-html/index.html
+++ b/examples/vanilla-html/index.html
@@ -14,8 +14,9 @@
 
         2. CDN (COMMENTED below) — the published-package path. Uncomment it and
            comment out the local <link> to smoke-test the real jsdelivr URL
-           AFTER the package is published (planned: 1.0 publish). Do not enable
-           both at once.
+           (pin the version, e.g. @0.15.0). Smoke-tested against @0.15.0 — see
+           docs/verification/framework-agnostic.md (#468). Do not enable both
+           at once.
 
       Only the <link> differs between the two methods — the entire markup body
       is identical, so there is a single source of truth and no drift risk.


### PR DESCRIPTION
## What

v0.15.0 に対して jsdelivr 配信経路の framework-agnostic スモーク (#468) を実施し、
結果を docs/verification/framework-agnostic.md の「CDN スモーク（jsdelivr）」節として記録。
examples/vanilla-html の README / head コメントの「1.0 publish 後に」の stale 文言を
「スモーク済み」へ更新。`<link>` の既定はローカル dist のまま (ハーネスの用途を維持)。

## Why

#466 はローカル dist 版で見た目契約を実測済みだったが、npm tarball → jsdelivr の
配信経路は未検証だった。lightningcss 産 dist が npm に載った最初のリリース
(v0.15.0) に対して経路をスモークし、1.0 RC 前に配信パイプラインの問題がないことを
確認した (#277 型の @layer 事故検出を含む)。

- Phase 1: curl 4 点全合格 (CDN バイト列 == npm tarball、77,259 bytes 一致)
- Phase 2: 実ブラウザ 7 項目全合格 — 計測値はローカル dist 版の記録と完全一致

## Related rules

- .claude/rules/css-api.md (@layer 順 / attribute-driven state 契約)
- .claude/rules/theme-architecture.md (Mode × Special)
- .claude/rules/vrt-spec-guideline.md (ad-hoc 検証は spec 化しない判断の整合)

## Test plan

- [x] `pnpm lint` 緑
- [x] `pnpm check:doc-links` 緑 (新設アンカー含む 274 links)
- [x] `pnpm test --run` 緑 (1126 passed)
- [x] `pnpm typecheck` 緑
- [x] Phase 1 curl 4 点 / Phase 2 実ブラウザ 7 項目 (本 PR の実施内容そのもの)

closes #468

🤖 Generated with [Claude Code](https://claude.com/claude-code)
