### PR TITLE
fix(pages): clean-exclude から .nojekyll を除去(source コピーからも除外される)

### DIFF
--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -66,8 +66,12 @@ jobs:
           # Everything that legitimately lives under the root, by name.
           # NOT excluded on purpose: the legacy pre-#502 layout (Storybook
           # files at the root, the old /next/) — this clean is what retires it.
+          # NOTE: clean-exclude doubles as an rsync --exclude on the SOURCE
+          # copy (JamesIves v4), so .nojekyll must NOT be listed here — it
+          # would be excluded from the deployment itself (learned in #509's
+          # follow-up). The file ships from .github/pages-root/ every deploy,
+          # so it needs no clean protection.
           clean-exclude: |
             site
             storybook
             pr
-            .nojekyll


### PR DESCRIPTION
JamesIves v4 の clean-exclude は rsync --exclude としてソース側にも効く(run 30608777107 のログで確認)。#509 の .nojekyll が deploy から除外され続けていたので exclude 指定を外す。refs #502

🤖 Generated with [Claude Code](https://claude.com/claude-code)