### PR TITLE
docs(release): framework-agnostic 利用例の最終鮮度確認 — README の st-btn size modifier 欠落を修正 (closes #168)

### DIFF
--- a/.claude/rules/css-api.md
+++ b/.claude/rules/css-api.md
@@ -88,6 +88,16 @@ Schatten classes follow a strict three-form BEM:
 - **`size` modifier values are always `--sm` / `--md` / `--lg`.** No
   `--small` / `--medium` / `--large` — the abbreviated form is the
   contract ([component-api-conventions.md](component-api-conventions.md#common-props-across-all-components)).
+- **The size modifier is required on blocks that have a size axis.**
+  Dimensions (height / padding / font-size) live **only** on
+  `.st-{block}--{sm|md|lg}`; the base rule deliberately carries no
+  fallback size, because the React layer's CVA always emits its
+  `defaultVariants` size (`st-btn st-btn--primary st-btn--md`) — a
+  second base-level definition would create two cascade sources for the
+  same visual. A bare `st-btn st-btn--primary` renders collapsed. The
+  **minimum renderable chain is block + variant + size**, exactly the
+  chain the React layer emits (found the expensive way: the README
+  quick-start snippets shipped size-less for ~6 versions, #168).
 - **Block names are kebab-case nouns.** Match the underlying React
   component name lowercased and de-camelCased (`FieldSet` →
   `st-fieldset`, `RadioGroup` → `st-radio-group`,
@@ -908,7 +918,10 @@ goal.
 - **BEM**: `.st-{block}` / `.st-{block}--{modifier}` /
   `.st-{block}__{element}`.
 - **Modifiers**: variant / appearance / size / orientation — one
-  axis per modifier, emitted side-by-side.
+  axis per modifier, emitted side-by-side. On blocks with a size axis
+  the size modifier is **required** (dimensions live only on
+  `--{sm|md|lg}`; no fallback on the base rule) — the minimum
+  renderable chain is block + variant + size.
 - **Pattern B composition**: tone × shape via **double-class
   selectors** (`.st-callout--success.st-callout--subtle`). Default
   appearance is first-class — write its rule via the same double-class

--- a/.claude/rules/storybook-guideline.md
+++ b/.claude/rules/storybook-guideline.md
@@ -237,7 +237,7 @@ README and CLAUDE.md only point here, they do not restate it.
 | Top-level group | What belongs there | Examples |
 |---|---|---|
 | `Welcome` | Landing / overview | `Welcome` |
-| `Getting Started` | Integration on-ramp | `Quick Start`, `Installation` |
+| `Getting Started` | Integration on-ramp — **currently empty, reserved**. The README owns the on-ramp narrative ([#112](https://github.com/yasmro/schatten/issues/112) / [#113](https://github.com/yasmro/schatten/issues/113) closed as superseded by it); the group stays in `storySort` as a reserved seat. Fill it only with *differentiated* onboarding (seasonal themes / Mode × Special live demos — see #113's closing note), never with README-duplicating Quick Start prose. | (none yet) |
 | `Tokens` | Design-token vocabulary (the *values*) | `Color`, `Typography`, `Spacing`, `Elevation`, `Motion`, `Iconography` |
 | `Theming` | The Mode × Special theme machinery | `Overview`, `Theme Audit`, `Customization` |
 | `CSS API` | The framework-agnostic `.st-*` class contract | `Overview`, `Class Reference` |

--- a/README.md
+++ b/README.md
@@ -39,6 +39,11 @@ no build step required.**
 <button class="st-btn st-btn--primary st-btn--md">Click me</button>
 ```
 
+The size modifier is part of the minimum chain: sizing (height /
+padding / font-size) lives only on `.st-btn--{sm,md,lg}` — there is no
+default size on the bare `.st-btn`. Always write **block + variant +
+size**, exactly the chain the React layer emits.
+
 > **Scope note:** the stylesheet ships every lv1 component's *visual*
 > classes, but it cannot ship behavior. In the matrix below, ✅ means the
 > component works with CSS alone (static rendering, or the browser

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ no build step required.**
   rel="stylesheet"
 />
 
-<button class="st-btn st-btn--primary">Click me</button>
+<button class="st-btn st-btn--primary st-btn--md">Click me</button>
 ```
 
 > **Scope note:** the stylesheet ships every lv1 component's *visual*
@@ -103,20 +103,20 @@ chains directly on any element. **No JavaScript import needed.**
 import '@yasmro/schatten/schatten.css'
 ---
 
-<button class="st-btn st-btn--primary">Click me</button>
-<a href="/docs" class="st-btn st-btn--secondary">Docs</a>
+<button class="st-btn st-btn--primary st-btn--md">Click me</button>
+<a href="/docs" class="st-btn st-btn--secondary st-btn--md">Docs</a>
 ```
 
 ```vue
 <!-- Vue -->
 <template>
-  <button class="st-btn st-btn--primary">Click me</button>
+  <button class="st-btn st-btn--primary st-btn--md">Click me</button>
 </template>
 ```
 
 ```svelte
 <!-- Svelte -->
-<button class="st-btn st-btn--primary">Click me</button>
+<button class="st-btn st-btn--primary st-btn--md">Click me</button>
 ```
 
 The exported CVA variant functions (`buttonVariants`, `badgeVariants`,


### PR DESCRIPTION
## What

1.0 DoD #168 の最終鮮度確認を実施し、発見した乖離 1 件を修正:

- README のコピペ用スニペット 5 箇所 (Quick start Vanilla / Astro / Vue /
  Svelte) の `.st-btn` チェーンに `st-btn--md` を追加。height / padding /
  font-size は `.st-btn--{size}` modifier にのみ定義されており (React 層は
  CVA が常に emit)、素の `st-btn st-btn--primary` では潰れたボタンになる。
  `examples/` ハーネス / `cssApiSamples.html.ts` fixture (SSOT) に整合させた。
- `storybook-guideline.md` の 7 グループ IA 表: 空の `Getting Started`
  グループを「予約席」として明文化 (#112/#113 の README superseded 判断を反映)。

- (review-pr P1 反映) **最小クラスチェーン (block + variant + size) を明文化**:
  css-api.md (BEM rules + Quick reference) と README (Vanilla quick start 直下) に
  「size modifier は必須 — 寸法は `--{sm|md|lg}` にのみ定義、base にフォールバックなし」
  を追記。size-less チェーンの再生産を執筆時点で防ぐ。

## Why

#168 (1.0 DoD) — framework-agnostic 利用例が全公開サーフェスで「現行実装で
実際に動く形」であることの最終確認。スイープの全結果 (✅ 一覧) は
#168 のコメントに記録。

## Related rules

- .claude/rules/css-api.md (size modifier は `--sm/--md/--lg`、React 側 CVA と同じチェーンが vanilla の契約)
- .claude/rules/storybook-guideline.md (7 グループ IA — 本 PR で予約席注記を追記)

## Test plan

- [x] `pnpm lint` 緑
- [x] `pnpm test --run` 緑 (1126 tests、CSSApi.coverage 含む)
- [x] `pnpm typecheck` 緑
- [x] `pnpm check:readme` / `pnpm check:manifest` 緑
- [x] VRT 411 テスト zero-diff (CSSApi / CSSApiDist 含む、stale 6006 なし確認済み)

closes #168

🤖 Generated with [Claude Code](https://claude.com/claude-code)

