### PR TITLE
infra(pages): deploy-storybook の dispatch に channel 入力を追加(refs #502)

### DIFF
--- a/.github/workflows/deploy-storybook.yml
+++ b/.github/workflows/deploy-storybook.yml
@@ -4,6 +4,12 @@ on:
   push:
     branches: [main, develop]
   workflow_dispatch:
+    inputs:
+      channel:
+        description: 'stable -> storybook/ (released), next -> storybook/next/ (develop)'
+        type: choice
+        options: [stable, next]
+        default: stable
 
 permissions:
   contents: write
@@ -21,8 +27,20 @@ jobs:
       #   develop -> /storybook/next/  — unreleased integration preview
       - name: Resolve deploy target
         id: target
+        # push: channel follows the ref (develop -> next, main -> stable).
+        # workflow_dispatch: the channel INPUT decides — needed because a
+        # dispatch runs the workflow definition of its ref, so the first
+        # stable deploy after #502 must be runnable from develop (main only
+        # picks up this file at the next release).
         run: |
-          if [ "${{ github.ref }}" = "refs/heads/develop" ]; then
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            CHANNEL="${{ inputs.channel }}"
+          elif [ "${{ github.ref }}" = "refs/heads/develop" ]; then
+            CHANNEL="next"
+          else
+            CHANNEL="stable"
+          fi
+          if [ "$CHANNEL" = "next" ]; then
             {
               echo "base=/schatten/storybook/next/"
               echo "channel=next"


### PR DESCRIPTION
#506 のフォローアップ。`workflow_dispatch` は選択 ref のワークフロー定義で動くため、main(旧定義)から初回の `storybook/` デプロイを実行できない問題への対処。dispatch 時のみ `channel` 入力(stable / next)でデプロイ先を決める。push 時は従来どおり ref 追従で挙動変更なし。

マージ後: `deploy-storybook`(develop, channel=stable)→ `deploy-site` の順に dispatch して #502 の本番切替を完了する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)