### PR TITLE
test(examples): vanilla ハーネスに Dialog / DropdownMenu の静的シェルを追加 (refs #167)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,15 @@ jobs:
       - name: README components drift
         run: pnpm check:readme
 
+      # The vanilla harness (examples/vanilla-html/index.html) is the
+      # human-eyeball surface for the class API, but nothing else gates it —
+      # audit:coverage forces the CSS API fixture complete, and the harness
+      # silently stayed at 23/25 when Dialog / DropdownMenu landed (found in
+      # #167 refinement, fixed in PR #488). Requires a data-component sample
+      # per lv1, both directions. No build dependency.
+      - name: Vanilla harness coverage drift
+        run: pnpm check:harness
+
       # Catches drift between `.claude/rules/css-api.md` §`@layer order` and
       # `src/styles/entry.css` — exactly the kind of doc-vs-implementation
       # mismatch that hid the preflight-priority bug fixed in #277. Runs in

--- a/examples/vanilla-html/README.md
+++ b/examples/vanilla-html/README.md
@@ -18,10 +18,10 @@ open index.html         # macOS  (or: xdg-open / just double-click)
 - **Theme toggles** — the toolbar toggles Mode (`.dark` class on `<html>`) and
   Special (`data-theme="season--*"` on `<html>`). Both are one attribute write;
   the browser re-resolves every `var()` at the next paint.
-- **区分 A/B (17 components)** — Text, Icon, Button, Badge, Callout, Spinner,
+- **区分 A/B** — Text, Icon, Button, Badge, Callout, Spinner,
   Input, Textarea, Checkbox, Switch, Radio, Separator, Field, FieldSet, Card,
   Skeleton, Table. Fully functional from the class API + HTML/ARIA attributes.
-- **区分 C/D (8 components)** — Avatar, Tooltip, Select, Toast, Popover, Tabs,
+- **区分 C/D** — Avatar, Tooltip, Select, Toast, Popover, Tabs,
   Dialog, DropdownMenu. Shown as **static class rendering only**; their
   interactive behaviour needs the React layer (see the on-page note).
 

--- a/examples/vanilla-html/README.md
+++ b/examples/vanilla-html/README.md
@@ -21,6 +21,9 @@ open index.html         # macOS  (or: xdg-open / just double-click)
 - **区分 A/B** — Text, Icon, Button, Badge, Callout, Spinner,
   Input, Textarea, Checkbox, Switch, Radio, Separator, Field, FieldSet, Card,
   Skeleton, Table. Fully functional from the class API + HTML/ARIA attributes.
+  Input / Textarea interact browser-natively; Checkbox / Switch / Radio
+  toggle via the few lines of state-flipping JS in the page script
+  (`aria-checked` / `data-state` — the wiring the React layer does for you).
 - **区分 C/D** — Avatar, Tooltip, Select, Toast, Popover, Tabs,
   Dialog, DropdownMenu. Shown as **static class rendering only**; their
   interactive behaviour needs the React layer (see the on-page note).

--- a/examples/vanilla-html/index.html
+++ b/examples/vanilla-html/index.html
@@ -290,7 +290,7 @@
           </div>
 
           <div class="demo-sample" data-component="switch">
-            <span class="demo-sample__label">Switch — .st-switch</span>
+            <span class="demo-sample__label">Switch — .st-switch (click toggles via JS below)</span>
             <div class="demo-row">
               <div class="st-switch-wrapper">
                 <button type="button" id="sw-1" role="switch" aria-checked="true" data-state="checked" class="st-switch st-switch--md">
@@ -303,7 +303,7 @@
           </div>
 
           <div class="demo-sample" data-component="radio">
-            <span class="demo-sample__label">Radio — .st-radio</span>
+            <span class="demo-sample__label">Radio — .st-radio (click toggles via JS below)</span>
             <div role="radiogroup" class="st-radio-group">
               <div class="st-radio-wrapper">
                 <button type="button" id="r-a" role="radio" aria-checked="false" data-state="unchecked" class="st-radio st-radio--md"></button>
@@ -574,6 +574,27 @@
           el.setAttribute('data-state', next ? 'checked' : 'unchecked')
           const thumb = el.querySelector('[class*="__thumb"]')
           if (thumb) thumb.setAttribute('data-state', next ? 'checked' : 'unchecked')
+        })
+      }
+
+      // Radio needs one extra step on top of the attribute flips above:
+      // Radix *unmounts* the indicator when unchecked (Radio.css has no
+      // CSS hide rule, unlike Checkbox's forceMount + display:none), so
+      // the consumer adds/removes the indicator element alongside the
+      // aria-checked / data-state flip. Group behavior: picking one
+      // unchecks the rest.
+      const RADIO_INDICATOR =
+        '<span class="st-radio__indicator"><span class="st-radio__dot"></span></span>'
+      for (const group of document.querySelectorAll('.st-radio-group')) {
+        group.addEventListener('click', (e) => {
+          const picked = e.target.closest('.st-radio')
+          if (!picked) return
+          for (const radio of group.querySelectorAll('.st-radio')) {
+            const checked = radio === picked
+            radio.setAttribute('aria-checked', String(checked))
+            radio.setAttribute('data-state', checked ? 'checked' : 'unchecked')
+            radio.innerHTML = checked ? RADIO_INDICATOR : ''
+          }
         })
       }
     </script>

