### PR TITLE
fix(docs-site): landing から季節ストリップを削除(brand ページと重複)

### DIFF
--- a/apps/docs/src/i18n/ui.ts
+++ b/apps/docs/src/i18n/ui.ts
@@ -32,9 +32,6 @@ interface Landing {
   proofRenderLabel: string
   proofRenderButton: string
   proofFooter: Html
-  seasonsTitle: string
-  seasonsLead: Html
-  seasonNames: readonly [string, string, string, string, string, string, string, string]
   calloutNote: Html
 }
 
@@ -133,19 +130,6 @@ export const ui: Record<Locale, Strings> = {
       proofRenderButton: 'Save',
       proofFooter:
         'This sample is painted by the same <code>dist/schatten.css</code> as the page you are reading.',
-      seasonsTitle: 'Eight seasons, one lightness ladder',
-      seasonsLead:
-        'A Special theme swaps only the <code>--color-theme-*</code> ramp; the lightness ladder is shared by every season. Color moves, the contrast structure does not — switched by a single <code>data-theme</code>.',
-      seasonNames: [
-        'Early spring',
-        'Late spring',
-        'Early summer',
-        'Peak summer',
-        'Early autumn',
-        'Late autumn',
-        'Early winter',
-        'Deep winter',
-      ],
       calloutNote:
         'Dark mode follows the OS setting (<code>prefers-color-scheme</code>). That switch is the token layer’s job too — zero page-side code.',
     },
@@ -275,10 +259,6 @@ export const ui: Record<Locale, Strings> = {
       proofRenderButton: '保存',
       proofFooter:
         'この見本を描画しているのも、いま読んでいるページ全体と同じ <code>dist/schatten.css</code> です。',
-      seasonsTitle: '8 つの季節、ひとつの明度設計',
-      seasonsLead:
-        'Special テーマは <code>--color-theme-*</code> のランプだけを差し替え、明度の梯子は全季節で共有します。コントラスト構造を壊さずに、季節が色だけを運ぶ — <code>data-theme</code> ひとつで切り替わる設計です。',
-      seasonNames: ['春・早', '春・晩', '夏・早', '夏・盛', '秋・早', '秋・晩', '冬・早', '冬・深'],
       calloutNote:
         'ダークモードは OS 設定に追従します(<code>prefers-color-scheme</code>)。この切り替えもトークン層の仕事で、ページ側のコードはゼロです。',
     },

--- a/apps/docs/src/pages/[...locale]/index.astro
+++ b/apps/docs/src/pages/[...locale]/index.astro
@@ -25,21 +25,6 @@ export function getStaticPaths() {
 
 const { locale } = Astro.props as { locale: Locale }
 const t = ui[locale].landing
-
-// Seasonal swatches: the 500 rung of each Special in
-// src/themes/seasonal/themes.css — every season shares one lightness ladder
-// (L 64% at 500) and moves only hue/chroma. Hand-copied for the skeleton;
-// Phase 3 should generate this strip from the tokens (SSOT → consumer map row).
-const seasonSwatches = [
-  'oklch(64% 0.1 12)',
-  'oklch(64% 0.1 138)',
-  'oklch(64% 0.09 162)',
-  'oklch(64% 0.11 45)',
-  'oklch(64% 0.085 230)',
-  'oklch(64% 0.1 70)',
-  'oklch(64% 0.048 250)',
-  'oklch(64% 0.08 255)',
-]
 ---
 
 <Base locale={locale} description={t.metaDescription}>
@@ -106,20 +91,6 @@ const seasonSwatches = [
       </div>
     </section>
 
-    <!-- Seasonal strip: the Mode × Special demo only a self-hosted site can run. -->
-    <section class="seasons">
-      <h2 class="seasons__title">{t.seasonsTitle}</h2>
-      <p class="seasons__lead" set:html={t.seasonsLead} />
-      <ul class="seasons__strip">
-        {
-          seasonSwatches.map((swatch, i) => (
-            <li class="seasons__swatch" style={`--swatch: ${swatch}`}>
-              <span>{t.seasonNames[i]}</span>
-            </li>
-          ))
-        }
-      </ul>
-    </section>
 
     <section class="callout-demo">
       <div class="st-callout st-callout--info st-callout--subtle" role="note">
@@ -240,52 +211,4 @@ const seasonSwatches = [
     }
   }
 
-  /* ---- seasonal strip ---- */
-  .seasons {
-    display: flex;
-    flex-direction: column;
-    gap: var(--spacing-4);
-  }
-
-  .seasons__title {
-    margin: 0;
-    font-family: var(--font-serif);
-    font-size: var(--text-2xl);
-  }
-
-  .seasons__lead {
-    margin: 0;
-    max-width: 44rem;
-    color: var(--color-foreground-muted);
-    line-height: 1.8;
-  }
-
-  .seasons__strip {
-    list-style: none;
-    margin: 0;
-    padding: 0;
-    display: grid;
-    grid-template-columns: repeat(8, 1fr);
-    gap: var(--spacing-2);
-  }
-
-  .seasons__swatch {
-    aspect-ratio: 3 / 4;
-    border-radius: var(--radius-control);
-    background: var(--swatch);
-    display: flex;
-    align-items: flex-end;
-    padding: var(--spacing-2);
-  }
-
-  .seasons__swatch span {
-    font-size: var(--text-xs);
-    color: oklch(98% 0.005 70);
-  }
-
-  @media (max-width: 40rem) {
-    .seasons__strip {
-      grid-template-columns: repeat(4, 1fr);
-    }
-  }
 </style>


### PR DESCRIPTION
/brand/ の八節セクション(節気 + 日付つき)が上位互換のため、landing の季節ストリップを削除して hero + proof + callout に絞る。refs #449

🤖 Generated with [Claude Code](https://claude.com/claude-code)