### PR TITLE
docs(release): 1.0 DoD 記録 — #167 再検証追記 + README バッジ (refs #167, #169)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Schatten
 
 [![npm](https://img.shields.io/npm/v/@yasmro/schatten.svg)](https://www.npmjs.com/package/@yasmro/schatten)
+[![release](https://img.shields.io/github/v/release/yasmro/schatten?label=release&color=16a34a)](https://github.com/yasmro/schatten/releases/latest)
+[![API stability](https://img.shields.io/badge/API%20stability-1.0%20contract-16a34a)](#api-stability-commitment)
 
 > **A two-layer design system: framework-agnostic CSS + optional React components.**
 

--- a/docs/verification/framework-agnostic.md
+++ b/docs/verification/framework-agnostic.md
@@ -125,6 +125,46 @@ ad-hoc 検証（spec はコミットしない）— で確認。**計測値は�
 チェックボックス設置済み。#479（ESM-only 化）は JS エントリのみで CSS の dist
 パスに触れないため、本記録は 1.0.0 でも配信経路の証明として有効。
 
+## 1.0 時点の再検証（§2.8.1 出口条件） — #167
+
+v1.0.0 release 候補 commit **`5a33f982a`**（develop、2026-07-18）上で
+[#167](https://github.com/yasmro/schatten/issues/167) の runbook を実施。
+
+### 機械 gate（ローカル + CI）
+
+| gate | 結果 |
+|---|---|
+| `pnpm check:manifest` / `check:manifest:export` | ✅ in sync（252 classes / 8 attrs / 127 vars） |
+| `pnpm check:layer-order` | ✅ `theme, base, reset, tokens, components, utilities` |
+| `pnpm audit:coverage --check` | ✅ 全 25 lv1 companions 充足 |
+| `pnpm check:registrar` / `check:esm-only` / `check:harness` | ✅（registrar 127 declared / ESM-only clean / ハーネス 25/25） |
+| VRT（`test:vrt` 全 411 テスト — dist 52 本 + parity 17 系列 + interaction 含む） | ✅ committed baseline に対し zero-diff（`--update-snapshots` 不使用） |
+| CI（commit `5a33f982a`） | ✅ lint / test / typecheck / size / **a11y** / audit 全 success（vrt / manifest は同一 tree の PR #489 で pass） |
+
+### manifest 凍結スキャン
+
+counts 252 / 8 / 127（issue 記載の期待値と一致）。classes は全て `st-` prefix
++ BEM 3 形のみ（collapsed modifier ゼロ）、dataAttributes は既知 8 個と完全一致、
+cssVariables は primitive 混入ゼロ・全変数が四層モデル layer 2/3/4 にマップ。
+承認記録は #167 コメント。
+
+### vanilla ハーネス（25/25 + Mode × Special）
+
+ローカル dist でハーネスを開き、25 セクション全ての実描画（layout box +
+computed style）と、Mode（`.dark`）× Special（`data-theme`）の 4 象限を実測:
+
+| 状態 | `--color-solid` → `.st-btn--primary` 実背景 |
+|---|---|
+| light | `oklch(37% .01 70)`（= theme-700、alabaster） |
+| dark | `oklch(83% .01 70)`（= theme-300 — rung flip 動作） |
+| light × `season--spring-early` | `oklch(46% .08 12)` 系 ramp の 700 rung（紅） |
+| dark × `season--spring-early` | `oklch(83% .08 12)`（= seasonal ramp の 300 rung） |
+
+「Mode が rung を選び、Special が ramp を供給する」二軸合成が vanilla でも
+成立。`info` は seasonal 下でも blue に pinned。既存
+`screenshots/vanilla-*.png` は再撮影しない — 全 411 VRT が zero-diff で
+描画不変を証明しており、同一描画の再撮影は churn（#468 と同じ判断）。
+
 ## TODO
 
 - [ ] （後続 [#483](https://github.com/yasmro/schatten/issues/483)）この記録の


### PR DESCRIPTION
## What

- `docs/verification/framework-agnostic.md` に **「1.0 時点の再検証（§2.8.1 出口条件）」節を追記** — #167 runbook の実施記録 (candidate commit `5a33f982a` / 機械 gate 全 green / VRT 411 テスト zero-diff / manifest 凍結スキャン 252/8/127 / vanilla ハーネス 25/25 + Mode × Special 4 象限の computed-style 実測)
- README に **release バッジ + API stability バッジ**を追加 (#169 のバッジ担当分 — release バッジは GitHub Releases 連動で v1.0.0 publish 後に自動反映、stability バッジは #170 で新設した `### API stability commitment` 節へアンカー)

## Why

#167 (クラス名公開 API 棚卸し確認) の DoD 「検証結果を docs/verification へ追記」と、#169 の DoD 「README バッジ追加」を release 前に消化する。verification-only のため changeset 不要 (`no-changeset`)。

## Test plan

- [x] `pnpm lint` / `check:doc-links` (279 links) / `check:readme` 緑

refs #167, #169

🤖 Generated with [Claude Code](https://claude.com/claude-code)