--- a/examples/vanilla-html/index.html
+++ b/examples/vanilla-html/index.html
@@ -106,6 +106,31 @@
         white-space: nowrap;
         border: 0;
       }
+      /* Dialog's portal-mounted markup uses fixed positioning in production.
+         Scope it to a host box (same technique as the CSSApiDist fixture's
+         .cssapi-fixture__dialog-host) so the static sample doesn't take over
+         the viewport. Demo chrome only — NOT part of the public API. */
+      .demo-dialog-host {
+        position: relative;
+        min-height: 12rem;
+        border-radius: 0.375rem;
+        overflow: hidden;
+        isolation: isolate;
+      }
+      .demo-dialog-host .st-dialog__overlay,
+      .demo-dialog-host .st-dialog__content {
+        position: absolute;
+      }
+      .demo-dialog-host .st-dialog__overlay {
+        inset: 0;
+      }
+      .demo-dialog-host .st-dialog__content {
+        top: 50%;
+        left: 50%;
+        translate: -50% -50%;
+        max-width: 22rem;
+        width: 90%;
+      }
     </style>
   </head>
 
@@ -448,6 +473,76 @@
                 <button class="st-tabs__trigger" role="tab" type="button" data-state="inactive" aria-selected="false">Password</button>
               </div>
               <div class="st-tabs__content" role="tabpanel">Manage your account details.</div>
