### PR TITLE
refactor(build): ESM-only 化 — CJS export (exports.require / main) を削除 (closes #479)

### DIFF
--- a/.changeset/esm-only-cjs-removal-e479.md
+++ b/.changeset/esm-only-cjs-removal-e479.md
@@ -8,6 +8,7 @@ BREAKING: The package is now ESM-only. Every `require` condition in
 fast with `ERR_PACKAGE_PATH_NOT_EXPORTED` instead of risking the
 dual-package hazard (the `Toast` store and `Field` / `FieldSet` / `Tooltip`
 Contexts fail silently when ESM and CJS module instances coexist; #208,
-#479). Supported consumers: Vite / Next.js 13+ / Remix / Astro / Node ESM.
-ESM consumers need no change. Migration:
+#479). Supported consumers: Vite / Next.js 13+ / Remix / Astro / Node ESM,
+now declared as `engines.node: ">=18"`. ESM consumers need no change.
+Migration:
 [docs/migrations/v0-to-v1.md §12](https://github.com/yasmro/schatten/blob/main/docs/migrations/v0-to-v1.md#12-esm-only--the-cjs-build-is-removed--v100).

--- a/.changeset/esm-only-cjs-removal-e479.md
+++ b/.changeset/esm-only-cjs-removal-e479.md
@@ -1,0 +1,13 @@
+---
+'@yasmro/schatten': major
+---
+
+BREAKING: The package is now ESM-only. Every `require` condition in
+`package.json#exports`, the top-level `main` field, and all `dist/**/*.cjs`
+/ `*.d.cts` artifacts are removed — `require('@yasmro/schatten')` now fails
+fast with `ERR_PACKAGE_PATH_NOT_EXPORTED` instead of risking the
+dual-package hazard (the `Toast` store and `Field` / `FieldSet` / `Tooltip`
+Contexts fail silently when ESM and CJS module instances coexist; #208,
+#479). Supported consumers: Vite / Next.js 13+ / Remix / Astro / Node ESM.
+ESM consumers need no change. Migration:
+[docs/migrations/v0-to-v1.md §12](https://github.com/yasmro/schatten/blob/main/docs/migrations/v0-to-v1.md#12-esm-only--the-cjs-build-is-removed--v100).

--- a/.claude/rules/api-stability.md
+++ b/.claude/rules/api-stability.md
@@ -34,6 +34,7 @@ CHANGELOG:
 | CSS custom properties | `--color-primary-600`, `--color-error`, `--spacing-4`, `--font-sans` |
 | CVA output strings | The class string returned by `buttonVariants({ variant: 'primary' })` |
 | Multi-entry exports | `@yasmro/schatten/components/lv1`, `/tokens`, `/variants`, `/themes/default`, `/themes/seasonal`, `/providers` |
+| Module format | ESM-only — every JS entry in `exports` carries an `import` condition only (no `require`, no `default`). Adding CJS support back would be additive (`minor`); going ESM-only again after that, or narrowing the supported-consumer set, is breaking. See [Module format — ESM-only](#module-format--esm-only-since-v100). |
 | Theme contract | Which CSS variables a custom theme must define to be valid |
 | Provider runtime contract | The `localStorage` key (`'schatten-theme'`) and JSON shape (`{ mode, special }`) that `<ThemeProvider>` reads/writes. This is the contract the FOUC inline snippet ([#129](https://github.com/yasmro/schatten/issues/129)) and any consumer-side persistence code depends on. Renaming the key, adding/removing a field, or changing field semantics is a breaking change. |
 | FOUC snippet bytes | The exact byte sequence of `THEME_INIT_SCRIPT` (and the output of `buildThemeInitScript()`). Consumers paste its SHA-256 into a `script-src 'sha256-…'` CSP directive, so the bytes themselves are public surface. See [FOUC snippet byte stability](#fouc-snippet-byte-stability-theme_init_script) below. |
@@ -230,6 +231,46 @@ to a peer dep, the same rules apply.
 - **Bumping a tooling dep that affects output** (e.g. `class-variance-authority`
   in a way that changes the emitted class string) is covered separately by
   the "CVA output stability" section above and is a `major`.
+
+## Module format — ESM-only (since v1.0.0)
+
+The package ships **ESM only** ([#479](https://github.com/yasmro/schatten/issues/479),
+decided in [#208](https://github.com/yasmro/schatten/issues/208)). The CJS
+build (`exports.*.require`, the top-level `main`, every `dist/**/*.cjs` /
+`*.d.cts`) was removed in v1.0.0. The motivation is structural, not
+aesthetic: Schatten carries module-level state — the `Toast` store, the
+`Field` / `FieldSet` / `Tooltip` React Contexts — that **fails silently**
+when a consumer's tree loads two module instances (the classic dual-package
+hazard). With no CJS resolution path, the hazard cannot occur.
+
+**Supported consumers**: Vite, Next.js 13+, Remix, Astro, and Node ESM
+(`"type": "module"` or dynamic `import()`). Legacy CJS tooling (webpack 4,
+Jest without ESM support) is out of contract; the migration path is in
+[docs/migrations/v0-to-v1.md](../../docs/migrations/v0-to-v1.md).
+
+Rules the contract pins:
+
+- **Every JS entry in `exports` declares an `import` condition only.**
+  Never add a `require` condition, and never swap `import` for `default`.
+  The `default` ban is the subtle half: Node ≥ 22.12 resolves `default` for
+  `require(esm)` and loads it, so a `default` condition would make
+  `require('@yasmro/schatten')` succeed on new Node and throw on old Node —
+  a Node-version-dependent reopening of the hazard. With `import`-only
+  conditions, `require()` fails fast **everywhere** with
+  `ERR_PACKAGE_PATH_NOT_EXPORTED`.
+- **No top-level `main` field.** The top-level `module` / `types` fields
+  are deliberately **kept** — they are the ESM/type path for legacy
+  resolvers that don't read `exports` (and TS `moduleResolution: node10`),
+  and removing them buys nothing.
+- **Re-adding CJS support is additive** (`minor`) but must re-litigate the
+  dual-package hazard first — the burden of proof is on the addition.
+  Removing it again afterwards is `major`.
+
+Machine-enforced by `pnpm check:esm-only`
+([scripts/check-esm-only.mjs](../../scripts/check-esm-only.mjs)): the CI
+`lint` job checks the exports map (no `require` / `default` condition, no
+`main`), and the `manifest` job re-runs it after its build to assert no
+`.cjs` / `.d.cts` artifact is emitted.
 
 ## Visual-contract-affecting dependencies
 

--- a/.claude/rules/api-stability.md
+++ b/.claude/rules/api-stability.md
@@ -244,9 +244,12 @@ when a consumer's tree loads two module instances (the classic dual-package
 hazard). With no CJS resolution path, the hazard cannot occur.
 
 **Supported consumers**: Vite, Next.js 13+, Remix, Astro, and Node ESM
-(`"type": "module"` or dynamic `import()`). Legacy CJS tooling (webpack 4,
+(`"type": "module"` or dynamic `import()`), declared as
+`engines.node: ">=18"` in `package.json`. Legacy CJS tooling (webpack 4,
 Jest without ESM support) is out of contract; the migration path is in
 [docs/migrations/v0-to-v1.md](../../docs/migrations/v0-to-v1.md).
+Narrowing the `engines` range post-1.0 is breaking (`major`), same as a
+peer-dependency range — see [Peer dependency ranges](#peer-dependency-ranges).
 
 Rules the contract pins:
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,15 @@ jobs:
       - name: Issue / PR template health
         run: pnpm check:issue-templates
 
+      # ESM-only packaging contract (#479): no `require` / `default` condition
+      # in package.json#exports, no top-level `main`. publint can't express
+      # condition bans, and a `default` condition would reopen the dual-package
+      # hazard Node-version-dependently (Node >= 22.12 require(esm)). Runs here
+      # for the exports-map half (no build dependency); the `manifest` job
+      # re-runs it after its build for the dist half (no .cjs emitted).
+      - name: ESM-only exports contract
+        run: pnpm check:esm-only
+
   typecheck:
     runs-on: ubuntu-latest
     steps:
@@ -165,6 +174,10 @@ jobs:
       # parses — the "a consumer can actually import it" half of the contract.
       - name: Check manifest export
         run: pnpm check:manifest:export
+      # Re-run of the lint job's exports-map check, now with dist/ present:
+      # asserts the build emitted no *.cjs / *.d.cts artifact (#479).
+      - name: ESM-only dist contract
+        run: pnpm check:esm-only
 
   changeset:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -209,6 +209,15 @@ their `icon` props. It is declared `optional` in `peerDependenciesMeta` only so
 that Layer A (CSS / token-only) consumers — who never touch the React layer —
 are not warned about a dependency they do not need.
 
+### ESM-only
+
+The package ships **ESM only** (since v1.0.0) — there is no CJS build, and
+`require('@yasmro/schatten')` fails fast with `ERR_PACKAGE_PATH_NOT_EXPORTED`.
+Supported consumers: **Vite, Next.js 13+, Remix, Astro, and Node ESM**
+(`"type": "module"` or dynamic `import()`). If your tooling still `require()`s
+Schatten, see [item 12 of the migration guide](docs/migrations/v0-to-v1.md#12-esm-only--the-cjs-build-is-removed--v100).
+Layer A (CSS / tokens) involves no JS and is unaffected.
+
 ### Upgrading from 0.x
 
 Moving from a pre-1.0 release? The

--- a/docs/migrations/v0-to-v1.md
+++ b/docs/migrations/v0-to-v1.md
@@ -1,9 +1,9 @@
 # Migrating from 0.x to 1.0
 
 This guide lists every breaking change made during Schatten's pre-1.0 period
-(v0.1.0 → v0.15.0) so you can upgrade to 1.0 with confidence. Each entry names
-the version that introduced it, its severity, why it changed, and a
-Before → After you can apply directly.
+and in 1.0.0 itself (v0.1.0 → v1.0.0) so you can upgrade to 1.0 with
+confidence. Each entry names the version that introduced it, its severity, why
+it changed, and a Before → After you can apply directly.
 
 > **Pre-1.0 recap.** Before 1.0, breaking changes were permitted in any
 > release (see [`api-stability.md`](../../.claude/rules/api-stability.md)). From
@@ -17,12 +17,15 @@ Before → After you can apply directly.
    ```sh
    pnpm add @yasmro/schatten@^1 lucide-react   # lucide-react only if you use the React layer
    ```
-2. **Fix type errors first.** The Radix type-boundary change (item 10) and the
+2. **Switch any `require()` to `import`.** The package is ESM-only from 1.0
+   (item 12) — a leftover `require('@yasmro/schatten')` fails at load time
+   with `ERR_PACKAGE_PATH_NOT_EXPORTED`, so this surfaces immediately.
+3. **Fix type errors next.** The Radix type-boundary change (item 10) and the
    `<Text asChild>` removal (item 7) surface as TypeScript errors — let `pnpm
    typecheck` (or your editor) drive them.
-3. **Update CSS-class and token references.** If you consume the vanilla CSS
+4. **Update CSS-class and token references.** If you consume the vanilla CSS
    path or read CSS variables directly, walk items 3–6, 8, 9, 11.
-4. **Verify visually.** Toast now renders through Sonner (item 9); re-check any
+5. **Verify visually.** Toast now renders through Sonner (item 9); re-check any
    custom toast styling.
 
 Who is affected by what, at a glance:
@@ -32,6 +35,7 @@ Who is affected by what, at a glance:
 | React props only | 1, 2, 7, 10 |
 | The vanilla `.st-*` CSS path | 4, 9 |
 | CSS variables / design tokens directly | 3, 5, 6, 8, 11 |
+| `require()` / CJS tooling | 12 |
 
 If you use `<Button>` and friends purely through their React props, most CSS
 and token items do not affect you.
@@ -214,6 +218,40 @@ references `--font-sans` / `--font-mono` directly (resolved value unchanged). (#
 - font-family: var(--default-font-family);
 + font-family: var(--font-sans);
 ```
+
+## 12. ESM-only — the CJS build is removed — v1.0.0
+
+**Severity: high (`require()` consumers only).** All `require` conditions in
+`package.json#exports`, the top-level `main` field, and every `dist/**/*.cjs`
+/ `*.d.cts` file were removed. The package now resolves through `import`
+conditions only. (#479, decided in #208)
+
+Why: Schatten carries module-level state — the `Toast` store and the `Field`
+/ `FieldSet` / `Tooltip` React Contexts — that **fails silently** when a
+consumer's tree loads two module instances (the dual-package hazard: a
+Provider from the ESM copy, a consumer from the CJS copy). Removing the CJS
+resolution path makes that failure mode structurally impossible: `require()`
+now fails fast with `ERR_PACKAGE_PATH_NOT_EXPORTED` instead of half-working.
+
+```diff
+- const { Button } = require('@yasmro/schatten')
++ import { Button } from '@yasmro/schatten'
+```
+
+From a CJS file that cannot become ESM, use dynamic import:
+
+```js
+const { Button } = await import('@yasmro/schatten')
+```
+
+**Supported consumers:** Vite, Next.js 13+, Remix, Astro, and Node ESM
+(`"type": "module"` or dynamic `import()`). ESM consumers — the above list —
+need **no change**; this item is invisible to them.
+
+**Out of contract:** webpack 4 and Jest configured with a CJS transform. For
+Jest, enable its ESM support or run component tests under Vitest (what
+Schatten itself uses). The Layer A CSS path (`schatten.css`, `/css/*`,
+tokens CSS) has no JS involved and is unaffected.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -4,18 +4,13 @@
   "packageManager": "pnpm@10.33.0+sha512.10568bb4a6afb58c9eb3630da90cc9516417abebd3fabbe6739f0ae795728da1491e9db5a544c76ad8eb7570f5c4bb3d6c637b2cb41bfdcdb47fa823c8649319",
   "description": "Design system with CSS variants and React components",
   "type": "module",
-  "main": "./dist/components/index.cjs",
   "module": "./dist/components/index.js",
   "types": "./dist/components/index.d.ts",
   "exports": {
     ".": {
-      "types": {
-        "import": "./dist/components/index.d.ts",
-        "require": "./dist/components/index.d.cts"
-      },
+      "types": "./dist/components/index.d.ts",
       "style": "./dist/schatten.css",
-      "import": "./dist/components/index.js",
-      "require": "./dist/components/index.cjs"
+      "import": "./dist/components/index.js"
     },
     "./schatten.css": "./dist/schatten.css",
     "./schatten.manifest.json": "./dist/schatten.manifest.json",
@@ -23,61 +18,33 @@
     "./core/tokens": "./dist/core/tokens/index.css",
     "./themes/default": "./dist/themes/default/index.css",
     "./themes/seasonal": {
-      "types": {
-        "import": "./dist/themes/seasonal/index.d.ts",
-        "require": "./dist/themes/seasonal/index.d.cts"
-      },
-      "import": "./dist/themes/seasonal/index.js",
-      "require": "./dist/themes/seasonal/index.cjs"
+      "types": "./dist/themes/seasonal/index.d.ts",
+      "import": "./dist/themes/seasonal/index.js"
     },
     "./themes/seasonal/themes.css": "./dist/themes/seasonal/themes.css",
     "./variants": {
-      "types": {
-        "import": "./dist/variants/index.d.ts",
-        "require": "./dist/variants/index.d.cts"
-      },
-      "import": "./dist/variants/index.js",
-      "require": "./dist/variants/index.cjs"
+      "types": "./dist/variants/index.d.ts",
+      "import": "./dist/variants/index.js"
     },
     "./tokens": {
-      "types": {
-        "import": "./dist/tokens/index.d.ts",
-        "require": "./dist/tokens/index.d.cts"
-      },
-      "import": "./dist/tokens/index.js",
-      "require": "./dist/tokens/index.cjs"
+      "types": "./dist/tokens/index.d.ts",
+      "import": "./dist/tokens/index.js"
     },
     "./components": {
-      "types": {
-        "import": "./dist/components/index.d.ts",
-        "require": "./dist/components/index.d.cts"
-      },
-      "import": "./dist/components/index.js",
-      "require": "./dist/components/index.cjs"
+      "types": "./dist/components/index.d.ts",
+      "import": "./dist/components/index.js"
     },
     "./components/lv1": {
-      "types": {
-        "import": "./dist/components/lv1/index.d.ts",
-        "require": "./dist/components/lv1/index.d.cts"
-      },
-      "import": "./dist/components/lv1/index.js",
-      "require": "./dist/components/lv1/index.cjs"
+      "types": "./dist/components/lv1/index.d.ts",
+      "import": "./dist/components/lv1/index.js"
     },
     "./providers": {
-      "types": {
-        "import": "./dist/providers/index.d.ts",
-        "require": "./dist/providers/index.d.cts"
-      },
-      "import": "./dist/providers/index.js",
-      "require": "./dist/providers/index.cjs"
+      "types": "./dist/providers/index.d.ts",
+      "import": "./dist/providers/index.js"
     },
     "./theme-init": {
-      "types": {
-        "import": "./dist/theme-init/index.d.ts",
-        "require": "./dist/theme-init/index.d.cts"
-      },
-      "import": "./dist/theme-init/index.js",
-      "require": "./dist/theme-init/index.cjs"
+      "types": "./dist/theme-init/index.d.ts",
+      "import": "./dist/theme-init/index.js"
     }
   },
   "files": [
@@ -109,6 +76,7 @@
     "check:issue-templates": "node scripts/check-issue-templates.mjs",
     "check:registrar": "node scripts/check-registrar-sync.mjs",
     "check:body-reset": "node scripts/check-body-reset-sync.mjs",
+    "check:esm-only": "node scripts/check-esm-only.mjs",
     "build:storybook": "storybook build",
     "test": "vitest",
     "test:ui": "vitest --ui",

--- a/package.json
+++ b/package.json
@@ -54,6 +54,9 @@
     "*.css",
     "**/*.css"
   ],
+  "engines": {
+    "node": ">=18"
+  },
   "scripts": {
     "dev": "storybook dev -p 6006",
     "build": "pnpm clean:dist && pnpm build:js && pnpm check:use-client && pnpm build:css && pnpm build:component-css && pnpm build:copy-css && pnpm build:manifest",

--- a/scripts/check-esm-only.mjs
+++ b/scripts/check-esm-only.mjs
@@ -1,0 +1,88 @@
+#!/usr/bin/env node
+// Guard the ESM-only packaging contract (#479, decision in #208).
+//
+// The package ships ESM only from v1.0.0. This is what structurally closes
+// the dual-package hazard: Schatten carries module-level state (the Toast
+// store, the Field / FieldSet / Tooltip React Contexts) that silently
+// breaks when two module instances coexist in one tree.
+//
+// What it checks:
+//
+// 1. `package.json#exports` — no entry may declare a `require` condition,
+//    and no JS entry may declare a `default` condition. `require` is the
+//    obvious regression; `default` is the subtle one: Node >= 22.12
+//    supports `require(esm)`, so a `default` condition would let
+//    `require('@yasmro/schatten')` succeed on new Node and throw on old
+//    Node — a Node-version-dependent reopening of the hazard. Keeping
+//    `import`-only makes require() resolution fail fast everywhere with
+//    ERR_PACKAGE_PATH_NOT_EXPORTED.
+// 2. `package.json` — no top-level `main` field (the CJS resolution root).
+//    The top-level `module` / `types` fields are deliberately KEPT: they
+//    are the ESM/type path for legacy resolvers that don't read `exports`.
+// 3. `dist/` (only when present) — no emitted `*.cjs` / `*.d.cts` files,
+//    so a tsup config regression can't silently ship dead CJS weight.
+//
+// publint cannot express any of these (it validates that export targets
+// exist, not which conditions are allowed). The full contract lives in
+// `.claude/rules/api-stability.md` § "Module format — ESM-only".
+//
+// Run as `pnpm check:esm-only`. Wired into CI's `lint` job (exports map,
+// no build needed) and into the `manifest` job after its build step
+// (where the dist check becomes effective).
+
+import { existsSync, readFileSync, readdirSync } from 'node:fs'
+
+const errors = []
+
+// --- 1 + 2. package.json surface -------------------------------------------
+const pkg = JSON.parse(readFileSync('package.json', 'utf8'))
+
+if ('main' in pkg) {
+  errors.push('package.json declares a top-level "main" field — the CJS resolution root must stay removed.')
+}
+
+for (const [subpath, target] of Object.entries(pkg.exports ?? {})) {
+  if (typeof target !== 'object' || target === null) continue // plain string targets (CSS/JSON) are fine
+  if ('require' in target || (target.types && typeof target.types === 'object' && 'require' in target.types)) {
+    errors.push(`exports["${subpath}"] declares a "require" condition.`)
+  }
+  if ('default' in target) {
+    errors.push(
+      `exports["${subpath}"] declares a "default" condition — use "import" instead (Node >= 22.12 resolves "default" for require(esm), reopening the dual-package hazard #208).`,
+    )
+  }
+}
+
+// --- 3. dist artifacts (post-build only) ------------------------------------
+/**
+ * @param {string} dir
+ * @returns {string[]}
+ */
+function collectCjsArtifacts(dir) {
+  const out = []
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const path = `${dir}/${entry.name}`
+    if (entry.isDirectory()) out.push(...collectCjsArtifacts(path))
+    else if (entry.name.endsWith('.cjs') || entry.name.endsWith('.d.cts')) out.push(path)
+  }
+  return out
+}
+
+let distNote = 'dist/ absent — skipped (run after `pnpm build` for the full check)'
+if (existsSync('dist')) {
+  const cjsArtifacts = collectCjsArtifacts('dist')
+  for (const file of cjsArtifacts) {
+    errors.push(`CJS artifact emitted: ${file} — tsup must build ESM only (format: ['esm']).`)
+  }
+  distNote = 'dist/ clean'
+}
+
+if (errors.length > 0) {
+  console.error('check-esm-only: FAILED')
+  for (const error of errors) console.error(`  - ${error}`)
+  console.error('\n  The package is ESM-only since v1.0.0 (#479, decided in #208).')
+  console.error('  See .claude/rules/api-stability.md § "Module format — ESM-only".')
+  process.exit(1)
+}
+
+console.log(`check-esm-only: OK — exports are import-only, no "main", ${distNote}`)

--- a/scripts/check-esm-only.mjs
+++ b/scripts/check-esm-only.mjs
@@ -15,7 +15,11 @@
 //    `require('@yasmro/schatten')` succeed on new Node and throw on old
 //    Node — a Node-version-dependent reopening of the hazard. Keeping
 //    `import`-only makes require() resolution fail fast everywhere with
-//    ERR_PACKAGE_PATH_NOT_EXPORTED.
+//    ERR_PACKAGE_PATH_NOT_EXPORTED. A plain-STRING target pointing at a
+//    JS file is banned for the same reason: per Node's resolution rules a
+//    string target is sugar for `default`, so it resolves for require()
+//    too. String targets are fine for non-JS assets (CSS / JSON), which
+//    is what every current string entry is.
 // 2. `package.json` — no top-level `main` field (the CJS resolution root).
 //    The top-level `module` / `types` fields are deliberately KEPT: they
 //    are the ESM/type path for legacy resolvers that don't read `exports`.
@@ -42,7 +46,17 @@ if ('main' in pkg) {
 }
 
 for (const [subpath, target] of Object.entries(pkg.exports ?? {})) {
-  if (typeof target !== 'object' || target === null) continue // plain string targets (CSS/JSON) are fine
+  if (typeof target === 'string') {
+    // A string target is sugar for a `default` condition — it resolves for
+    // require() too. Only non-JS assets (CSS / JSON) may use the string form.
+    if (/\.(js|mjs|cjs)$/.test(target)) {
+      errors.push(
+        `exports["${subpath}"] is a plain-string JS target (${target}) — a string target acts as "default" and resolves for require(); use { "import": "…" } conditions instead.`,
+      )
+    }
+    continue
+  }
+  if (typeof target !== 'object' || target === null) continue
   if ('require' in target || (target.types && typeof target.types === 'object' && 'require' in target.types)) {
     errors.push(`exports["${subpath}"] declares a "require" condition.`)
   }

--- a/scripts/check-use-client-banner.mjs
+++ b/scripts/check-use-client-banner.mjs
@@ -19,13 +19,14 @@ function firstLine(path) {
   return readFileSync(path, 'utf8').split('\n', 1)[0].trim()
 }
 
-// Recursively collect emitted JS/CJS files (skips .css / .d.ts / .d.cts).
+// Recursively collect emitted JS files (skips .css / .d.ts). The package is
+// ESM-only since #479, so there are no .cjs bundles to scan.
 function collectBundles(dir) {
   const out = []
   for (const entry of readdirSync(dir, { withFileTypes: true })) {
     const path = `${dir}/${entry.name}`
     if (entry.isDirectory()) out.push(...collectBundles(path))
-    else if (entry.name.endsWith('.js') || entry.name.endsWith('.cjs')) out.push(path)
+    else if (entry.name.endsWith('.js')) out.push(path)
   }
   return out
 }
@@ -41,7 +42,7 @@ const reactBundles = reactBundleDirs.flatMap((dir) =>
 )
 if (reactBundles.length === 0) {
   errors.push(
-    `${reactBundleDirs.join(' / ')} has no .js/.cjs output — did \`pnpm build:js\` run?`,
+    `${reactBundleDirs.join(' / ')} has no .js output — did \`pnpm build:js\` run?`,
   )
 }
 for (const file of reactBundles) {

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -52,7 +52,7 @@ export default defineConfig([
       // string directly — see src/theme-init.ts header.
       'theme-init/index': 'src/theme-init.ts',
     },
-    format: ['esm', 'cjs'],
+    format: ['esm'],
     dts: true,
     external: ['react', 'react-dom', 'lucide-react'],
   },
@@ -85,29 +85,12 @@ export default defineConfig([
       options.jsx = 'automatic'
     },
   },
-  // Components — CJS. Barrels only: `require()` consumers do not tree-shake,
-  // and emitting per-component CJS files would duplicate the bundled Radix
-  // code across 17 standalone bundles and bloat the published package.
-  // Carries the same `'use client'` banner as the ESM group (see above) so
-  // the `.cjs` barrels are equally safe to import from a Server Component.
-  {
-    entry: { ...componentBarrelEntries, ...providerEntries },
-    format: ['cjs'],
-    dts: false,
-    external: ['react', 'react-dom', 'lucide-react'],
-    banner: {
-      js: "'use client';",
-    },
-    esbuildOptions(options) {
-      options.jsx = 'automatic'
-    },
-  },
   // Components & providers — type declarations. Only published barrel entries
-  // need `.d.ts` / `.d.cts`; the per-component ESM entries are an internal
-  // build detail and are not part of `package.json#exports`.
+  // need `.d.ts`; the per-component ESM entries are an internal build detail
+  // and are not part of `package.json#exports`.
   {
     entry: { ...componentBarrelEntries, ...providerEntries },
-    format: ['esm', 'cjs'],
+    format: ['esm'],
     dts: { only: true },
     external: ['react', 'react-dom', 'lucide-react'],
   },
@@ -116,7 +99,7 @@ export default defineConfig([
     entry: {
       'themes/seasonal/index': 'src/themes/seasonal/index.ts',
     },
-    format: ['esm', 'cjs'],
+    format: ['esm'],
     dts: true,
     external: ['react', 'react-dom', 'lucide-react'],
   },


### PR DESCRIPTION
## What

パッケージを ESM-only 化。`package.json#exports` の全 8 entry から `require` 条件を削除し、
top-level `main` と tsup の CJS ビルドグループ(barrels + `.d.cts`)を撤去。
恒久 gate `check:esm-only` を新設して CI の lint job(exports map)と manifest job
(build 後の dist)に組み込んだ。api-stability.md / migration guide(item 12)/ README に
契約を明文化。この changeset(`major`)が 0.15.0 → 1.0.0 bump のドライバー。

## Why

#208 で採択した ESM-only 方針の実装(#479)。Schatten は module-level state
(Toast store / Field・FieldSet・Tooltip Context)を持ち、ESM と CJS の module instance が
同一 tree に混在すると無音故障する(dual-package hazard)。CJS 解決経路を消すことで構造的に解消する。

設計上の要点: `require` 条件の跡を `default` 条件にしないこと。Node >= 22.12 は
`require(esm)` をサポートするため、`default` があると `require()` が Node バージョン依存で
成功/失敗する。`import` 条件のみなら全 Node で `ERR_PACKAGE_PATH_NOT_EXPORTED` で
fail-fast する(実測済み — 下記)。この理由は api-stability.md に明文化し、
`check:esm-only` が機械的に pin する。

## Related rules

- [.claude/rules/api-stability.md](https://github.com/yasmro/schatten/blob/develop/.claude/rules/api-stability.md) — 「Module format — ESM-only」節を追加
- [docs/migrations/v0-to-v1.md](https://github.com/yasmro/schatten/blob/develop/docs/migrations/v0-to-v1.md) — item 12 追加

## Test plan

- [x] `pnpm lint` 緑
- [x] `pnpm test --run` 緑 (1126 passed)
- [x] `pnpm typecheck` 緑
- [x] `pnpm build` 後 `dist/**/*.cjs` / `*.d.cts` 0 件、`pnpm check:esm-only` OK
- [x] ESM スモーク: 全 8 JS entry を self-reference import で確認
- [x] require fail-fast 実証: tarball を一時プロジェクトへ install → Node 22.22 で
      `require('@yasmro/schatten')` / `require('@yasmro/schatten/theme-init')` とも
      `ERR_PACKAGE_PATH_NOT_EXPORTED`、`import()` は正常動作
- [x] publint / `pnpm size` / `pnpm check:manifest` / `pnpm check:doc-links` 緑
- [x] tarball 実測: unpacked 1,296.6 kB → 792.8 kB(**-38.9%**、151 → 137 files)

## Review follow-up (f3ed49b)

/review-pr の P0 / P2 を反映:

- **P0**: `check-esm-only` にプレーン文字列 JS target の検出を追加(Node の解決規則では
  文字列 target は `default` 条件と等価 — require() でも解決される穴だった)。
  negative fixture で 4 検出(`main` / `require` / `default` / 文字列 JS)の発火と
  CSS / JSON 文字列 entry の非検出を確認済み
- **P2**: `engines.node: ">=18"` を宣言(api-stability.md + changeset にも反映。
  post-1.0 に範囲を狭めるのは `major`)
- **P1**(repo 外): #170 の本文に #484 の実装参照と reconcile 対象
  (`engines.node` / 新設「Module format」節)を追記済み

closes #479

🤖 Generated with [Claude Code](https://claude.com/claude-code)

