### PR TITLE
infra(pages): site/ + storybook/ ディレクトリ分離と docs サイト本番デプロイ(closes #502)

### DIFF
--- a/.github/pages-root/index.html
+++ b/.github/pages-root/index.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<!-- Pages root router (#502). The root belongs to nobody: it routes readers
+     to the two surfaces that live under named directories.
+
+     - Old-style Storybook deep links carry `?path=` — send them to
+       storybook/ so pre-migration links keep working.
+     - Everyone else goes to site/ (the public docs site).
+     - <noscript> falls back to site/.
+
+     Deployed to the Pages root by deploy-site.yml. The PR-preview workflow
+     (storybook-preview.yml) copies the SAME file to pr/<n>/, so the preview
+     tree mirrors production exactly. -->
+<meta charset="utf-8">
+<title>Schatten</title>
+<script>
+  var q = location.search;
+  location.replace(q.indexOf('path=') !== -1 ? 'storybook/' + q : 'site/');
+</script>
+<noscript><meta http-equiv="refresh" content="0; url=site/"></noscript>

--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -1,0 +1,72 @@
+name: Deploy Docs Site
+
+# The public docs site is RELEASE-TAG-SYNCED (#449 論点 (5) / #502): readers can
+# only install npm latest, so the site describes released state, never develop.
+# workflow_dispatch exists for the initial publication and for re-deploys of an
+# already-released state (run it on a tag, or on develop only when develop's
+# site content still describes npm latest).
+#
+# This workflow also owns the Pages ROOT: a router page (shared with the PR
+# preview) that sends `?path=` deep links to storybook/ and everyone else to
+# site/. Deploying it here — with clean-exclude for the named directories —
+# also sweeps any legacy files left at the root by the pre-#502 layout.
+
+on:
+  push:
+    tags: ['v*']
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: pnpm/action-setup@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Build library (dist the site consumes)
+        run: pnpm build
+
+      # Same gates as the CI docs job — a tag deploy must not publish what a
+      # PR would have failed on.
+      - name: Type-check docs site
+        run: pnpm --filter schatten-docs exec astro check
+
+      - name: Check Storybook links
+        run: pnpm --filter schatten-docs check:links
+
+      - name: Build docs site
+        env:
+          DOCS_BASE: /schatten/site/
+        run: pnpm --filter schatten-docs build
+
+      - name: Deploy site
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          folder: apps/docs/dist
+          target-folder: site
+          clean: true
+
+      - name: Deploy root router
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          folder: .github/pages-root
+          target-folder: ''
+          clean: true
+          # Everything that legitimately lives under the root, by name.
+          # NOT excluded on purpose: the legacy pre-#502 layout (Storybook
+          # files at the root, the old /next/) — this clean is what retires it.
+          clean-exclude: |
+            site
+            storybook
+            pr

--- a/.github/workflows/deploy-storybook.yml
+++ b/.github/workflows/deploy-storybook.yml
@@ -14,23 +14,25 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      # Resolve where this build is published, based on the pushed ref:
-      #   main    -> root (/schatten/)        — canonical, consumer-facing
-      #   develop -> /next/ (/schatten/next/) — unreleased integration preview
+      # Resolve where this build is published, based on the pushed ref (#502 —
+      # the Pages root belongs to nobody; it carries only the router page that
+      # deploy-site.yml owns):
+      #   main    -> /storybook/       — released, what the docs site links to
+      #   develop -> /storybook/next/  — unreleased integration preview
       - name: Resolve deploy target
         id: target
         run: |
           if [ "${{ github.ref }}" = "refs/heads/develop" ]; then
             {
-              echo "base=/schatten/next/"
+              echo "base=/schatten/storybook/next/"
               echo "channel=next"
-              echo "target-folder=next"
+              echo "target-folder=storybook/next"
             } >> "$GITHUB_OUTPUT"
           else
             {
-              echo "base=/schatten/"
+              echo "base=/schatten/storybook/"
               echo "channel=stable"
-              echo "target-folder="
+              echo "target-folder=storybook"
             } >> "$GITHUB_OUTPUT"
           fi
 
@@ -53,10 +55,12 @@ jobs:
         uses: JamesIves/github-pages-deploy-action@v4
         with:
           folder: storybook-static
-          # main -> root; develop -> next/ subpath (root stays canonical)
+          # main -> storybook/; develop -> storybook/next/ (#502)
           target-folder: ${{ steps.target.outputs.target-folder }}
           clean: true
-          # main deploy must not wipe PR previews or the develop /next/ build
+          # clean-exclude is relative to target-folder: the main deploy
+          # (storybook/) must not wipe the develop build at storybook/next/.
+          # The develop deploy targets storybook/next/ itself, where the
+          # exclude simply matches nothing.
           clean-exclude: |
-            pr
             next

--- a/.github/workflows/storybook-preview.yml
+++ b/.github/workflows/storybook-preview.yml
@@ -50,18 +50,9 @@ jobs:
           mkdir -p preview-dist/storybook preview-dist/site
           cp -r storybook-static/. preview-dist/storybook/
           cp -r apps/docs/dist/. preview-dist/site/
-          # Router: old-style Storybook deep links carry ?path= — send them to
-          # storybook/, everyone else to site/. <noscript> falls back to site/.
-          cat > preview-dist/index.html <<'HTML'
-          <!doctype html>
-          <meta charset="utf-8">
-          <title>Schatten</title>
-          <script>
-            var q = location.search;
-            location.replace(q.indexOf('path=') !== -1 ? 'storybook/' + q : 'site/');
-          </script>
-          <noscript><meta http-equiv="refresh" content="0; url=site/"></noscript>
-          HTML
+          # Router page — the SAME file production deploys to the Pages root
+          # (deploy-site.yml), so the preview tree mirrors production exactly.
+          cp .github/pages-root/index.html preview-dist/index.html
 
       - name: Deploy preview
         uses: JamesIves/github-pages-deploy-action@v4

--- a/.storybook/manager.ts
+++ b/.storybook/manager.ts
@@ -18,7 +18,7 @@ if (isNextChannel) {
       base: 'light',
       brandTitle:
         'Schatten <span style="margin-left:6px;padding:1px 6px;border-radius:4px;background:#92400e;color:#fff;font-size:10px;font-weight:700;vertical-align:middle">未リリース · develop</span>',
-      brandUrl: 'https://yasmro.github.io/schatten/',
+      brandUrl: 'https://yasmro.github.io/schatten/storybook/',
       brandTarget: '_blank',
     }),
   })

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -56,7 +56,7 @@ function mountUnreleasedBanner() {
   })
   banner.innerHTML =
     '<span>⚠ 未リリース (develop) — 次バージョンの統合プレビューです。npm 未公開のトークン・API が含まれます。</span>' +