+            </div>
+          </div>
+
+          <div class="demo-sample" data-component="dialog">
+            <span class="demo-sample__label">Dialog — .st-dialog__* (static, scoped)</span>
+            <div class="demo-dialog-host">
+              <div class="st-dialog__overlay"></div>
+              <div class="st-dialog__content" role="dialog" aria-modal="true"
+                   aria-labelledby="demo-dialog-title" aria-describedby="demo-dialog-desc">
+                <div class="st-dialog__header">
+                  <h2 id="demo-dialog-title" class="st-dialog__title">Confirm</h2>
+                  <p id="demo-dialog-desc" class="st-dialog__description">Are you sure?</p>
+                </div>
+                <div class="st-dialog__footer">
+                  <button type="button" class="st-btn st-btn--secondary st-btn--md">
+                    <span class="st-btn__spinner-overlay" aria-hidden="true"></span>
+                    <span class="st-btn__content">Cancel</span>
+                  </button>
+                  <button type="button" class="st-btn st-btn--primary st-btn--md">
+                    <span class="st-btn__spinner-overlay" aria-hidden="true"></span>
+                    <span class="st-btn__content">Confirm</span>
+                  </button>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <div class="demo-sample" data-component="dropdownmenu">
+            <span class="demo-sample__label">DropdownMenu — .st-dropdown-menu__* (static, no portal)</span>
+            <div class="st-dropdown-menu__content" role="menu" data-state="open" style="position: static;">
+              <div class="st-dropdown-menu__label">Actions</div>
+              <div class="st-dropdown-menu__separator"></div>
+              <div class="st-dropdown-menu__item" role="menuitem" data-highlighted>
+                <svg class="st-dropdown-menu__item-icon" viewBox="0 0 24 24" fill="none"
+                     stroke="currentColor" stroke-width="2" stroke-linecap="round"
+                     stroke-linejoin="round" aria-hidden="true">
+                  <path d="M12 20h9" /><path d="M16.5 3.5a2.1 2.1 0 0 1 3 3L7 19l-4 1 1-4Z" />
+                </svg>
+                Edit
+                <span class="st-dropdown-menu__shortcut">⌘E</span>
+              </div>
+              <div class="st-dropdown-menu__item st-dropdown-menu__checkbox-item" role="menuitemcheckbox" aria-checked="true">
+                <span class="st-dropdown-menu__item-indicator">
+                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+                       stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                    <path d="M20 6 9 17l-5-5" />
+                  </svg>
+                </span>
+                Status Bar
+              </div>
+              <div class="st-dropdown-menu__item st-dropdown-menu__radio-item" role="menuitemradio" aria-checked="true">
+                <span class="st-dropdown-menu__item-indicator">
+                  <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+                    <circle cx="12" cy="12" r="12" />
+                  </svg>
+                </span>
+                Bottom
+              </div>
+              <div class="st-dropdown-menu__item st-dropdown-menu__sub-trigger" role="menuitem" data-state="closed">
+                Share
+                <svg class="st-dropdown-menu__sub-trigger-chevron" viewBox="0 0 24 24" fill="none"
+                     stroke="currentColor" stroke-width="2" stroke-linecap="round"
+                     stroke-linejoin="round" aria-hidden="true">
+                  <path d="m9 18 6-6-6-6" />
+                </svg>
+              </div>
+              <div class="st-dropdown-menu__separator"></div>
+              <div class="st-dropdown-menu__item st-dropdown-menu__item--destructive" role="menuitem">
+                Delete
+              </div>
             </div>
           </div>
         </div>

--- a/examples/vanilla-html/index.html
+++ b/examples/vanilla-html/index.html
@@ -184,7 +184,7 @@
            ================================================================ -->
       <section class="demo-section">
         <h2 class="st-text st-text--heading st-text--md st-text--default" style="margin-bottom: 1rem;">
-          Fully functional (区分 A/B — 17 components)
+          Fully functional (区分 A/B)
         </h2>
         <div class="demo-grid">
           <div class="demo-sample" data-component="text">
@@ -411,7 +411,7 @@
            ================================================================ -->
       <section class="demo-section">
         <h2 class="st-text st-text--heading st-text--md st-text--default" style="margin-bottom: 1rem;">
-          React-required (区分 C/D — 8 components, static class only)
+          React-required (区分 C/D — static class only)
         </h2>
         <div class="demo-note">
           These render their visual shell from the class API, but do

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "check:manifest:export": "node scripts/check-manifest-export.mjs",
     "sync:readme": "node scripts/sync-readme-components.mjs",
     "check:readme": "node scripts/sync-readme-components.mjs --check",
+    "check:harness": "node scripts/check-harness-sync.mjs",
     "check:use-client": "node scripts/check-use-client-banner.mjs",
     "audit:coverage": "node scripts/audit-coverage.mjs",
     "schatten:csp-hash": "node scripts/print-csp-hash.mjs",

