### PR TITLE
release(1.0): API stability commitment 発効 — reconcile pass + CVA exact pin (closes #170)

### DIFF
--- a/.changeset/api-stability-cva-pin-170.md
+++ b/.changeset/api-stability-cva-pin-170.md
@@ -1,0 +1,10 @@
+---
+'@yasmro/schatten': patch
+---
+
+Pin `class-variance-authority` exact (`0.7.1`) as required by the v1.0.0 API
+stability contract (api-stability.md § CVA output stability, #170). CVA output
+strings are public API — a floating range would let a consumer's lockfile
+resolve a different 0.7.x patch than the one Schatten tested, shifting the
+emitted class chain without a Schatten release. No behavior change today:
+0.7.1 is the only version the previous `^0.7.1` range could resolve.

--- a/.claude/rules/api-stability.md
+++ b/.claude/rules/api-stability.md
@@ -78,7 +78,7 @@ we will not consider their breakage when scoping a release.
 | **1.0+ patch** | Bug fixes only. No public API **surface** changes — no renames, removals, or additions. Token value tweaks (e.g. a slight hex shift on `--color-primary-600`) are permitted because they don't change the *contract*, only the *value at the named slot*; flag them in the CHANGELOG. |
 | **1.0+ minor** | Additive surface changes only (new components, new variants, new CSS variables, new exports). Existing surface must remain compatible. |
 | **1.0+ major** | Breaking changes permitted. Must ship a migration guide. |
-| **Deprecation** | Anything to be removed in a major must spend at least one full major cycle marked deprecated first — in TSDoc (`@deprecated`), in console warnings where feasible, and in the CHANGELOG. |
+| **Deprecation** | Anything to be removed in a major must be marked deprecated — in TSDoc (`@deprecated`), in console warnings where feasible, and in the CHANGELOG — for at least one minor release before the removal ships in the next major. (Same rule as step 3 of [When you're about to ship a change](#when-youre-about-to-ship-a-change).) |
 
 ### What counts as "breaking" for CSS
 
@@ -168,7 +168,8 @@ The implications:
   would silently break consumers — cva rides in `dependencies`, so a floating
   range would let a consumer's lockfile resolve a different patch than the one
   Schatten tested, without any Schatten release. Upgrading CVA across a
-  version where output shape changes is a `major`.
+  version where output shape changes is a `major`. Decision log:
+  [docs/decisions/2026-07-cva-exact-pin.md](../../docs/decisions/2026-07-cva-exact-pin.md).
 - The **set** of class names produced for a given variant tuple is part of
   the contract; the **order** within the string is not. This is safe because
   the CVA output is now **`.st-*` classes only** — every variant emits a

--- a/.claude/rules/api-stability.md
+++ b/.claude/rules/api-stability.md
@@ -3,8 +3,8 @@
 ## Overview
 
 This document defines Schatten's **public API stability contract**, in effect from
-**v1.0.0 onward**. Pre-1.0 releases are explicitly **out of scope** — breaking
-changes are permitted in any release while we settle the surface.
+**v1.0.0 onward**. Pre-1.0 releases were explicitly **out of scope** — breaking
+changes were permitted in any release while the surface settled.
 
 Schatten ships both **React components** and a **framework-agnostic CSS layer**
 (see [#58](https://github.com/yasmro/schatten/issues/58)). Both surfaces are
@@ -12,13 +12,15 @@ consumer-facing and need the same stability guarantees. That means CSS class
 names, CSS variable names, and CVA output strings are part of the contract —
 not just the React props.
 
-> **Before tagging the v1.0.0 RC, re-read this document end-to-end** and
-> reconcile it against the actual surface (the `package.json` `exports` map,
-> the generated `dist/schatten.manifest.json` if it exists by then, the
-> exported CSS classes and variables). This doc was written while pre-1.0;
-> some claims (e.g. the class-name audit deadline, the manifest's existence,
-> peer dependency ranges) will need to be confirmed or revised before the
-> contract goes live. Track that review as a v1.0 release blocker.
+> **Reconcile pass completed 2026-07-18**
+> ([#170](https://github.com/yasmro/schatten/issues/170)): this document was
+> re-read end-to-end and reconciled against the v1.0.0 surface — the
+> `package.json` `exports` map (ESM-only,
+> [#479](https://github.com/yasmro/schatten/issues/479)),
+> `src/__generated__/schatten.manifest.json` (classes / dataAttributes /
+> cssVariables), the peer ranges (`react` / `react-dom` `^18 || ^19`,
+> `lucide-react` `^1.0.0` — all optional), and `engines.node: ">=18"`.
+> The contract below is live as of v1.0.0.
 
 ## What counts as public API
 
@@ -72,7 +74,7 @@ we will not consider their breakage when scoping a release.
 
 | Phase | Policy |
 |---|---|
-| **Pre-1.0** (current) | Breaking changes permitted in any release. CHANGELOG should still call them out so early adopters can migrate. |
+| **Pre-1.0** (historical) | Breaking changes were permitted in any release. The CHANGELOG still called them out so early adopters could migrate. |
 | **1.0+ patch** | Bug fixes only. No public API **surface** changes — no renames, removals, or additions. Token value tweaks (e.g. a slight hex shift on `--color-primary-600`) are permitted because they don't change the *contract*, only the *value at the named slot*; flag them in the CHANGELOG. |
 | **1.0+ minor** | Additive surface changes only (new components, new variants, new CSS variables, new exports). Existing surface must remain compatible. |
 | **1.0+ major** | Breaking changes permitted. Must ship a migration guide. |
@@ -161,9 +163,12 @@ WordPress blocks).
 
 The implications:
 
-- **Pin the `class-variance-authority` dependency** at v1.0. CVA changing how
-  it joins, dedupes, or orders class names would silently break consumers.
-  Upgrading CVA across a version where output shape changes is a `major`.
+- **The `class-variance-authority` dependency is pinned exact** (`0.7.1`,
+  since v1.0.0). CVA changing how it joins, dedupes, or orders class names
+  would silently break consumers — cva rides in `dependencies`, so a floating
+  range would let a consumer's lockfile resolve a different patch than the one
+  Schatten tested, without any Schatten release. Upgrading CVA across a
+  version where output shape changes is a `major`.
 - The **set** of class names produced for a given variant tuple is part of
   the contract; the **order** within the string is not. This is safe because
   the CVA output is now **`.st-*` classes only** — every variant emits a
@@ -218,10 +223,15 @@ The contract:
 
 ## Peer dependency ranges
 
-The `peerDependencies` ranges in `package.json` (currently `react` and
-`react-dom` at `^18.0.0 || ^19.0.0`) are part of the contract because consumers
-resolve them against their own trees. If we ever promote `class-variance-authority`
-to a peer dep, the same rules apply.
+The `peerDependencies` ranges in `package.json` — `react` and `react-dom` at
+`^18.0.0 || ^19.0.0`, and `lucide-react` at `^1.0.0` (the icon vendor lock,
+[#223](https://github.com/yasmro/schatten/pull/223)) — are part of the contract
+because consumers resolve them against their own trees. All three are marked
+optional in `peerDependenciesMeta` so CSS-only consumers install warning-free;
+dropping the `optional` flag on an existing peer is breaking (it turns a
+working install into a warning/failure). The narrowing / widening rules below
+apply to all three. If we ever promote `class-variance-authority` to a peer
+dep, the same rules apply.
 
 - **Narrowing a range** (e.g. dropping React 18 support so the package only
   accepts React 19+) is **breaking** — a `major` is required. Some
@@ -378,10 +388,10 @@ Two consequences worth pinning here:
   consumer to rewrite their attribute wiring. (See [css-api.md §state](css-api.md#state-is-expressed-as-attributes-not-classes)
   for the full attribute table.)
 
-The class-name audit is tracked by
-[#154](https://github.com/yasmro/schatten/issues/154) (v0.9.0) and writes
-every public class into the manifest below. Once #154 ships, the manifest
-becomes the diff a reviewer sees on every CSS change.
+The class-name audit shipped in v0.9.0
+([#154](https://github.com/yasmro/schatten/issues/154)) and wrote every public
+class into the manifest below; the manifest is the diff a reviewer sees on
+every CSS change.
 
 ## CSS variable naming — the four-layer model
 
@@ -449,8 +459,9 @@ indirection already resolved to those). See the decision log.
 The class-name audit shipped in v0.9.0 (#58 Phase 2, implemented by
 [#154](https://github.com/yasmro/schatten/issues/154)). The CSS-variable audit
 ([#231](https://github.com/yasmro/schatten/issues/231)) settled the four-layer
-model above before v1.0.0. CONTRIBUTING.md (planned for v0.15.0) will reference
-this document as the source of truth for what consumers can rely on.
+model above before v1.0.0. CONTRIBUTING.md references this document
+([§ Changesets & release](../../CONTRIBUTING.md#changesets--release)) as the
+source of truth for what consumers can rely on.
 
 ## Manifest as the authoritative API listing
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -159,6 +159,16 @@ Pick the bump level per the breaking-change policy and CHANGELOG prefixes in
 the policy table there).
 CI runs `changeset status` and fails a source change that ships without one.
 
+**Breaking changes (post-1.0).** Before shipping a change that renames,
+removes, or re-points anything on the published surface, walk the 3-step
+decision in
+[api-stability.md § When you're about to ship a change](.claude/rules/api-stability.md#when-youre-about-to-ship-a-change):
+(1) is the surface public? (2) is the change purely additive? (3) if breaking
+— `major` bump, a `BREAKING:` changeset entry linking a migration note, and
+the deprecation cycle (at least one minor marked `@deprecated`) observed. CSS
+renames additionally fail `pnpm check:manifest` until the manifest snapshot is
+regenerated and shipped with a `CSS API:` changeset.
+
 **Internal-only PRs** — `.github/` workflows, docs, `.claude/`, test-only work
 — do not touch the published package. Skip the changeset by applying the
 **`no-changeset`** label to the PR. Release mechanics are described in

--- a/README.md
+++ b/README.md
@@ -267,6 +267,18 @@ Moving from a pre-1.0 release? The
 [0.x → 1.0 migration guide](docs/migrations/v0-to-v1.md) lists every breaking
 change with a Before → After and the recommended upgrade order.
 
+### API stability commitment
+
+From **v1.0.0**, Schatten commits to semantic versioning over its full public
+surface — React props and exported types, `.st-*` class names, public CSS
+variables, CVA output strings, the multi-entry `exports` map (ESM-only), the
+theme contract, and the FOUC snippet bytes. Breaking changes ship only in a
+**major**, with a migration guide, after at least one minor marked
+`@deprecated`. The authoritative definition of what is public is
+[`.claude/rules/api-stability.md`](.claude/rules/api-stability.md); the
+machine-readable listing is
+[`schatten.manifest.json`](#programmatic-introspection).
+
 ## SSR / Next.js App Router
 
 From **v0.8.0**, every Schatten lv1 component bundle carries a `'use client'`

--- a/docs/decisions/2026-07-cva-exact-pin.md
+++ b/docs/decisions/2026-07-cva-exact-pin.md
@@ -1,0 +1,38 @@
+# `class-variance-authority` は exact pin（`0.7.1`）で固定する
+
+- **Status**: Accepted
+- **Related**: [#170](https://github.com/yasmro/schatten/issues/170)（API stability
+  発効 — reconcile pass で言行不一致として検出）/
+  [api-stability.md § CVA output stability](../../.claude/rules/api-stability.md#cva-output-stability)
+
+## Context
+
+api-stability.md は「CVA の出力文字列（`buttonVariants({ variant: 'primary' })`
+が返すクラスチェーン）は公開 API であり、v1.0 で cva を pin せよ」と要求して
+いたが、実際の `package.json` は `^0.7.1`（caret）のままだった — #170 の
+reconcile pass で検出した言行不一致。
+
+cva は `peerDependencies` ではなく **`dependencies`** に載っているため、caret の
+ままだと **consumer の lockfile が Schatten のテストした版と異なる 0.7.x patch を
+解決しうる**。cva が join / dedupe / 順序の挙動を patch で変えた場合、Schatten の
+リリースを一切経ずに consumer 側の出力クラスチェーンが動く — CVA output
+stability 契約の穴になる。
+
+## Decision
+
+**`0.7.1` に exact pin する**（v1.0.0 から）。判断材料:
+
+- npm 上の 0.7.x は `0.7.0` / `0.7.1` のみ（canary 除く）で、lockfile も
+  `0.7.1` を解決済み — **pin 実施時点で挙動変化はゼロ**。純粋な将来防御。
+- 「出力が deterministic な契約 / 検査に食い込む依存は exact pin」という既存
+  規律（`vite` / `lightningcss` / `@biomejs/biome` / `sonner`）と同型。
+
+## Consequences
+
+- 以後の cva バンプは dependabot の明示的 PR として届く。**レビュー時は
+  「出力クラスチェーンの形が変わるか」を必ず確認**し、変わるなら `major`
+  （api-stability.md § CVA output stability）。変わらない patch / minor は
+  通常の dependabot triage（squash、visual-contract 依存に準ずる注意）で可。
+- pin 解除（caret へ戻す）は契約の穴を再導入するため不可。緩めたい場合は
+  cva を `peerDependencies` へ昇格する設計変更として別途議論する
+  （api-stability.md § Peer dependency ranges が既にその場合のルールを規定）。

--- a/package.json
+++ b/package.json
@@ -165,7 +165,7 @@
     "@radix-ui/react-switch": "^1.2.6",
     "@radix-ui/react-tabs": "^1.1.14",
     "@radix-ui/react-tooltip": "^1.2.8",
-    "class-variance-authority": "^0.7.1",
+    "class-variance-authority": "0.7.1",
     "clsx": "^2.1.1",
     "sonner": "2.0.7"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,7 +45,7 @@ importers:
         specifier: ^1.2.8
         version: 1.2.12(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       class-variance-authority:
-        specifier: ^0.7.1
+        specifier: 0.7.1
         version: 0.7.1
       clsx:
         specifier: ^2.1.1


### PR DESCRIPTION
## What

- api-stability.md の RC blocker (冒頭 blockquote) を実施記録 (2026-07-18, #170) に置換し、
  未来形記述 4 箇所を確定形に更新
- 実査で発見した言行不一致 2 件を解消:
  - peer ranges の列挙漏れ — `lucide-react ^1.0.0` を明記し、全 peer の `optional` フラグと
    「optional 剥がしは breaking」を追記
  - CVA pin 未実施 — `class-variance-authority` を `0.7.1` に exact pin (doc L164 の明文要求。
    npm 上の 0.7.x は 0.7.1 のみ・lockfile も 0.7.1 解決済みで挙動変化ゼロ)
- README: `### API stability commitment` 節を Installation 配下 (§Upgrading from 0.x 直後) に新設
- CONTRIBUTING: §Changesets & release に breaking-change checklist を追記

## Why

api-stability.md 自身が RC タグ前の end-to-end reconcile を v1.0 release blocker として
要求している (#170)。#479 (ESM-only, PR #484) マージ済みで凍結対象 surface が確定したため発効。
#480 (リリース実施) と #169 (アナウンス) を unblock する。

## Related rules

- [.claude/rules/api-stability.md](.claude/rules/api-stability.md) — 本 PR の編集対象そのもの

## Test plan

- [x] `pnpm lint` 緑
- [x] `pnpm test --run` 緑 (1133/1133)
- [x] `pnpm typecheck` 緑
- [x] `pnpm check:doc-links` / `check:esm-only` (full) / `check:manifest` 緑
- [x] `pnpm build` 緑 — cva pin 前後で解決版 0.7.1 不変 = 出力差分ゼロ
- [x] `changeset status` — 既存 major (ESM-only) が 1.0.0 を牽引、本 PR の patch は相乗り

closes #170

🤖 Generated with [Claude Code](https://claude.com/claude-code)