-    '<a href="https://yasmro.github.io/schatten/" style="color:#fff;text-decoration:underline;font-weight:700">公開版を見る →</a>'
+    '<a href="https://yasmro.github.io/schatten/storybook/" style="color:#fff;text-decoration:underline;font-weight:700">公開版を見る →</a>'
   document.body.appendChild(banner)
 }
 

--- a/apps/docs/src/lib/storybook-links.mjs
+++ b/apps/docs/src/lib/storybook-links.mjs
@@ -6,7 +6,7 @@
 // runs under bare Node and must import the SAME derivation the pages use —
 // a .ts copy would be a second source of truth.
 
-export const STORYBOOK_ORIGIN = 'https://yasmro.github.io/schatten/'
+export const STORYBOOK_ORIGIN = 'https://yasmro.github.io/schatten/storybook/'
 
 /**
  * Autodocs URL for an lv1 component.

--- a/apps/docs/src/pages/[...locale]/index.astro
+++ b/apps/docs/src/pages/[...locale]/index.astro
@@ -4,9 +4,17 @@
 //
 // i18n: rest-param route — `/` renders the default locale (en), `/ja/` the
 // Japanese variant. Copy lives in src/i18n/ui.ts; this template is shared.
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
 import Base from '../../layouts/Base.astro'
 import { defaultLocale, type Locale, locales, ui } from '../../i18n/ui'
 import { STORYBOOK_ORIGIN } from '../../lib/storybook-links.mjs'
+
+// Version badge is generated from the library's package.json — the site is
+// tag-synced (#502), so this always names the release being described.
+const { version } = JSON.parse(
+  readFileSync(fileURLToPath(new URL('../../../../../package.json', import.meta.url)), 'utf8'),
+) as { version: string }
 
 export function getStaticPaths() {
   return locales.map((locale) => ({
@@ -57,7 +65,7 @@ const seasonSwatches = [
       </div>
 
       <div class="hero__badges">
-        <span class="st-badge st-badge--neutral st-badge--solid st-badge--md">v1.0.0</span>
+        <span class="st-badge st-badge--neutral st-badge--solid st-badge--md">v{version}</span>
         <span class="st-badge st-badge--success st-badge--subtle st-badge--md">API stable</span>
         <span class="st-badge st-badge--info st-badge--outline st-badge--md">ESM only</span>
       </div>


### PR DESCRIPTION
## 概要

#502 の 3 手順を実装。Pages root の所有権を固定せず、`site/`(tag 同期・公開)と `storybook/`(develop 追随 + main の released 版)を名前付きディレクトリで分離する。

## 変更

| 面 | before | after |
|---|---|---|
| Storybook(released) | root | `storybook/` |
| Storybook(develop) | `next/` | `storybook/next/` |
| docs サイト | 無し | **`site/`(release tag 同期)** |
| root | Storybook 本体 | **router**(`?path=` → storybook/、他 → site/) |

- **deploy-site.yml 新設** — `v*` タグ push + workflow_dispatch(初回公開用)。CI docs job と同じゲート(`astro check` / `check:links`)を通過してからデプロイ。root router のデプロイ時の clean が旧レイアウトの残骸(root 直下の Storybook・旧 `/next/`)を一掃する
- **router は共有ファイル**(`.github/pages-root/index.html`)— PR プレビューも同一ファイルを使用し、`pr/<n>/` と本番の構造が完全一致
- **リンク張り替え** — site 側は `STORYBOOK_ORIGIN` の 1 行(PR #494 で一元化済み)、`.storybook` の「公開版」リンク 2 箇所
- **version バッジ生成化** — landing のバッジを root `package.json` から生成(tag 同期なので常に記述対象リリースと一致)

## Storybook の main ビルド存廃(#502 の未決事項)への判断

**残す**(`storybook/` = main)。site は tag 同期 = released 状態を記述するので、site からの 25 本のコンポーネントリンクの飛び先も released 版であるべき。develop 追随一本にすると、develop 側のリネームで site のリンクが先に死ぬ。二層の意味は従来と同じで、場所だけが `storybook/{,next/}` に移る。

## マージ後の手順(この順で実行)

1. `deploy-storybook` を **main** で dispatch → `storybook/` 生成
2. `deploy-site` を dispatch → `site/` 生成 + root 切替(残骸一掃)
3. URL 疎通確認(root router / site / storybook / storybook/next)

refs #449

🤖 Generated with [Claude Code](https://claude.com/claude-code)