--- a/scripts/__tests__/check-harness-sync.test.ts
+++ b/scripts/__tests__/check-harness-sync.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest'
+import { diffHarnessSlugs, parseHarnessSlugs } from '../check-harness-sync.mjs'
+
+// Unit tests for the pure helpers behind the `check:harness` gate. Feeding
+// them string fixtures keeps the assertions independent of the real harness —
+// the CI script itself is what wires them to `examples/vanilla-html/index.html`
+// and `discoverLv1()` at the integration layer.
+
+describe('parseHarnessSlugs', () => {
+  it('collects every data-component slug in the source', () => {
+    const source = `
+      <div class="demo-sample" data-component="button">…</div>
+      <div class="demo-sample" data-component="dialog">…</div>
+      <div class="demo-sample" data-component="dropdownmenu">…</div>
+    `
+    expect(parseHarnessSlugs(source)).toEqual(new Set(['button', 'dialog', 'dropdownmenu']))
+  })
+
+  it('dedupes repeated slugs', () => {
+    const source = '<i data-component="button"></i><i data-component="button"></i>'
+    expect(parseHarnessSlugs(source)).toEqual(new Set(['button']))
+  })
+
+  it('returns an empty set when no marker is present', () => {
+    expect(parseHarnessSlugs('<html><body>no markers</body></html>')).toEqual(new Set())
+  })
+})
+
+describe('diffHarnessSlugs', () => {
+  it('reports nothing when the sets match', () => {
+    const { missing, orphaned } = diffHarnessSlugs(
+      ['button', 'dialog'],
+      new Set(['dialog', 'button']),
+    )
+    expect(missing).toEqual([])
+    expect(orphaned).toEqual([])
+  })
+
+  it('reports an lv1 without a harness sample as missing (the PR #488 drift)', () => {
+    const { missing, orphaned } = diffHarnessSlugs(
+      ['button', 'dialog', 'dropdownmenu'],
+      new Set(['button']),
+    )
+    expect(missing).toEqual(['dialog', 'dropdownmenu'])
+    expect(orphaned).toEqual([])
+  })
+
+  it('reports a harness sample without an lv1 directory as orphaned', () => {
+    const { missing, orphaned } = diffHarnessSlugs(
+      ['button'],
+      new Set(['button', 'ghost-component']),
+    )
+    expect(missing).toEqual([])
+    expect(orphaned).toEqual(['ghost-component'])
+  })
+
+  it('sorts both lists for stable output', () => {
+    const { missing, orphaned } = diffHarnessSlugs(
+      ['b-comp', 'a-comp'],
+      new Set(['z-orphan', 'y-orphan']),
+    )
+    expect(missing).toEqual(['a-comp', 'b-comp'])
+    expect(orphaned).toEqual(['y-orphan', 'z-orphan'])
+  })
+})

--- a/scripts/check-harness-sync.d.mts
+++ b/scripts/check-harness-sync.d.mts
@@ -1,0 +1,22 @@
+// TypeScript declarations for scripts/check-harness-sync.mjs. The .mjs
+// carries JSDoc-typed annotations, but typed consumers
+// (scripts/__tests__/check-harness-sync.test.ts) import the helpers from a
+// .ts module — an explicit .d.mts gives TypeScript a strongly-typed view
+// without converting the script to .ts. Mirrors the lv1-slugs.d.mts /
+// check-manifest-export.d.mts pattern.
+
+/** Repo-relative path of the vanilla-HTML verification harness. */
+export const HARNESS_REL: string
+
+/** Collect every `data-component="<slug>"` slug in the harness source. */
+export function parseHarnessSlugs(source: string): Set<string>
+
+/**
+ * Diff the on-disk lv1 slug set against the harness slug set. `missing` =
+ * lv1 with no harness sample; `orphaned` = harness sample with no matching
+ * lv1. Both sorted.
+ */
+export function diffHarnessSlugs(
+  lv1Slugs: Iterable<string>,
+  harnessSlugs: Set<string>,
+): { missing: string[]; orphaned: string[] }

