### PR TITLE
fix(pages): .nojekyll を root デプロイに同梱(_astro/ の Jekyll 除外で CSS 404)

### DIFF
--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -70,3 +70,4 @@ jobs:
             site
             storybook
             pr
+            .nojekyll


### PR DESCRIPTION
本番 site/ の CSS が全 404(スクリーンショット報告)。原因: #506 の root 掃除が旧 Storybook 由来の `.nojekyll` を消し、Jekyll が `_astro/` を配信除外。`.github/pages-root/.nojekyll` を root デプロイに同梱して恒久化。refs #502

🤖 Generated with [Claude Code](https://claude.com/claude-code)