### PR TITLE
docs(rules): a11y 例外カテゴリに aria-hidden-focus を文書化 (#163)

### DIFF
--- a/.changeset/seven-days-tap.md
+++ b/.changeset/seven-days-tap.md
@@ -1,0 +1,4 @@
+---
+---
+
+Docs-only (#163): `Patterns/Accessibility` の a11y 例外記述を rule doc（vrt-spec-guideline §a11y assertions）と同期。Storybook stories は published surface 外のためリリース不要（empty changeset）。

--- a/.claude/rules/component-architecture.md
+++ b/.claude/rules/component-architecture.md
@@ -602,8 +602,11 @@ fallback — that policy only holds if the contract below holds.
    Playwright exit code, so a new violation fails the PR. The only axe
    `color-contrast` findings that remain are intentional design exceptions
    (solid treatments / inverted-on-saturated / the foreground-subtle
-   tertiary tier), each disabled with a documented rationale scoped to its
-   own story — see [vrt-spec-guideline §a11y assertions](vrt-spec-guideline.md).
+   tertiary tier / the Dialog overlay-compositing artifact), each disabled
+   with a documented rationale scoped to its own story; the same
+   discipline covers the one other documented exception rule id,
+   `aria-hidden-focus` on open Radix poppers (Select / DropdownMenu /
+   Popover) — see [vrt-spec-guideline §a11y assertions](vrt-spec-guideline.md).
    The Storybook `addon-a11y` panel remains the manual dev-time companion.
 3. **Code review** — when reviewing an lv1 PR, walk the four
    guarantees and Hard rules above. If the component opts out of a

--- a/.claude/rules/component-architecture.md
+++ b/.claude/rules/component-architecture.md
@@ -633,9 +633,11 @@ fallback — that policy only holds if the contract below holds.
     `@axe-core/playwright` VRT-paired check (v0.11.0); the Phase 1
     backlog (#344 / #345) is now cleared and the `a11y` CI job is
     blocking (#346) — "Verifying compliance" reflects this. If a future
-    component needs a genuinely new `color-contrast` exception, it must
-    be a documented, story-scoped `disableRules(['color-contrast'])`
-    with a rationale (not a blanket disable) — see
+    component needs a genuinely new exception, it must use one of the two
+    documented rule ids (`color-contrast` for design exceptions,
+    `aria-hidden-focus` for open Radix poppers), as a documented,
+    story-scoped `disableRules([…])` with a rationale (not a blanket
+    disable, and no other rule id) — see
     [vrt-spec-guideline §a11y assertions](vrt-spec-guideline.md).
   - `Field.required` now propagates `aria-required` (announce-only) to
     the wrapped control ([#428](https://github.com/yasmro/schatten/issues/428)) —

--- a/.claude/rules/vrt-spec-guideline.md
+++ b/.claude/rules/vrt-spec-guideline.md
@@ -210,11 +210,28 @@ rendering, so the scarce macos runner stays pixel-only.
 > remain are **intentional design exceptions** — solid treatments (white
 > foreground on a saturated/neutral-solid fill, the AA trilemma),
 > inverted-on-saturated foreground, and the `foreground-subtle` tertiary
-> tier (large/incidental-only). Each is suppressed with a **story-scoped**
+> tier (large/incidental-only) — plus one **portal-pattern artifact**: a
+> full-page portal spec (Dialog today) also has axe compositing the
+> `aria-hidden` trigger sitting *behind* the semi-transparent modal
+> overlay into a blended, non-readable pair — not a real content-contrast
+> issue. Each is suppressed with a **story-scoped**
 > `disableRules(['color-contrast'])` carrying a one-line rationale + the
 > `#344` / `#346` refs, mirrored in the story's `parameters.a11y` for the
 > addon panel (the [Per-story rule disable](storybook-guideline.md) rule).
-> A blanket or whole-file `color-contrast` disable is **not** acceptable —
+>
+> One more rule id carries a documented exception: **`aria-hidden-focus`**
+> on open-popper components (`Select` / `DropdownMenu` / `Popover`). While
+> the popper is open, Radix (`hideOthers`) sets `aria-hidden` on
+> `#storybook-root` but leaves the trigger focusable; focus is trapped in
+> the portaled content, so no real keyboard escape exists — a known Radix
+> behavior, not fixable from Schatten. The disable is scoped to the
+> open-state (`portalStories`) a11y tests only, carries the rationale
+> comment, and is mirrored story-scoped in `parameters.a11y` (inventoried
+> in #163).
+>
+> The allowed exception rule ids are **exactly these two** —
+> `color-contrast` and `aria-hidden-focus`. A blanket or whole-file
+> disable, or a disable of any other rule id, is **not** acceptable —
 > if you reach for one, you are masking a real regression. New components
 > must land with zero new violations.
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -247,7 +247,10 @@ jobs:
     # design exceptions (solid treatments / inverted-on-saturated / the
     # foreground-subtle tertiary tier — see state-token-guideline.md), each
     # disabled with a documented rationale scoped to its own story in the VRT
-    # spec + mirrored in `parameters.a11y`. So the gate now propagates the
+    # spec + mirrored in `parameters.a11y`; ditto the documented
+    # `aria-hidden-focus` disables on open Radix poppers (Select /
+    # DropdownMenu / Popover — see vrt-spec-guideline.md §a11y assertions).
+    # So the gate now propagates the
     # Playwright exit code (a new violation fails the PR). Adding `a11y` to
     # develop's required checks is a repo-settings change (ruleset), tracked in
     # #346, not in this workflow.

--- a/src/docs/Accessibility.stories.tsx
+++ b/src/docs/Accessibility.stories.tsx
@@ -405,10 +405,11 @@ export const Contrast: Story = {
 
       <SectionTitle>Intentional AA exceptions</SectionTitle>
       <Note>
-        Three contrast patterns are deliberately exempt from the 4.5 : 1 body-text line. These are
-        the <em>only</em> <Code>color-contrast</Code> findings the CI a11y gate (#346) suppresses —
-        each via a documented, story-scoped <Code>disableRules([&apos;color-contrast&apos;])</Code>{' '}
-        in the component&apos;s <Code>*.vrt.spec.ts</Code> (mirrored in the story&apos;s{' '}
+        Four patterns are deliberately exempt from the 4.5 : 1 body-text line — three design
+        exceptions plus one portal-testing artifact. These are the <em>only</em>{' '}
+        <Code>color-contrast</Code> findings the CI a11y gate (#346) suppresses — each via a
+        documented, story-scoped <Code>disableRules([&apos;color-contrast&apos;])</Code> in the
+        component&apos;s <Code>*.vrt.spec.ts</Code> (mirrored in the story&apos;s{' '}
         <Code>parameters.a11y</Code>). A blanket disable is never allowed; anything outside this
         table must clear AA. See <Code>.claude/rules/state-token-guideline.md</Code> for the token
         rationale.
@@ -438,6 +439,14 @@ export const Contrast: Story = {
               'foreground-subtle (tertiary)',
               'Text color="subtle"; faint helper / placeholder-like copy',
               'The third foreground tier clears the 3 : 1 large-text line but is intentionally below 4.5 : 1 at small sizes. Never use it for body copy.',
+            ],
+          },
+          {
+            key: 'overlay',
+            cells: [
+              'Dialog overlay compositing (test artifact)',
+              'Dialog *.vrt.spec.ts a11y tests — every story',
+              'The full-page portal spec has axe compositing the aria-hidden trigger sitting behind the semi-transparent modal overlay into a blended, non-readable pair. A portal-pattern testing artifact, not a real content-contrast issue — the dialog text itself clears AA.',
             ],
           },
         ]}
@@ -650,10 +659,16 @@ pnpm test:vrt     # playwright test --grep-invert a11y    → screenshots only`}
       <Note>
         The CI a11y job <strong>blocks</strong> (#346) — it propagates the Playwright exit code, so
         a new WCAG 2.1 A/AA violation fails the PR (the full violation list is still tee&apos;d into
-        the job summary). The only <Code>color-contrast</Code> findings that remain are intentional
-        design exceptions — solid treatments, inverted-on-saturated foreground, and the{' '}
-        <Code>foreground-subtle</Code> tertiary tier — each suppressed with a documented,
-        story-scoped <Code>disableRules([&apos;color-contrast&apos;])</Code>. The addon panel&apos;s{' '}
+        the job summary). The only <Code>color-contrast</Code> findings that remain are the
+        intentional exceptions inventoried on the <strong>Contrast</strong> page of this section,
+        each suppressed with a documented, story-scoped{' '}
+        <Code>disableRules([&apos;color-contrast&apos;])</Code>. One other rule id carries a
+        documented exception: <Code>aria-hidden-focus</Code> on open Radix poppers (Select /
+        DropdownMenu / Popover) — while open, Radix hides the page behind the popper via{' '}
+        <Code>aria-hidden</Code> but leaves the trigger focusable, a known Radix behavior not
+        fixable from Schatten; the disable is scoped to the open-state a11y tests only. These two
+        rule ids are the <em>entire</em> allowed set (see{' '}
+        <Code>.claude/rules/vrt-spec-guideline.md</Code> §a11y assertions). The addon panel&apos;s{' '}
         <Code>test</Code> flag is <Code>off</Code> so its headless preview run does not race the
         Playwright suite; addon-a11y stays the on-demand dev companion — click{' '}
         <strong>Rerun</strong> in the Accessibility panel to scan the current story.


### PR DESCRIPTION
## 概要

#163（1.0 DoD: a11y 自動テスト全 lv1 合格の確認）の棚卸しで判明した **rule doc drift の同期**。コード変更なし。

棚卸しの結果、story-scoped の `disableRules` 例外には文書化済みの `color-contrast`（6 spec）に加えて、rule doc に載っていない `aria-hidden-focus`（Select / DropdownMenu / Popover、3 spec）が存在した。3 件とも rationale コメント + story-scoped ミラー付きで規律には準拠している（Radix `hideOthers` が open popper 中に `#storybook-root` へ `aria-hidden` を付けつつトリガーを focusable のまま残す — Schatten 側で修正不能）。本 PR は文書側を実態に合わせる。

## 変更内容

- **`.claude/rules/vrt-spec-guideline.md`** §a11y assertions（Phase 2 note）— 許容される disable rule id を `color-contrast` / `aria-hidden-focus` の **2 つに固定**して明文化。Dialog の full-page portal spec で axe が overlay 越しに背景を合成する artifact も color-contrast の事由として追記。
- **`.claude/rules/component-architecture.md`** §8 Verifying compliance — 同カテゴリへの言及を追加（詳細は vrt-spec-guideline へ委譲）。
- **`.github/workflows/ci.yml`** — `a11y` job のコメントの同 drift を同期（コメントのみ、job 定義は不変）。

## 関連

- #163（inventory 全文と解決済み論点は issue 本文に反映済み）
- changeset なし — published surface に触れない rule doc / CI コメントのみ

🤖 Generated with [Claude Code](https://claude.com/claude-code)