--- a/scripts/check-harness-sync.mjs
+++ b/scripts/check-harness-sync.mjs
@@ -1,0 +1,95 @@
+#!/usr/bin/env node
+// Check that the vanilla-HTML verification harness
+// (`examples/vanilla-html/index.html`) carries a
+// `data-component="<slug>"` sample for every lv1 component on disk —
+// and no orphaned samples for components that no longer exist.
+//
+// Why this exists: the harness is a hand-maintained copy of the class
+// API surface, and nothing else gates it. The CSS API fixture
+// (`src/docs/__fixtures__/cssApiSamples.html.ts`) is forced complete by
+// `pnpm audit:coverage` (fixture column), but when Dialog / DropdownMenu
+// landed, the harness silently stayed at 23/25 while
+// `examples/vanilla-html/README.md` and
+// `docs/verification/framework-agnostic.md` both claimed full static
+// coverage (found during #167 refinement, fixed in PR #488). This script
+// makes that drift class impossible to ship: a new lv1 must add its
+// harness sample in the same PR, or the `lint` job fails.
+//
+// The coverage chain after this gate:
+//   lv1 dirs on disk ──audit:coverage──▶ CSS API fixture (dist VRT input)
+//   lv1 dirs on disk ──check:harness──▶ vanilla harness (human-eyeball surface)
+//
+// The slug convention is `discoverLv1()`'s: lowercased component name
+// (`DropdownMenu` → `dropdownmenu`), the same value the fixture uses.
+//
+// Run as `pnpm check:harness`. Wired into CI's `lint` job. No build
+// dependency — reads only the lv1 directories and the harness HTML.
+
+import { existsSync, readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { discoverLv1 } from './lv1-slugs.mjs'
+
+export const HARNESS_REL = 'examples/vanilla-html/index.html'
+
+// Same shape as audit-coverage.mjs's DATA_COMPONENT_RE — the marker is
+// the contract both the fixture and the harness annotate samples with.
+const DATA_COMPONENT_RE = /data-component="([^"]+)"/g
+
+/**
+ * Collect every `data-component="<slug>"` slug in the harness source.
+ *
+ * @param {string} source harness HTML source text
+ * @returns {Set<string>}
+ */
+export function parseHarnessSlugs(source) {
+  const slugs = new Set()
+  for (const m of source.matchAll(DATA_COMPONENT_RE)) {
+    slugs.add(m[1])
+  }
+  return slugs
+}
+
+/**
+ * Diff the on-disk lv1 slug set against the harness slug set.
+ *
+ * @param {Iterable<string>} lv1Slugs slugs derived from `src/components/lv1/`
+ * @param {Set<string>} harnessSlugs slugs found in the harness
+ * @returns {{ missing: string[], orphaned: string[] }} `missing` = lv1 with no
+ *   harness sample; `orphaned` = harness sample with no matching lv1. Both
+ *   sorted for stable output.
+ */
+export function diffHarnessSlugs(lv1Slugs, harnessSlugs) {
+  const lv1 = new Set(lv1Slugs)
+  const missing = [...lv1].filter((s) => !harnessSlugs.has(s)).sort()
+  const orphaned = [...harnessSlugs].filter((s) => !lv1.has(s)).sort()
+  return { missing, orphaned }
+}
+
+const isCliEntry = import.meta.url === `file://${resolve(process.argv[1] ?? '')}`
+
+if (isCliEntry) {
+  if (!existsSync(HARNESS_REL)) {
+    console.error(`✗ harness not found: ${HARNESS_REL} (run from the repo root)`)
+    process.exit(1)
+  }
+
+  const lv1Slugs = discoverLv1().map((e) => e.slug)
+  const harnessSlugs = parseHarnessSlugs(readFileSync(HARNESS_REL, 'utf8'))
+  const { missing, orphaned } = diffHarnessSlugs(lv1Slugs, harnessSlugs)
+
+  if (missing.length > 0 || orphaned.length > 0) {
+    console.error(`✗ vanilla harness drift against src/components/lv1/ (${HARNESS_REL}):\n`)
+    for (const s of missing) {
+      console.error(
+        `  - missing sample: no <... data-component="${s}"> — add a static sample ` +
+          `(port it from src/docs/__fixtures__/cssApiSamples.html.ts)`,
+      )
+    }
+    for (const s of orphaned) {
+      console.error(`  - orphaned sample: data-component="${s}" has no lv1 directory`)
+    }
+    process.exit(1)
+  }
+
+  console.log(`✓ vanilla harness covers all ${lv1Slugs.length} lv1 components (${HARNESS_REL})`)
+}


