### PR TITLE
fix(spinner): ラベルの sr-only を公開クラス .st-spinner__label に置換

### DIFF
--- a/.changeset/spinner-label-dist.md
+++ b/.changeset/spinner-label-dist.md
@@ -1,0 +1,12 @@
+---
+'@yasmro/schatten': minor
+---
+
+CSS API: add `.st-spinner__label` — the Spinner's visually-hidden accessible
+label class. The JSX previously hid the label with Tailwind's `sr-only`
+utility, which does not exist in the Tailwind-free dist build, so
+framework-agnostic CSS consumers (and React consumers styling via
+`dist/schatten.css`) saw the label rendered as visible text — most visibly
+"Loading" inside a busy `<Button isLoading>`. The label span now carries
+`.st-spinner__label`, shipped in the dist with the standard visually-hidden
+pattern. Vanilla-HTML spinner markup should adopt the same class.

--- a/src/__generated__/schatten.manifest.json
+++ b/src/__generated__/schatten.manifest.json
@@ -161,6 +161,7 @@
     "st-spinner--sm",
     "st-spinner__arc",
     "st-spinner__dot",
+    "st-spinner__label",
     "st-spinner__ripple-1",
     "st-spinner__ripple-2",
     "st-spinner__rotor",

--- a/src/components/lv1/Spinner/Spinner.css
+++ b/src/components/lv1/Spinner/Spinner.css
@@ -84,6 +84,24 @@
 }
 
 @layer components {
+  /* Visually-hidden accessible label. Public class — the sr-only utility the
+   * JSX used before was Tailwind-only and does NOT exist in the dist build
+   * (#317 Tailwind-free), so framework-agnostic consumers saw the label as
+   * visible text ("Loading") inside busy Buttons. Found by the docs site's
+   * exports-map consumption (#449 dogfood). */
+  .st-spinner__label {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0 0 0 0);
+    clip-path: inset(50%);
+    white-space: nowrap;
+    border: 0;
+  }
+
   /* ===== base layout ===== */
   .st-spinner {
     display: inline-flex;

--- a/src/components/lv1/Spinner/Spinner.test.tsx
+++ b/src/components/lv1/Spinner/Spinner.test.tsx
@@ -21,7 +21,7 @@ describe('Spinner', () => {
     render(<Spinner />)
     const labelEl = screen.getByText('Loading')
     expect(labelEl).toBeInTheDocument()
-    expect(labelEl).toHaveClass('sr-only')
+    expect(labelEl).toHaveClass('st-spinner__label')
   })
 
   it('renders a custom label', () => {

--- a/src/components/lv1/Spinner/Spinner.tsx
+++ b/src/components/lv1/Spinner/Spinner.tsx
@@ -82,7 +82,7 @@ export const Spinner = forwardRef<HTMLDivElement, SpinnerProps>(
         {...props}
       >
         {type === 'ripple' ? <RippleSpinner /> : <DefaultSpinner />}
-        <span className="sr-only">{label}</span>
+        <span className="st-spinner__label">{label}</span>
       </div>
     )
   },

--- a/src/docs/__fixtures__/cssApiSamples.html.ts
+++ b/src/docs/__fixtures__/cssApiSamples.html.ts
@@ -178,7 +178,7 @@ export const vanillaHtml = `
         <circle class="st-spinner__track" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="3" />
         <path class="st-spinner__arc" d="M22 12a10 10 0 0 0-10-10" stroke="currentColor" stroke-width="3" stroke-linecap="round" />
       </svg>
-      <span class="cssapi-fixture__sr-only">Loading</span>
+      <span class="st-spinner__label">Loading</span>
     </div>
   </div>
 </section>


### PR DESCRIPTION
## 問題

`Spinner` のアクセシブルラベルが Tailwind の `sr-only` で隠されていたが、**dist ビルド(#317 で Tailwind-free)には `sr-only` が存在しない**。dist CSS 消費者ではラベルが可視テキストになり、最も目立つ症状として `<Button isLoading>` 内に「Loading」が生表示され、スピナーが見えない状態だった。

**検出経路が本題**: Storybook(Tailwind パス)では隠れるため既存の全ゲートを素通りし、docs サイトの exports map 実消費(#449 の dogfood)で初めて露見した。fixture も自前の `cssapi-fixture__sr-only` ヘルパーで穴を覆っていたため dist VRT にも映らなかった。

## 変更

- `Spinner.tsx`: `sr-only` → `.st-spinner__label`(公開クラス新設)
- `Spinner.css`: visually-hidden パターンを `@layer components` に追加(dist に同梱)
- fixture: 自前ヘルパーを公開クラスへ置換 — **以後この欠落は dist VRT がピクセル差分として検出**
- manifest +1 class、changeset(`CSS API:` minor・additive)

## 検証

- Spinner unit 14/14 pass、lint / typecheck green
- docs サイトをローカルで再ビルドし、busy Button でスピナー表示・ラベル不可視(1×1px)を実測
- VRT baseline は不変の想定(旧: Tailwind sr-only で不可視 / 新: 公開クラスで不可視 — 両方式ともピクセルに出ない)。CI の vrt で確認

マージ後 `deploy-site` を dispatch して本番の /components/ に反映する。

refs #449

🤖 Generated with [Claude Code](https://claude.com/claude-code)