### PR TITLE
docs(1.0 DoD): README Storybook 導線 + CONTRIBUTING pre-1.0 表記の解消 (#166)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -155,7 +155,8 @@ pnpm changeset
 
 Pick the bump level per the breaking-change policy and CHANGELOG prefixes in
 [api-stability.md](.claude/rules/api-stability.md#changelog-conventions)
-(`patch` for fixes, `minor` for additions; pre-1.0 permits breaking changes).
+(`patch` for fixes, `minor` for additions, `major` for breaking changes — see
+the policy table there).
 CI runs `changeset status` and fails a source change that ships without one.
 
 **Internal-only PRs** — `.github/` workflows, docs, `.claude/`, test-only work

--- a/README.md
+++ b/README.md
@@ -1040,7 +1040,8 @@ Primitive components live under `src/components/lv1/`:
 
 Badge · Button · Callout · Checkbox · Dialog · DropdownMenu · Field · FieldSet · Icon · Input · Popover · Radio · Select · Separator · Skeleton · Spinner · Switch · Tabs · Text · Textarea · Toast · Tooltip
 
-See Storybook for live examples and prop documentation.
+Run `pnpm dev` to browse live examples and prop documentation in Storybook
+(see [Development](#development)).
 
 ## Project Structure
 


### PR DESCRIPTION
## 概要

#166（1.0 DoD: docs 完備確認)の残作業 2 点を解消する docs-only PR。

## 変更内容

- **README.md L1043** — 「See Storybook for live examples」にリンク実体がなかった(hosted Storybook 不在)ため、Development 節の \`pnpm dev\` 手順への内部リンクに変更。ローカル起動を正式な導線とし、Storybook 公開は 1.0 DoD 外とする(#166 の未解決論点 1 の採択)。
- **CONTRIBUTING.md L158** — changeset バンプ基準の「pre-1.0 permits breaking changes」を「\`major\` for breaking changes — see the policy table there」へ。#479 の major changeset により次リリースは必ず 1.0.0 のため、publish 時点で記述が正になる。

## 検証

- \`pnpm check:doc-links\` — OK(275 relative links / 23 files、新規 \`#development\` アンカー含む)
- placeholder grep(\`coming in v0|coming soon|will (ship|land) in v0\`)— ヒットゼロ
- \`## Development\` アンカー実在確認(README L1060)

## 対象外(他 issue 管轄)

- \`.claude/rules/api-stability.md\` 冒頭の pre-1.0 注記 → #170
- migration guide / decision log 内の pre-1.0 言及 → 歴史記録、変更不要

published surface に触れないため changeset なし(\`no-changeset\`)。

Refs #166

🤖 Generated with [Claude Code](https://claude.com/claude-code)