### PR DESCRIPTION
## 概要

#167 (1.0 DoD — クラス名公開 API 棚卸し確認) の refinement で発見したドキュメント⇄ハーネス drift の解消 + 再発防止 gate。

vanilla ハーネスの 区分 C/D セクションが 6/8 (Dialog / DropdownMenu 欠落) で、以下 2 つの「8 個静的掲載」記載と食い違っていた:

- `examples/vanilla-html/README.md` — 「区分 C/D … Shown as static class rendering only」
- `docs/verification/framework-agnostic.md` — 区分 C/D 表の Dialog「overlay + content の静的描画」/ DropdownMenu「メニューパネルの静的描画」

## 変更内容

### 1. ハーネスを 25/25 に (commit 1)

`CSSApiDist.vrt.spec.ts` の fixture (`cssApiSamples.html.ts`) から vanilla-safe マークアップを移植:

- **Dialog**: fixture と同じ host スコープ手法 — `.demo-dialog-host` (demo chrome、公開 API 外) で `position: fixed` を absolute に閉じ込め
- **DropdownMenu**: `position: static` 化した `.st-dropdown-menu__content` + label / separator / item (icon+shortcut) / checkbox-item / radio-item / sub-trigger / destructive の全 sub-element

### 2. 再発防止 gate `check:harness` (commit 2 — セルフレビュー P2 の前倒し)

ハーネスは fixture と違い `audit:coverage` の対象外で、今回の drift はその非対称が原因。`scripts/check-harness-sync.mjs` を新設し CI `lint` job に配線:

- lv1 slug 集合 (`discoverLv1()` SSOT) ⇔ ハーネスの `data-component` 集合を**双方向**照合 (missing / orphaned)
- カバレッジ連鎖: lv1 → fixture は `audit:coverage`、lv1 → ハーネスは `check:harness`
- pure helper を unit test (7 cases) + `.d.mts` 型定義 (repo 規約)

### 3. 個数ハードコードの削除 (commit 2)

ハーネス見出し・README の「17 components」「8 components」を削除。「18 lv1」表記と同じ腐敗クラスで、gate が守るのは集合なので数を書く必要がない。

### 4. Radio のトグル配線 (commit 3)

Checkbox / Switch には consumer-wiring デモ JS が既にあったが、**Radio だけ未配線**でクリックが no-op だった (レビュー中にユーザー操作で発見)。Radio は属性 flip に加えて indicator の **DOM 付け外し**が必要 (Radix は unchecked 時 indicator を unmount する契約 — Checkbox の forceMount + CSS hide と違う) なため取り残されていた。グループ動作込みで配線し、Radio / Switch のラベルに「(click toggles via JS below)」注記、README に state-flipping JS の一文を追記。

Playwright 実クリック検証: A 選択 → dot 移動 + `aria-checked` / `data-state` 反転、label 経由の選択、Checkbox / Switch の既存配線の無事を確認。

## 検証

- Playwright Chromium で `file://` を直接開き実測 (docs/verification と同手法): 25 セクション、`.st-dialog__content` bg = surface / host 内 absolute、overlay `rgba(0,0,0,0.5)`、destructive item = `oklch(0.46 0.14 22)`、light / dark スクリーンショット目視確認済み
- sanity: `.st-btn--primary` bg = `oklch(0.37 0.01 70)` (framework-agnostic.md の記録値と一致)
- `pnpm check:harness` ✓ (25/25) / 新規 unit test 7 passed / `pnpm typecheck` ✓ / `pnpm lint` ✓

## changeset

なし (`no-changeset` ラベル) — `examples/` は npm tarball 外、`scripts/` + CI は内部 tooling で公開 surface 外。

refs #167

🤖 Generated with [Claude Code](https://claude.com/claude-code)
