### PR TITLE
fix(pages): gh-pages への deploy を concurrency group で直列化

### DIFF
--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -19,6 +19,14 @@ on:
 permissions:
   contents: write
 
+# gh-pages に書く workflow は全て同一グループで直列化する。JamesIves の deploy は
+# 実行開始時点の gh-pages を base に force-push するため、並走すると後着が先着の
+# コミットを黙って巻き戻す(#502 の切替作業で 2 回実測: cannot-lock-ref 失敗と、
+# force-push による site 更新の消失)。cancel はせず順番待ちにする。
+concurrency:
+  group: gh-pages
+  cancel-in-progress: false
+
 jobs:
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy-storybook.yml
+++ b/.github/workflows/deploy-storybook.yml
@@ -14,6 +14,14 @@ on:
 permissions:
   contents: write
 
+# gh-pages に書く workflow は全て同一グループで直列化する。JamesIves の deploy は
+# 実行開始時点の gh-pages を base に force-push するため、並走すると後着が先着の
+# コミットを黙って巻き戻す(#502 の切替作業で 2 回実測: cannot-lock-ref 失敗と、
+# force-push による site 更新の消失)。cancel はせず順番待ちにする。
+concurrency:
+  group: gh-pages
+  cancel-in-progress: false
+
 jobs:
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/storybook-preview.yml
+++ b/.github/workflows/storybook-preview.yml
@@ -9,6 +9,14 @@ permissions:
   contents: write
   pull-requests: write
 
+# gh-pages に書く workflow は全て同一グループで直列化する。JamesIves の deploy は
+# 実行開始時点の gh-pages を base に force-push するため、並走すると後着が先着の
+# コミットを黙って巻き戻す(#502 の切替作業で 2 回実測: cannot-lock-ref 失敗と、
+# force-push による site 更新の消失)。cancel はせず順番待ちにする。
+concurrency:
+  group: gh-pages
+  cancel-in-progress: false
+
 jobs:
   deploy-preview:
     if: github.event.action != 'closed'


### PR DESCRIPTION
並走する JamesIves deploy の force-push が互いのコミットを巻き戻す競合(#502 切替で 2 回実測)への恒久策。gh-pages に書く 3 workflow を同一 concurrency グループで直列化(cancel なし)。refs #502

🤖 Generated with [Claude Code](https://claude.com/claude-code)